### PR TITLE
[PR] Enable BaseSearchCV

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -47,6 +47,8 @@ API Changes:
 * The modules :mod:`~sklearn_genetic.plots` and :class:`~sklearn_genetic.mlflow.MLflowConfig`
   now requires an explicit installation of seaborn and mlflow, now those
   are optionally installed using ``pip install sklearn-genetic-opt[all].``
+* The GASearchCV.logbook property now has extra information that comes from the
+  scikit-learn cross_validate function
 
 ^^^^^
 Docs:
@@ -57,6 +59,15 @@ Docs:
 * The modules of the package now have a summary of their classes/functions in the docs.
 * Updated the callbacks and custom callbacks tutorials to add new TensorBoard callback and
   the new methods on the base callback.
+
+
+^^^^^^^^^
+Internal:
+^^^^^^^^^
+
+* Now the hof uses the `self.best_params_` for the position 0, to be consistent with the
+  scikit-learn API and parameters like `self.best_index_`
+
 
 What's new in 0.5.0
 -------------------

--- a/sklearn_genetic/genetic_search.py
+++ b/sklearn_genetic/genetic_search.py
@@ -156,47 +156,6 @@ class GASearchCV(BaseSearchCV):
     cv_results_ : dict of numpy (masked) ndarrays
         A dict with keys as column headers and values as columns, that can be
         imported into a pandas ``DataFrame``.
-        For instance the below given table
-        +------------+-----------+------------+-----------------+---+---------+
-        |param_kernel|param_gamma|param_degree|split0_test_score|...|rank_t...|
-        +============+===========+============+=================+===+=========+
-        |  'poly'    |     --    |      2     |       0.80      |...|    2    |
-        +------------+-----------+------------+-----------------+---+---------+
-        |  'poly'    |     --    |      3     |       0.70      |...|    4    |
-        +------------+-----------+------------+-----------------+---+---------+
-        |  'rbf'     |     0.1   |     --     |       0.80      |...|    3    |
-        +------------+-----------+------------+-----------------+---+---------+
-        |  'rbf'     |     0.2   |     --     |       0.93      |...|    1    |
-        +------------+-----------+------------+-----------------+---+---------+
-        will be represented by a ``cv_results_`` dict of::
-            {
-            'param_kernel': masked_array(data = ['poly', 'poly', 'rbf', 'rbf'],
-                                         mask = [False False False False]...)
-            'param_gamma': masked_array(data = [-- -- 0.1 0.2],
-                                        mask = [ True  True False False]...),
-            'param_degree': masked_array(data = [2.0 3.0 -- --],
-                                         mask = [False False  True  True]...),
-            'split0_test_score'  : [0.80, 0.70, 0.80, 0.93],
-            'split1_test_score'  : [0.82, 0.50, 0.70, 0.78],
-            'mean_test_score'    : [0.81, 0.60, 0.75, 0.85],
-            'std_test_score'     : [0.01, 0.10, 0.05, 0.08],
-            'rank_test_score'    : [2, 4, 3, 1],
-            'split0_train_score' : [0.80, 0.92, 0.70, 0.93],
-            'split1_train_score' : [0.82, 0.55, 0.70, 0.87],
-            'mean_train_score'   : [0.81, 0.74, 0.70, 0.90],
-            'std_train_score'    : [0.01, 0.19, 0.00, 0.03],
-            'mean_fit_time'      : [0.73, 0.63, 0.43, 0.49],
-            'std_fit_time'       : [0.01, 0.02, 0.01, 0.01],
-            'mean_score_time'    : [0.01, 0.06, 0.04, 0.04],
-            'std_score_time'     : [0.00, 0.00, 0.00, 0.01],
-            'params'             : [{'kernel': 'poly', 'degree': 2}, ...],
-            }
-        NOTE
-        The key ``'params'`` is used to store a list of parameter
-        settings dicts for all the parameter candidates.
-        The ``mean_fit_time``, ``std_fit_time``, ``mean_score_time`` and
-        ``std_score_time`` are all in seconds.
-
 
     best_estimator_ : estimator
         Estimator that was chosen by the search, i.e. estimator

--- a/sklearn_genetic/genetic_search.py
+++ b/sklearn_genetic/genetic_search.py
@@ -3,7 +3,7 @@ import random
 import numpy as np
 from deap import base, creator, tools
 from sklearn.base import clone
-from sklearn.model_selection import cross_val_score, cross_validate
+from sklearn.model_selection import cross_validate
 from sklearn.base import is_classifier, is_regressor
 from sklearn.utils.metaestimators import if_delegate_has_method
 from sklearn.utils.validation import check_is_fitted

--- a/sklearn_genetic/genetic_search.py
+++ b/sklearn_genetic/genetic_search.py
@@ -156,15 +156,12 @@ class GASearchCV(BaseSearchCV):
     cv_results_ : dict of numpy (masked) ndarrays
         A dict with keys as column headers and values as columns, that can be
         imported into a pandas ``DataFrame``.
-
     best_estimator_ : estimator
         Estimator that was chosen by the search, i.e. estimator
         which gave highest score
         on the left out data. Not available if ``refit=False``.
-
     best_params_ : dict
         Parameter setting that gave the best results on the hold out data.
-
     best_index_ : int
         The index (of the ``cv_results_`` arrays) which corresponds to the best
         candidate parameter setting.
@@ -176,11 +173,9 @@ class GASearchCV(BaseSearchCV):
         parameters for the model.
     n_splits_ : int
         The number of cross-validation splits (folds/iterations).
-
     refit_time_ : float
         Seconds used for refitting the best model on the whole dataset.
         This is present only if ``refit`` is not False.
-
     """
 
     def __init__(

--- a/sklearn_genetic/tests/test_genetic_search.py
+++ b/sklearn_genetic/tests/test_genetic_search.py
@@ -49,6 +49,7 @@ def test_expected_ga_results():
         verbose=False,
         algorithm="eaSimple",
         n_jobs=-1,
+        return_train_score=True,
     )
 
     evolved_estimator.fit(X_train, y_train)
@@ -73,6 +74,27 @@ def test_expected_ga_results():
     assert "fitness" in evolved_estimator[0]
     assert "fitness_std" in evolved_estimator[0]
     assert "fitness_min" in evolved_estimator[0]
+
+    cv_results_ = evolved_estimator.cv_results_
+
+    assert "param_l1_ratio" in set(cv_results_.keys())
+    assert "param_alpha" in set(cv_results_.keys())
+    assert "param_average" in set(cv_results_.keys())
+    assert "split1_test_score" in set(cv_results_.keys())
+    assert "split1_test_score" in set(cv_results_.keys())
+    assert "split2_test_score" in set(cv_results_.keys())
+    assert "split0_train_score" in set(cv_results_.keys())
+    assert "split1_train_score" in set(cv_results_.keys())
+    assert "split2_train_score" in set(cv_results_.keys())
+    assert "mean_test_score" in set(cv_results_.keys())
+    assert "std_test_score" in set(cv_results_.keys())
+    assert "rank_test_score" in set(cv_results_.keys())
+    assert "mean_train_score" in set(cv_results_.keys())
+    assert "std_train_score" in set(cv_results_.keys())
+    assert "rank_train_score" in set(cv_results_.keys())
+    assert "std_fit_time" in set(cv_results_.keys())
+    assert "mean_score_time" in set(cv_results_.keys())
+    assert "params" in set(cv_results_.keys())
 
 
 @pytest.mark.parametrize(

--- a/sklearn_genetic/utils/cv_scores.py
+++ b/sklearn_genetic/utils/cv_scores.py
@@ -1,0 +1,70 @@
+import numpy as np
+
+
+def select_dict_keys(dictionary, keys):
+    return {key: dictionary[key] for key in set(keys)}
+
+
+def crete_cv_results_(logbook, space, return_train_score):
+    cv_results = {}
+    n_splits = len(logbook.chapters["parameters"].select("cv_scores")[0])
+
+    for parameter in space.parameters:
+        cv_results[f"param{parameter}"] = logbook.chapters["parameters"].select(
+            parameter
+        )
+
+    for split in range(n_splits):
+        cv_results[f"split_{split}_test_score"] = [
+            cv_scores[split]
+            for cv_scores in logbook.chapters["parameters"].select("cv_scores")
+        ]
+
+    cv_results["mean_test_score"] = logbook.chapters["parameters"].select("score")
+    cv_results["std_test_score"] = [
+        np.nanstd(cv_scores)
+        for cv_scores in logbook.chapters["parameters"].select("cv_scores")
+    ]
+
+    if return_train_score:
+
+        for split in range(n_splits):
+            cv_results[f"split{split}_train_score"] = [
+                cv_scores[split]
+                for cv_scores in logbook.chapters["parameters"].select("train_score")
+            ]
+
+        cv_results["mean_train_score"] = [
+            np.nanmean(cv_scores)
+            for cv_scores in logbook.chapters["parameters"].select("train_score")
+        ]
+
+        cv_results["std_train_score"] = [
+            np.nanstd(cv_scores)
+            for cv_scores in logbook.chapters["parameters"].select("train_score")
+        ]
+
+    cv_results["mean_fit_time"] = [
+        np.nanmean(fit_time)
+        for fit_time in logbook.chapters["parameters"].select("fit_time")
+    ]
+    cv_results["std_fit_time"] = [
+        np.nanstd(fit_time)
+        for fit_time in logbook.chapters["parameters"].select("fit_time")
+    ]
+
+    cv_results["mean_score_time"] = [
+        np.nanmean(score_time)
+        for score_time in logbook.chapters["parameters"].select("score_time")
+    ]
+    cv_results["std_score_time"] = [
+        np.nanstd(score_time)
+        for score_time in logbook.chapters["parameters"].select("score_time")
+    ]
+
+    cv_results["params"] = [
+        select_dict_keys(individual, space.parameters)
+        for individual in logbook.chapters["parameters"]
+    ]
+
+    return cv_results

--- a/sklearn_genetic/utils/cv_scores.py
+++ b/sklearn_genetic/utils/cv_scores.py
@@ -3,7 +3,7 @@ from scipy.stats import rankdata
 
 
 def select_dict_keys(dictionary, keys):
-    return {key: dictionary[key] for key in set(keys)}
+    return {key: dictionary[key] for key in keys}
 
 
 def crete_cv_results_(logbook, space, return_train_score):

--- a/sklearn_genetic/utils/cv_scores.py
+++ b/sklearn_genetic/utils/cv_scores.py
@@ -1,4 +1,5 @@
 import numpy as np
+from scipy.stats import rankdata
 
 
 def select_dict_keys(dictionary, keys):
@@ -10,12 +11,12 @@ def crete_cv_results_(logbook, space, return_train_score):
     n_splits = len(logbook.chapters["parameters"].select("cv_scores")[0])
 
     for parameter in space.parameters:
-        cv_results[f"param{parameter}"] = logbook.chapters["parameters"].select(
+        cv_results[f"param_{parameter}"] = logbook.chapters["parameters"].select(
             parameter
         )
 
     for split in range(n_splits):
-        cv_results[f"split_{split}_test_score"] = [
+        cv_results[f"split{split}_test_score"] = [
             cv_scores[split]
             for cv_scores in logbook.chapters["parameters"].select("cv_scores")
         ]
@@ -25,6 +26,10 @@ def crete_cv_results_(logbook, space, return_train_score):
         np.nanstd(cv_scores)
         for cv_scores in logbook.chapters["parameters"].select("cv_scores")
     ]
+
+    cv_results["rank_test_score"] = rankdata(
+        -np.array(cv_results["mean_test_score"]), method="min"
+    ).astype(int)
 
     if return_train_score:
 
@@ -43,6 +48,10 @@ def crete_cv_results_(logbook, space, return_train_score):
             np.nanstd(cv_scores)
             for cv_scores in logbook.chapters["parameters"].select("train_score")
         ]
+
+        cv_results["rank_train_score"] = rankdata(
+            -np.array(cv_results["mean_train_score"]), method="min"
+        ).astype(int)
 
     cv_results["mean_fit_time"] = [
         np.nanmean(fit_time)


### PR DESCRIPTION
This PR implement the missing properties of scikit-learn BaseSearchCV, the parameter `return_train_score` was added in `GASearchCV`, the following properties now are calculated as in scikit-learn:

* cv_results_
* best_estimator_
* best_params_
* best_index_
* scorer_
* n_splits_
* refit_time_

This introduces some changes: 

* The `GASearchCV.logbook` property now has extra information that comes from the scikit-learn cross_validate function
* Internally, now the hof uses the `self.best_params_` for the position 0, to be consistent with the scikit-learn API and parameters like `self.best_index_`.

Tests and documentation is added