### PR TITLE
[PR] generation param in DeltaThreshold callback

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -10,6 +10,15 @@ What's new in 0.7.0dev0
 This is the current in-development version, these features are not yet
 available via PyPI
 
+^^^^^^^^^
+Features:
+^^^^^^^^^
+
+* Added the parameter `generations` to the :class:`~sklearn_genetic.callbacks.DeltaThreshold`.
+  Now it compares the maximum and minimum values of a metric from the last generations, instead
+  of just the current and previous ones. The default value is 2, so the behavior remains the same
+  as in previous versions.
+
 ^^^^^^^^^^
 Bug Fixes:
 ^^^^^^^^^^

--- a/docs/tutorials/callbacks.rst
+++ b/docs/tutorials/callbacks.rst
@@ -93,16 +93,19 @@ Now we just have to pass it to the estimator during the fitting
 
 DeltaThreshold
 --------------
-This callback stops the optimization if the absolute difference
-between the current and last metric is less or equals to a threshold.
+Stops the optimization if the absolute difference between the maximum and minimum value from the last N generations
+is less or equals to a threshold.
 
-It just requires the threshold and the metric name, for example
-using the 'fitness_min' value:
+The threshold gets evaluated after the number of generations specified is reached;
+the default number is 2 (the current and previous one).
+
+It just requires the threshold, the metric name and the generations, for example
+using the 'fitness_min' value and comparing the last 5 generations:
 
 .. code:: python3
 
     from sklearn_genetic.callbacks import DeltaThreshold
-    callback = DeltaThreshold(threshold=0.001, metric='fitness')
+    callback = DeltaThreshold(threshold=0.001, generations=5, metric='fitness_min')
 
     evolved_estimator.fit(X, y, callbacks=callback)
 

--- a/sklearn_genetic/callbacks/tests/test_callbacks.py
+++ b/sklearn_genetic/callbacks/tests/test_callbacks.py
@@ -177,7 +177,10 @@ def test_delta_callback():
 
     # Abs difference is bigger than the threshold
     assert callback(logbook=logbook)
-    assert callback(logbook=logbook, record={"fitness": 0.9141})
+
+    callback = DeltaThreshold(0.1, generations=4)
+
+    assert callback(logbook=logbook)
 
     with pytest.raises(Exception) as excinfo:
         callback()

--- a/sklearn_genetic/tests/test_genetic_search.py
+++ b/sklearn_genetic/tests/test_genetic_search.py
@@ -460,7 +460,7 @@ def test_param_grid_one_param():
     assert (
         record[0].message.args[0]
         == "Warning, only one parameter was provided to the param_grid, the optimization routine might not have effect, "
-           "it's advised to use at least 2 parameters"
+        "it's advised to use at least 2 parameters"
     )
 
     evolved_estimator.fit(X, y_labels)
@@ -488,4 +488,3 @@ def test_param_grid_one_param():
     assert "rank_test_score" in cv_result_keys
     assert "std_fit_time" in cv_result_keys
     assert "params" in cv_result_keys
-


### PR DESCRIPTION
This PR adds the parameter `generations` to the DeltaThreshold callback.

Now it compares the maximum and minimum values of a metric from the last generations, instead of just the current and previous ones. The default value is 2, so the behavior remains the same as in previous versions.

This is an implementation of the described in issue #64 