### PR TITLE
BaseSearchCV Partial Inheritance

### DIFF
--- a/docs/api/gasearchcv.rst
+++ b/docs/api/gasearchcv.rst
@@ -4,7 +4,6 @@ GASearchCV
 
 .. autoclass:: sklearn_genetic.GASearchCV
    :members:
-   :exclude-members: evaluate, mutate
-   :undoc-members: False
-
-
+   :inherited-members:
+   :exclude-members: evaluate, mutate, n_features_in_, classes_
+   :undoc-members: True

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,7 +39,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
     "numpydoc",
-    "sphinx.ext.napoleon",
+    # "sphinx.ext.napoleon",
     "sphinx.ext.mathjax",
     "sphinx.ext.viewcode",
     "sphinx_copybutton",

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -16,6 +16,8 @@ Features:
   the iterations after a total (threshold) fitting time has been elapsed.
 * Now if one or more callbacks decides to stop the algorithm, it will print
   its class name to know which callbacks were responsible of the stopping.
+* Added support for extra methods coming from scikit-learn's BaseSearchCV, it is
+  still partial support, missing properties like `cv_results_`, `best_index_` and `multimetric_`.
 
 ^^^^^
 Docs:

--- a/sklearn_genetic/callbacks/early_stoppers.py
+++ b/sklearn_genetic/callbacks/early_stoppers.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-import logging
 
 from .validations import check_stats
 from .base import BaseCallback

--- a/sklearn_genetic/genetic_search.py
+++ b/sklearn_genetic/genetic_search.py
@@ -3,13 +3,14 @@ import random
 
 import numpy as np
 from deap import base, creator, tools
-from sklearn.base import clone, ClassifierMixin, RegressorMixin
+from sklearn.base import clone
 from sklearn.model_selection import cross_val_score
 from sklearn.base import is_classifier, is_regressor
 from sklearn.utils.metaestimators import if_delegate_has_method
-from sklearn.utils.validation import check_array, check_is_fitted
+from sklearn.utils.validation import check_is_fitted
 from sklearn.metrics import check_scoring
 from sklearn.exceptions import NotFittedError
+from sklearn.model_selection._search import BaseSearchCV
 
 from .parameters import Algorithms, Criteria
 from .space import Space
@@ -17,7 +18,7 @@ from .algorithms import eaSimple, eaMuPlusLambda, eaMuCommaLambda
 from .callbacks.validations import check_callback
 
 
-class GASearchCV(ClassifierMixin, RegressorMixin):
+class GASearchCV(BaseSearchCV):
     """
     Evolutionary optimization over hyperparameters.
 
@@ -27,6 +28,128 @@ class GASearchCV(ClassifierMixin, RegressorMixin):
     estimator used.
     The parameters of the estimator used to apply these methods are optimized
     by cross-validated search over parameter settings.
+
+    Parameters
+    ----------
+    estimator : estimator object, default=None
+        estimator object implementing 'fit'
+        The object to use to fit the data.
+
+    cv : int, cross-validation generator or an iterable, default=None
+        Determines the cross-validation splitting strategy.
+        Possible inputs for cv are:
+        - None, to use the default 5-fold cross validation,
+        - int, to specify the number of folds in a `(Stratified)KFold`,
+        - CV splitter,
+        - An iterable yielding (train, test) splits as arrays of indices.
+        For int/None inputs, if the estimator is a classifier and ``y`` is
+        either binary or multiclass, :class:`StratifiedKFold` is used. In all
+        other cases, :class:`KFold` is used. These splitters are instantiated
+        with `shuffle=False` so the splits will be the same across calls.
+
+    param_grid : dict, default=None
+        Grid with the parameters to tune, expects keys a valid name
+        of hyperparameter based on the estimator selected and as values
+        one of :class:`~sklearn_genetic.space.Integer` ,
+        :class:`~sklearn_genetic.space.Categorical`
+        :class:`~sklearn_genetic.space.Continuous` classes
+
+    population_size : int, default=10
+        Size of the initial population to sample randomly generated individuals.
+
+    generations : int, default=40
+        Number of generations or iterations to run the evolutionary algorithm.
+
+    crossover_probability : float, default=0.8
+        Probability of crossover operation between two individuals.
+
+    mutation_probability : float, default=0.1
+        Probability of child mutation.
+
+    tournament_size : int, default=3
+        Number of individuals to perform tournament selection.
+
+    elitism : bool, default=True
+        If True takes the *tournament_size* best solution to the next generation.
+
+    scoring : str or callable, default=None
+        A str (see model evaluation documentation) or
+        a scorer callable object / function with signature
+        ``scorer(estimator, X, y)`` which should return only
+        a single value.
+
+    n_jobs : int, default=None
+        Number of jobs to run in parallel. Training the estimator and computing
+        the score are parallelized over the cross-validation splits.
+        ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
+        ``-1`` means using all processors.
+
+    verbose : bool, default=True
+        If ``True``, shows the metrics on the optimization routine.
+
+    keep_top_k : int, default=1
+        Number of best solutions to keep in the hof object. If a callback stops the algorithm before k iterations,
+        it will return only one set of parameters per iteration.
+
+    criteria : {'max', 'min'} , default='max'
+        ``max`` if a higher scoring metric is better, ``min`` otherwise.
+
+    algorithm : {'eaMuPlusLambda', 'eaMuCommaLambda', 'eaSimple'}, default='eaMuPlusLambda'
+        Evolutionary algorithm to use.
+        See more details in the deap algorithms documentation.
+
+    refit : bool, default=True
+        Refit an estimator using the best found parameters on the whole dataset.
+        If ``False``, it is not possible to make predictions
+        using this GASearchCV instance after fitting.
+
+    pre_dispatch : int or str, default='2*n_jobs'
+        Controls the number of jobs that get dispatched during parallel
+        execution. Reducing this number can be useful to avoid an
+        explosion of memory consumption when more jobs get dispatched
+        than CPUs can process. This parameter can be:
+            - None, in which case all the jobs are immediately
+              created and spawned. Use this for lightweight and
+              fast-running jobs, to avoid delays due to on-demand
+              spawning of the jobs
+            - An int, giving the exact number of total jobs that are
+              spawned
+            - A str, giving an expression as a function of n_jobs,
+              as in '2*n_jobs'
+
+    error_score : 'raise' or numeric, default=np.nan
+        Value to assign to the score if an error occurs in estimator fitting.
+        If set to ``'raise'``, the error is raised.
+        If a numeric value is given, FitFailedWarning is raised.
+
+    log_config : :class:`~sklearn_genetic.mlflow.MLflowConfig`, default = None
+        Configuration to log metrics and models to mlflow, of None,
+        no mlflow logging will be performed
+
+    Attributes
+    ----------
+
+    logbook : :class:`DEAP.tools.Logbook`
+        Contains the logs of every set of hyperparameters fitted with its average scoring metric.
+    history : dict
+        Dictionary of the form:
+        {"gen": [],
+        "fitness": [],
+        "fitness_std": [],
+        "fitness_max": [],
+        "fitness_min": []}
+
+         *gen* returns the index of the evaluated generations.
+         Each entry on the others lists, represent the average metric in each generation.
+
+    best_estimator_ : estimator
+        Estimator that was chosen by the search, i.e. estimator
+        which gave highest score
+        on the left out data. Not available if ``refit=False``.
+
+    best_params_ : dict
+        Parameter setting that gave the best results on the hold out data.
+
     """
 
     def __init__(
@@ -52,135 +175,11 @@ class GASearchCV(ClassifierMixin, RegressorMixin):
         log_config=None,
     ):
 
-        """
-        Parameters
-        ----------
-        estimator : estimator object, default=None
-            estimator object implementing 'fit'
-            The object to use to fit the data.
-
-        cv : int, cross-validation generator or an iterable, default=None
-            Determines the cross-validation splitting strategy.
-            Possible inputs for cv are:
-            - None, to use the default 5-fold cross validation,
-            - int, to specify the number of folds in a `(Stratified)KFold`,
-            - CV splitter,
-            - An iterable yielding (train, test) splits as arrays of indices.
-            For int/None inputs, if the estimator is a classifier and ``y`` is
-            either binary or multiclass, :class:`StratifiedKFold` is used. In all
-            other cases, :class:`KFold` is used. These splitters are instantiated
-            with `shuffle=False` so the splits will be the same across calls.
-
-        param_grid : dict, default=None
-            Grid with the parameters to tune, expects keys a valid name
-            of hyperparameter based on the estimator selected and as values
-            one of :class:`~sklearn_genetic.space.Integer` ,
-            :class:`~sklearn_genetic.space.Categorical`
-            :class:`~sklearn_genetic.space.Continuous` classes
-
-        population_size : int, default=10
-            Size of the initial population to sample randomly generated individuals.
-
-        generations : int, default=40
-            Number of generations or iterations to run the evolutionary algorithm.
-
-        crossover_probability : float, default=0.8
-            Probability of crossover operation between two individuals.
-
-        mutation_probability : float, default=0.1
-            Probability of child mutation.
-
-        tournament_size : int, default=3
-            Number of individuals to perform tournament selection.
-
-        elitism : bool, default=True
-            If True takes the *tournament_size* best solution to the next generation.
-
-        scoring : str or callable, default=None
-            A str (see model evaluation documentation) or
-            a scorer callable object / function with signature
-            ``scorer(estimator, X, y)`` which should return only
-            a single value.
-
-        n_jobs : int, default=None
-            Number of jobs to run in parallel. Training the estimator and computing
-            the score are parallelized over the cross-validation splits.
-            ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
-            ``-1`` means using all processors.
-
-        verbose : bool, default=True
-            If ``True``, shows the metrics on the optimization routine.
-
-        keep_top_k : int, default=1
-            Number of best solutions to keep in the hof object. If a callback stops the algorithm before k iterations,
-            it will return only one set of parameters per iteration.
-
-        criteria : {'max', 'min'} , default='max'
-            ``max`` if a higher scoring metric is better, ``min`` otherwise.
-
-        algorithm : {'eaMuPlusLambda', 'eaMuCommaLambda', 'eaSimple'}, default='eaMuPlusLambda'
-            Evolutionary algorithm to use.
-            See more details in the deap algorithms documentation.
-
-        refit : bool, default=True
-            Refit an estimator using the best found parameters on the whole dataset.
-            If ``False``, it is not possible to make predictions
-            using this GASearchCV instance after fitting.
-
-        pre_dispatch : int or str, default='2*n_jobs'
-            Controls the number of jobs that get dispatched during parallel
-            execution. Reducing this number can be useful to avoid an
-            explosion of memory consumption when more jobs get dispatched
-            than CPUs can process. This parameter can be:
-                - None, in which case all the jobs are immediately
-                  created and spawned. Use this for lightweight and
-                  fast-running jobs, to avoid delays due to on-demand
-                  spawning of the jobs
-                - An int, giving the exact number of total jobs that are
-                  spawned
-                - A str, giving an expression as a function of n_jobs,
-                  as in '2*n_jobs'
-
-        error_score : 'raise' or numeric, default=np.nan
-            Value to assign to the score if an error occurs in estimator fitting.
-            If set to ``'raise'``, the error is raised.
-            If a numeric value is given, FitFailedWarning is raised.
-
-        log_config : :class:`~sklearn_genetic.mlflow.MLflowConfig`, default = None
-            Configuration to log metrics and models to mlflow, of None,
-            no mlflow logging will be performed
-
-        Attributes
-        ----------
-
-        logbook : :class:`DEAP.tools.Logbook`
-            Contains the logs of every set of hyperparameters fitted with its average scoring metric.
-        history : dict
-            Dictionary of the form:
-            {"gen": [],
-            "fitness": [],
-            "fitness_std": [],
-            "fitness_max": [],
-            "fitness_min": []}
-
-             *gen* returns the index of the evaluated generations.
-             Each entry on the others lists, represent the average metric in each generation.
-
-        best_estimator_ : estimator
-            Estimator that was chosen by the search, i.e. estimator
-            which gave highest score
-            on the left out data. Not available if ``refit=False``.
-
-        best_params_ : dict
-            Parameter setting that gave the best results on the hold out data.
-
-        """
-
         self.estimator = clone(estimator)
         self.toolbox = base.Toolbox()
         self.cv = cv
         self.scoring = scoring
-        self.pop_size = population_size
+        self.population_size = population_size
         self.generations = generations
         self.crossover_probability = crossover_probability
         self.mutation_probability = mutation_probability
@@ -188,6 +187,7 @@ class GASearchCV(ClassifierMixin, RegressorMixin):
         self.elitism = elitism
         self.verbose = verbose
         self.keep_top_k = keep_top_k
+        self.criteria = criteria
         self.param_grid = param_grid
         self.algorithm = algorithm
         self.refit = refit
@@ -208,6 +208,10 @@ class GASearchCV(ClassifierMixin, RegressorMixin):
         self._hof = None
         self.hof = None
         self.X_predict = None
+        self.scorer_ = None
+        self.cv_results_ = None
+        self.best_index_ = None
+        self.multimetric_ = False
         self.log_config = log_config
         self._initial_training_time = None
 
@@ -226,6 +230,17 @@ class GASearchCV(ClassifierMixin, RegressorMixin):
             self.criteria_sign = -1
 
         self.space = Space(param_grid)
+
+        super(GASearchCV, self).__init__(
+            estimator=estimator,
+            scoring=scoring,
+            n_jobs=n_jobs,
+            refit=refit,
+            cv=cv,
+            verbose=verbose,
+            pre_dispatch=pre_dispatch,
+            error_score=error_score,
+        )
 
     def _register(self):
 
@@ -263,7 +278,7 @@ class GASearchCV(ClassifierMixin, RegressorMixin):
 
         self.toolbox.register("evaluate", self.evaluate)
 
-        self._pop = self.toolbox.population(n=self.pop_size)
+        self._pop = self.toolbox.population(n=self.population_size)
         self._hof = tools.HallOfFame(self.keep_top_k)
 
         self._stats = tools.Statistics(lambda ind: ind.fitness.values)
@@ -343,6 +358,8 @@ class GASearchCV(ClassifierMixin, RegressorMixin):
         self.X_ = X
         self.y_ = y
         self.callbacks = check_callback(callbacks)
+        self.scorer_ = check_scoring(
+            self.estimator, scoring=self.scoring)
 
         self._register()
 
@@ -403,8 +420,8 @@ class GASearchCV(ClassifierMixin, RegressorMixin):
             pop, log, gen = eaMuPlusLambda(
                 pop,
                 self.toolbox,
-                mu=self.pop_size,
-                lambda_=2 * self.pop_size,
+                mu=self.population_size,
+                lambda_=2 * self.population_size,
                 cxpb=self.crossover_probability,
                 stats=stats,
                 mutpb=self.mutation_probability,
@@ -419,8 +436,8 @@ class GASearchCV(ClassifierMixin, RegressorMixin):
             pop, log, gen = eaMuCommaLambda(
                 pop,
                 self.toolbox,
-                mu=self.pop_size,
-                lambda_=2 * self.pop_size,
+                mu=self.population_size,
+                lambda_=2 * self.population_size,
                 cxpb=self.crossover_probability,
                 stats=stats,
                 mutpb=self.mutation_probability,
@@ -438,6 +455,9 @@ class GASearchCV(ClassifierMixin, RegressorMixin):
             )
 
         return pop, log, gen
+
+    def _run_search(self, evaluate_candidates):
+        pass
 
     @property
     def _fitted(self):
@@ -501,76 +521,3 @@ class GASearchCV(ClassifierMixin, RegressorMixin):
         self.generations otherwise
         """
         return self._n_iterations
-
-    @if_delegate_has_method(delegate="estimator")
-    def predict(self, X):
-        """
-        Call predict on the estimator with the best found parameters.
-
-        Only available if refit=True and the underlying estimator supports predict.
-
-        Parameters
-        ----------
-        X: indexable, length n_samples
-            Must fulfill the input assumptions of the underlying estimator.
-        """
-
-        X = check_array(X)
-        return self.estimator.predict(X)
-
-    @if_delegate_has_method(delegate="estimator")
-    def score(self, X, y=None):
-        """
-        Returns the score on the given data, if the estimator has been refit.
-        This uses the score defined by scoring where provided
-
-        X : array-like of shape (n_samples, n_features)
-            Input data, where n_samples is the number of samples and n_features is the number of features.
-        y : array-like of shape (n_samples, n_output) or (n_samples,), default=None
-            Target relative to X for classification or regression; None for unsupervised learning.
-        """
-
-        X = check_array(X)
-        return self.estimator.score(X, y)
-
-    @if_delegate_has_method(delegate="estimator")
-    def decision_function(self, X):
-        """Call decision_function on the estimator with the best found parameters.
-
-        Parameters
-        ----------
-        X : indexable, length n_samples
-            Must fulfill the input assumptions of the underlying estimator.
-        """
-        X = check_array(X)
-        return self.estimator.decision_function(X)
-
-    @if_delegate_has_method(delegate="estimator")
-    def predict_proba(self, X):
-        """
-        Call predict_proba on the estimator with the best found parameters.
-
-        Only available if refit=True and the underlying estimator supports predict.
-
-        Parameters
-        ----------
-        X: indexable, length n_samples
-            Must fulfill the input assumptions of the underlying estimator.
-        """
-        X = check_array(X)
-        return self.estimator.predict_proba(X)
-
-    @if_delegate_has_method(delegate="estimator")
-    def predict_log_proba(self, X):
-        """
-        Call predict_log_proba on the estimator with the best found parameters.
-
-        Only available if refit=True and the underlying estimator supports predict.
-
-        Parameters
-        ----------
-        X: indexable, length n_samples
-            Must fulfill the input assumptions of the underlying estimator.
-        """
-        X = check_array(X)
-        return self.estimator.predict_log_proba(X)

--- a/sklearn_genetic/genetic_search.py
+++ b/sklearn_genetic/genetic_search.py
@@ -457,7 +457,7 @@ class GASearchCV(BaseSearchCV):
         return pop, log, gen
 
     def _run_search(self, evaluate_candidates):
-        pass
+        pass  # noqa
 
     @property
     def _fitted(self):

--- a/sklearn_genetic/tests/test_genetic_search.py
+++ b/sklearn_genetic/tests/test_genetic_search.py
@@ -6,6 +6,7 @@ from sklearn.model_selection import train_test_split
 from sklearn.utils.validation import check_is_fitted
 from sklearn.tree import DecisionTreeRegressor
 from sklearn.cluster import KMeans
+from sklearn.metrics import accuracy_score
 
 from .. import GASearchCV
 from ..space import Integer, Categorical, Continuous
@@ -61,6 +62,8 @@ def test_expected_ga_results():
     assert len(evolved_estimator.decision_function(X_test)) == len(X_test)
     assert len(evolved_estimator.predict_proba(X_test)) == len(X_test)
     assert len(evolved_estimator.predict_log_proba(X_test)) == len(X_test)
+    assert evolved_estimator.score(X_test, y_test) == accuracy_score(y_test, evolved_estimator.predict(X_test))
+    assert bool(evolved_estimator.get_params())
     assert len(evolved_estimator.hof) == evolved_estimator.keep_top_k
     assert "gen" in evolved_estimator[0]
     assert "fitness_max" in evolved_estimator[0]
@@ -145,6 +148,8 @@ def test_expected_algorithms_callbacks(algorithm, callback):
     assert len(evolved_estimator.decision_function(X_test)) == len(X_test)
     assert len(evolved_estimator.predict_proba(X_test)) == len(X_test)
     assert len(evolved_estimator.predict_log_proba(X_test)) == len(X_test)
+    assert evolved_estimator.score(X_test, y_test) == accuracy_score(y_test, evolved_estimator.predict(X_test))
+    assert bool(evolved_estimator.get_params())
     assert len(evolved_estimator.hof) <= evolved_estimator.keep_top_k
     assert "gen" in evolved_estimator[0]
     assert "fitness_max" in evolved_estimator[0]
@@ -240,7 +245,7 @@ def test_negative_criteria():
     assert "max_depth" in evolved_estimator.best_params_
     assert "min_samples_split" in evolved_estimator.best_params_
     assert len(evolved_estimator.predict(X_test_b)) == len(X_test_b)
-    assert evolved_estimator.score(X_train_b, y_train_b) >= 0
+    assert evolved_estimator.score(X_train_b, y_train_b) <= 0
 
 
 def test_wrong_criteria():


### PR DESCRIPTION
This PR implements partially what is described in the issue #9, here is a summary:

**What is done:**
* The `GASearchCV` now has inheritance from `BaseSearchCV` instead of `ClassifierMixin`, `RegressorMixin`.
* This support the inherit use of methods like .predict, .predit_proba, .score and more. Check the `GASearchCV` [documentation](https://sklearn-genetic-opt.readthedocs.io/en/latest/api/gasearchcv.html) to see the full list. So the past hard-coded methods were removed.
* Renamed the property `self.pop_size` to `self.population_size`, this is to be consistent with the scikit-learn `get_params` method; for this same reason, implemented some extra properties.

**What is left to do:**
* Implement properties that are not yet supported, like `cv_results_`, `best_index_` and `multimetric_`.
* Extra tests should be added.