### PR TITLE
[PR] Docs on Tensorboard support

### DIFF
--- a/docs/tutorials/callbacks.rst
+++ b/docs/tutorials/callbacks.rst
@@ -116,7 +116,8 @@ TensorBoard
 It saves at each iteration the fitness metrics into a log folder that can be
 read by Tensorboard.
 
-To use this callback you must install tensorflow first::
+To use this callback you must install tensorflow first, this is not installed
+within this package due it's usually a sensitive and heavy dependency::
 
     pip install tensorflow
 

--- a/sklearn_genetic/callbacks/loggers.py
+++ b/sklearn_genetic/callbacks/loggers.py
@@ -4,6 +4,7 @@ import time
 from copy import deepcopy
 from joblib import dump
 
+
 from .base import BaseCallback
 from ..parameters import Metrics
 
@@ -12,9 +13,7 @@ logger = logging.getLogger(__name__)  # noqa
 try:
     import tensorflow as tf
 except ModuleNotFoundError:  # noqa
-    logger.error(
-        "Tensorflow not found, pip install tensorflow to use TensorBoard callback"
-    )  # noqa
+    tf = None # noqa
 
 
 class LogbookSaver(BaseCallback):
@@ -58,6 +57,10 @@ class TensorBoard(BaseCallback):
             Subfolder where the data will be log, if None it will create a folder
             with the current datetime with format time.strftime("%Y_%m_%d-%H_%M_%S")
         """
+        if tf is None:
+            logger.error(
+                "Tensorflow not found, pip install tensorflow to use TensorBoard callback"
+            )  # noqa
 
         self.log_dir = log_dir
 


### PR DESCRIPTION
This PR makes that the warning "Tensorflow not found, pip install tensorflow to use TensorBoard callback" is only shown when explicitly import the `TensorBoard` callback.
It also adds a small note of why tensorflow is not installed with sklearn-genetic-opt.