### PR TITLE
Base Callback

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -10,3 +10,7 @@ omit =
 [report]
 precision = 2
 show_missing = True
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+    noqa

--- a/docs/api/callbacks.rst
+++ b/docs/api/callbacks.rst
@@ -1,6 +1,10 @@
 Callbacks
 ----------
 
+.. autoclass:: sklearn_genetic.callbacks.base.BaseCallback
+   :members:
+   :undoc-members: False
+
 .. autoclass:: sklearn_genetic.callbacks.ConsecutiveStopping
    :members:
    :undoc-members: False

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -26,6 +26,16 @@ Docs:
 ^^^^^
 
 * Added user guide "Integrating with MLflow"
+* Update the tutorial "Custom Callbacks" for new API inheritance behavior
+
+^^^^^^^^^
+Internal:
+^^^^^^^^^
+
+* Added a base class :class:`~sklearn_genetic.callbacks.base.BaseCallback` from
+  which all Callbacks must inherit from
+* Now coverage report doesn't take into account the lines with # pragma: no cover
+  and # noqa
 
 What's new in 0.4.1
 -------------------

--- a/docs/tutorials/custom_callback.rst
+++ b/docs/tutorials/custom_callback.rst
@@ -5,9 +5,10 @@ sklearn-genetic-opt comes with some pre-defined callbacks,
 but you can make one of your own by defining a callable with
 certain methods.
 
-The callback must be a class that implements the ``__call__`` and
-``on_step`` methods, the result of them must be a bool, ``True`` means
-that the optimization must stop, ``False``, means it can continue.
+The callback must be a class with inheritance from the class
+:class:`~sklearn_genetic.callbacks.base.BaseCallback` that implements the
+``__call__`` and ``on_step`` methods, the result of them must be a bool,
+``True`` means that the optimization must stop, ``False``, means it can continue.
 
 In this example, we are going to define a dummy callback that
 stops the process if there have been more that `N` fitness values
@@ -49,7 +50,9 @@ that will have all this parameters, so we can rewrite it like this:
 
 .. code-block:: python
 
-   class DummyThreshold:
+   from sklearn_genetic.callbacks.base import BaseCallback
+
+   class DummyThreshold(BaseCallback):
        def __init__(self, threshold, N, metric='fitness'):
            self.threshold = threshold
            self.N = N

--- a/sklearn_genetic/callbacks/base.py
+++ b/sklearn_genetic/callbacks/base.py
@@ -1,0 +1,31 @@
+from abc import ABC, abstractmethod
+
+
+class BaseCallback(ABC):
+    """
+    Base Callback from which all Callbacks must inherit from
+    """
+
+    @abstractmethod
+    def on_step(self, record=None, logbook=None, estimator=None):
+        """
+        Parameters
+        ----------
+        record: dict: default=None
+            A logbook record
+        logbook:
+            Current stream logbook with the stats required
+        estimator:
+            :class:`~sklearn_genetic.GASearchCV` Estimator that is being optimized
+
+        Returns
+        -------
+        decision: False
+            Always returns False as this class doesn't take decisions over the optimization
+        """
+
+        pass  # pragma: no cover
+
+    @abstractmethod
+    def __call__(self, record=None, logbook=None, estimator=None):
+        pass  # pragma: no cover

--- a/sklearn_genetic/callbacks/early_stoppers.py
+++ b/sklearn_genetic/callbacks/early_stoppers.py
@@ -1,7 +1,8 @@
 from .validations import check_stats
+from .base import BaseCallback
 
 
-class ThresholdStopping:
+class ThresholdStopping(BaseCallback):
     """
     Stop the optimization if the metric from
     cross validation score is greater or equals than the define threshold
@@ -24,21 +25,6 @@ class ThresholdStopping:
         self.metric = metric
 
     def on_step(self, record, logbook, estimator):
-        """
-        Parameters
-        ----------
-        record: dict: default=None
-            A logbook record
-        logbook:
-            Current stream logbook with the stats required
-        estimator:
-            :class:`~sklearn_genetic.GASearchCV` Estimator that is being optimized
-
-        Returns
-        -------
-        decision: bool
-            True if the optimization algorithm must stop, false otherwise
-        """
         if record is not None:
             return record[self.metric] >= self.threshold
         elif logbook is not None:
@@ -54,7 +40,7 @@ class ThresholdStopping:
         return self.on_step(record, logbook, estimator)
 
 
-class ConsecutiveStopping:
+class ConsecutiveStopping(BaseCallback):
     """
     Stop the optimization if the current metric value is no greater that at least one metric from the last N generations
     """
@@ -75,21 +61,6 @@ class ConsecutiveStopping:
         self.metric = metric
 
     def on_step(self, record=None, logbook=None, estimator=None):
-        """
-        Parameters
-        ----------
-        record: dict: default=None
-            A logbook record
-        logbook:
-            Current stream logbook with the stats required
-        estimator:
-            :class:`~sklearn_genetic.GASearchCV` Estimator that is being optimized
-
-        Returns
-        -------
-        decision: bool
-            True if the optimization algorithm must stop, false otherwise
-        """
         if logbook is not None:
             if len(logbook) <= self.generations:
                 return False
@@ -109,7 +80,7 @@ class ConsecutiveStopping:
         return self.on_step(record, logbook, estimator)
 
 
-class DeltaThreshold:
+class DeltaThreshold(BaseCallback):
     """
     Stop the optimization if the absolute difference between the current and last metric less or equals than a threshold
     """
@@ -130,21 +101,6 @@ class DeltaThreshold:
         self.metric = metric
 
     def on_step(self, record=None, logbook=None, estimator=None):
-        """
-        Parameters
-        ----------
-        record: dict: default=None
-            A logbook record
-        logbook:
-            Current stream logbook with the stats required
-        estimator:
-            :class:`~sklearn_genetic.GASearchCV` Estimator that is being optimized
-
-        Returns
-        -------
-        decision: bool
-            True if the optimization algorithm must stop, false otherwise
-        """
         if logbook is not None:
             if len(logbook) <= 1:
                 return False

--- a/sklearn_genetic/callbacks/loggers.py
+++ b/sklearn_genetic/callbacks/loggers.py
@@ -2,8 +2,10 @@ import logging
 from copy import deepcopy
 from joblib import dump
 
+from .base import BaseCallback
 
-class LogbookSaver:
+
+class LogbookSaver(BaseCallback):
     """
     Saves the estimator.logbook parameter chapter object in a local file system
     """
@@ -22,21 +24,6 @@ class LogbookSaver:
         self.dump_options = dump_options
 
     def on_step(self, record=None, logbook=None, estimator=None):
-        """
-        Parameters
-        ----------
-        record: dict: default=None
-            A logbook record
-        logbook:
-            Current stream logbook with the stats required
-        estimator:
-            :class:`~sklearn_genetic.GASearchCV` Estimator that is being optimized
-
-        Returns
-        -------
-        decision: False
-            Always returns False as this class doesn't take decisions over the optimization
-        """
         try:
             dump_logbook = deepcopy(estimator.logbook.chapters["parameters"])
             dump(dump_logbook, self.checkpoint_path, **self.dump_options)

--- a/sklearn_genetic/callbacks/validations.py
+++ b/sklearn_genetic/callbacks/validations.py
@@ -1,6 +1,5 @@
-from typing import Callable
-
 from ..parameters import Metrics
+from .base import BaseCallback
 
 
 def check_stats(metric):
@@ -15,17 +14,18 @@ def check_callback(callback):
     Check if callback is a callable or a list of callables.
     """
     if callback is not None:
-        if isinstance(callback, Callable):
+        if isinstance(callback, BaseCallback):
             return [callback]
 
         elif isinstance(callback, list) and all(
-            [isinstance(c, Callable) for c in callback]
+            [isinstance(c, BaseCallback) for c in callback]
         ):
             return callback
 
         else:
             raise ValueError(
-                "callback should be either a callable or a list of callables."
+                "callback should be either a class or a list of classes with inheritance from "
+                "callbacks.base.BaseCallback"
             )
     else:
         return []

--- a/sklearn_genetic/genetic_search.py
+++ b/sklearn_genetic/genetic_search.py
@@ -486,7 +486,7 @@ class GASearchCV(ClassifierMixin, RegressorMixin):
             self.n += 1
             return result
         else:
-            raise StopIteration
+            raise StopIteration  # pragma: no cover
 
     def __len__(self):
         """

--- a/sklearn_genetic/tests/test_callbacks.py
+++ b/sklearn_genetic/tests/test_callbacks.py
@@ -76,6 +76,11 @@ def test_wrong_base_callback():
 
 
 def test_base_callback_call():
+    possible_messages = [
+        "Can't instantiate abstract class MyDummyCallback with abstract methods __call__",
+        "Can't instantiate abstract class MyDummyCallback with abstract method __call__",
+    ]
+
     class MyDummyCallback(BaseCallback):
         def __init__(self, metric):
             self.metric = metric
@@ -86,10 +91,7 @@ def test_base_callback_call():
     with pytest.raises(Exception) as excinfo:
         callback = MyDummyCallback(metric="fitness")
 
-    assert (
-        str(excinfo.value)
-        == "Can't instantiate abstract class MyDummyCallback with abstract methods __call__"
-    )
+    assert any([str(excinfo.value) == i for i in possible_messages])
 
 
 def test_threshold_callback():


### PR DESCRIPTION
This PR implement the base class for all Callbakcs as specified in issue #10 

* Added a base class class `sklearn_genetic.callbacks.base.BaseCallback` from which all Callbacks must inherit from
* Now coverage report doesn't take into account the lines with # pragma: no cover and # noqa