### PR TITLE
Multi-metric evaluation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ Sklearn-genetic-opt
 
 scikit-learn models hyperparameters tuning and feature selection, using evolutionary algorithms.
 
-This is meant to be an alternative from popular methods inside scikit-learn such as Grid Search and Randomized Grid Search
+This is meant to be an alternative to popular methods inside scikit-learn such as Grid Search and Randomized Grid Search
 for hyperparameteres tuning, and from RFE, Select From Model for feature selection.
 
 Sklearn-genetic-opt uses evolutionary algorithms from the DEAP package to choose the set of hyperparameters that

--- a/docs/external_references.rst
+++ b/docs/external_references.rst
@@ -4,7 +4,7 @@ of Sklearn-genetic-opt.
 Articles
 ========
 
-
+* `Evolutionary Feature Selection for Machine Learning <https://towardsdatascience.com/evolutionary-feature-selection-for-machine-learning-7f61af2a8c12>`_
 * `Hyperparameters Tuning: From Grid Search to Optimization. <https://towardsdatascience.com/hyperparameters-tuning-from-grid-search-to-optimization-a09853e4e9b8#542d-6748243ca9d4>`_
 * `Tune your Scikit-learn model using evolutionary algorithms <https://medium.com/mlearning-ai/tune-your-scikit-learn-model-using-evolutionary-algorithms-30538248ac16>`_
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@
    contain the root `toctree` directive.
 
 sklearn-genetic-opt
-==================
+===================
 scikit-learn models hyperparameters tuning and feature selection,
 using evolutionary algorithms.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -79,6 +79,7 @@ as it is usually advised to look further which distribution works better for you
    notebooks/Iris_feature_selection.ipynb
    notebooks/Digits_decision_tree.ipynb
    notebooks/MLflow_logger.ipynb
+   notebooks/Iris_multimetric.ipynb
 
 .. toctree::
    :maxdepth: 2

--- a/docs/notebooks/Iris_multimetric.ipynb
+++ b/docs/notebooks/Iris_multimetric.ipynb
@@ -1,0 +1,237 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "# Iris Multi-metric"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "outputs": [],
+   "source": [
+    "from sklearn_genetic import GASearchCV\n",
+    "from sklearn_genetic.space import Categorical, Integer, Continuous\n",
+    "from sklearn.model_selection import train_test_split, StratifiedKFold\n",
+    "from sklearn.tree import DecisionTreeClassifier\n",
+    "from sklearn.datasets import load_iris\n",
+    "from sklearn.metrics import make_scorer\n",
+    "from sklearn.metrics import balanced_accuracy_score"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Import the data and split it in train and test sets"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "outputs": [],
+   "source": [
+    "data = load_iris()\n",
+    "X, y = data[\"data\"], data[\"target\"]\n",
+    "\n",
+    "X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.33, random_state=0)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Define the GASearchCV options and Multi-metric\n"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "outputs": [],
+   "source": [
+    "clf = DecisionTreeClassifier()\n",
+    "\n",
+    "params_grid = {\n",
+    "    \"min_weight_fraction_leaf\": Continuous(0, 0.5),\n",
+    "    \"criterion\": Categorical([\"gini\", \"entropy\"]),\n",
+    "    \"max_depth\": Integer(2, 20),\n",
+    "    \"max_leaf_nodes\": Integer(2, 30),\n",
+    "}\n",
+    "\n",
+    "scoring = {\"accuracy\": \"accuracy\",\n",
+    "           \"balanced_accuracy\": make_scorer(balanced_accuracy_score)}"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Define the GASearchCV options"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "outputs": [],
+   "source": [
+    "# Low number of generations and population\n",
+    "# Just to see the effect of multimetric\n",
+    "# In logbook and cv_results_\n",
+    "\n",
+    "evolved_estimator = GASearchCV(\n",
+    "    clf,\n",
+    "    scoring=scoring,\n",
+    "    population_size=3,\n",
+    "    generations=2,\n",
+    "    crossover_probability=0.9,\n",
+    "    mutation_probability=0.05,\n",
+    "    param_grid=params_grid,\n",
+    "    algorithm=\"eaSimple\",\n",
+    "    n_jobs=-1,\n",
+    "    verbose=True,\n",
+    "    error_score='raise',\n",
+    "    refit=\"accuracy\")"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Fit the model and see some results"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "gen\tnevals\tfitness \tfitness_std\tfitness_max\tfitness_min\n",
+      "0  \t3     \t0.856902\t0.117921   \t0.940285   \t0.690137   \n",
+      "1  \t2     \t0.940285\t0          \t0.940285   \t0.940285   \n",
+      "2  \t2     \t0.940285\t0          \t0.940285   \t0.940285   \n"
+     ]
+    }
+   ],
+   "source": [
+    "evolved_estimator.fit(X_train, y_train)\n",
+    "y_predict_ga = evolved_estimator.predict(X_test)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "{'param_min_weight_fraction_leaf': [0.22963955365985156,\n  0.11807874354582698,\n  0.4566955700628974,\n  0.11807874354582698,\n  0.22963955365985156,\n  0.22963955365985156,\n  0.22963955365985156],\n 'param_criterion': ['gini',\n  'entropy',\n  'entropy',\n  'gini',\n  'entropy',\n  'entropy',\n  'gini'],\n 'param_max_depth': [2, 9, 10, 2, 9, 2, 9],\n 'param_max_leaf_nodes': [13, 7, 3, 7, 13, 13, 13],\n 'split0_test_accuracy': [0.9117647058823529,\n  0.9117647058823529,\n  0.6764705882352942,\n  0.9117647058823529,\n  0.9117647058823529,\n  0.9117647058823529,\n  0.9117647058823529],\n 'split1_test_accuracy': [0.9696969696969697,\n  0.9696969696969697,\n  0.696969696969697,\n  0.9696969696969697,\n  0.9696969696969697,\n  0.9696969696969697,\n  0.9696969696969697],\n 'split2_test_accuracy': [0.9393939393939394,\n  0.9393939393939394,\n  0.696969696969697,\n  0.9393939393939394,\n  0.9393939393939394,\n  0.9393939393939394,\n  0.9393939393939394],\n 'mean_test_accuracy': [0.9402852049910874,\n  0.9402852049910874,\n  0.690136660724896,\n  0.9402852049910874,\n  0.9402852049910874,\n  0.9402852049910874,\n  0.9402852049910874],\n 'std_test_accuracy': [0.023659142890153965,\n  0.023659142890153965,\n  0.009663372529584432,\n  0.023659142890153965,\n  0.023659142890153965,\n  0.023659142890153965,\n  0.023659142890153965],\n 'rank_test_accuracy': array([1, 1, 7, 1, 1, 1, 1]),\n 'split0_train_accuracy': [0.9696969696969697,\n  0.9696969696969697,\n  0.696969696969697,\n  0.9696969696969697,\n  0.9696969696969697,\n  0.9696969696969697,\n  0.9696969696969697],\n 'split1_train_accuracy': [0.9552238805970149,\n  0.9552238805970149,\n  0.6865671641791045,\n  0.9552238805970149,\n  0.9552238805970149,\n  0.9552238805970149,\n  0.9552238805970149],\n 'split2_train_accuracy': [0.9701492537313433,\n  0.9701492537313433,\n  0.6865671641791045,\n  0.9701492537313433,\n  0.9701492537313433,\n  0.9701492537313433,\n  0.9701492537313433],\n 'mean_train_accuracy': [0.9650233680084427,\n  0.9650233680084427,\n  0.6900346751093019,\n  0.9650233680084427,\n  0.9650233680084427,\n  0.9650233680084427,\n  0.9650233680084427],\n 'std_train_accuracy': [0.006931743665052123,\n  0.006931743665052123,\n  0.004903800985162277,\n  0.006931743665052123,\n  0.006931743665052123,\n  0.006931743665052123,\n  0.006931743665052123],\n 'rank_train_accuracy': array([1, 1, 7, 1, 1, 1, 1]),\n 'split0_test_balanced_accuracy': [0.9090909090909092,\n  0.9090909090909092,\n  0.6666666666666666,\n  0.9090909090909092,\n  0.9090909090909092,\n  0.9090909090909092,\n  0.9090909090909092],\n 'split1_test_balanced_accuracy': [0.9722222222222222,\n  0.9722222222222222,\n  0.6666666666666666,\n  0.9722222222222222,\n  0.9722222222222222,\n  0.9722222222222222,\n  0.9722222222222222],\n 'split2_test_balanced_accuracy': [0.9333333333333332,\n  0.9388888888888888,\n  0.6666666666666666,\n  0.9333333333333332,\n  0.9388888888888888,\n  0.9333333333333332,\n  0.9333333333333332],\n 'mean_test_balanced_accuracy': [0.9382154882154882,\n  0.94006734006734,\n  0.6666666666666666,\n  0.9382154882154882,\n  0.94006734006734,\n  0.9382154882154882,\n  0.9382154882154882],\n 'std_test_balanced_accuracy': [0.02600342607735869,\n  0.02578671796107406,\n  0.0,\n  0.02600342607735869,\n  0.02578671796107406,\n  0.02600342607735869,\n  0.02600342607735869],\n 'rank_test_balanced_accuracy': array([3, 1, 7, 3, 1, 3, 3]),\n 'split0_train_balanced_accuracy': [0.9722222222222222,\n  0.9722222222222222,\n  0.6666666666666666,\n  0.9722222222222222,\n  0.9722222222222222,\n  0.9722222222222222,\n  0.9722222222222222],\n 'split1_train_balanced_accuracy': [0.9551414768806072,\n  0.9551414768806072,\n  0.6666666666666666,\n  0.9551414768806072,\n  0.9551414768806072,\n  0.9551414768806072,\n  0.9551414768806072],\n 'split2_train_balanced_accuracy': [0.9710144927536232,\n  0.9710144927536232,\n  0.6666666666666666,\n  0.9710144927536232,\n  0.9710144927536232,\n  0.9710144927536232,\n  0.9710144927536232],\n 'mean_train_balanced_accuracy': [0.9661260639521508,\n  0.9661260639521508,\n  0.6666666666666666,\n  0.9661260639521508,\n  0.9661260639521508,\n  0.9661260639521508,\n  0.9661260639521508],\n 'std_train_balanced_accuracy': [0.007782909373174586,\n  0.007782909373174586,\n  0.0,\n  0.007782909373174586,\n  0.007782909373174586,\n  0.007782909373174586,\n  0.007782909373174586],\n 'rank_train_balanced_accuracy': array([1, 1, 7, 1, 1, 1, 1]),\n 'mean_fit_time': [0.001999060312906901,\n  0.0016531944274902344,\n  0.0016682147979736328,\n  0.0019936561584472656,\n  0.0016682942708333333,\n  0.0023442904154459634,\n  0.0016681353251139324],\n 'std_fit_time': [8.104673248279548e-07,\n  0.00048135126754460846,\n  0.0004735620798937051,\n  8.939901952387178e-06,\n  0.00047260810461652655,\n  0.0004931964528559586,\n  0.0004699654688748367],\n 'mean_score_time': [0.0019881725311279297,\n  0.0026591618855794272,\n  0.0026796658833821616,\n  0.001337607701619466,\n  0.0013335545857747395,\n  0.0023202896118164062,\n  0.002334038416544596],\n 'std_score_time': [1.2906940492414977e-05,\n  0.0009508785819826155,\n  0.0009365762649996311,\n  0.00047234976131361057,\n  0.00047080875797289405,\n  0.0004528267864869186,\n  0.00047109380912835715],\n 'params': [{'min_weight_fraction_leaf': 0.22963955365985156,\n   'criterion': 'gini',\n   'max_depth': 2,\n   'max_leaf_nodes': 13},\n  {'min_weight_fraction_leaf': 0.11807874354582698,\n   'criterion': 'entropy',\n   'max_depth': 9,\n   'max_leaf_nodes': 7},\n  {'min_weight_fraction_leaf': 0.4566955700628974,\n   'criterion': 'entropy',\n   'max_depth': 10,\n   'max_leaf_nodes': 3},\n  {'min_weight_fraction_leaf': 0.11807874354582698,\n   'criterion': 'gini',\n   'max_depth': 2,\n   'max_leaf_nodes': 7},\n  {'min_weight_fraction_leaf': 0.22963955365985156,\n   'criterion': 'entropy',\n   'max_depth': 9,\n   'max_leaf_nodes': 13},\n  {'min_weight_fraction_leaf': 0.22963955365985156,\n   'criterion': 'entropy',\n   'max_depth': 2,\n   'max_leaf_nodes': 13},\n  {'min_weight_fraction_leaf': 0.22963955365985156,\n   'criterion': 'gini',\n   'max_depth': 9,\n   'max_leaf_nodes': 13}]}"
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "evolved_estimator.cv_results_\n"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "[{'index': 0,\n  'min_weight_fraction_leaf': 0.22963955365985156,\n  'criterion': 'gini',\n  'max_depth': 2,\n  'max_leaf_nodes': 13,\n  'score': 0.9402852049910874,\n  'cv_scores': array([0.91176471, 0.96969697, 0.93939394]),\n  'fit_time': array([0.00199986, 0.00199795, 0.00199938]),\n  'score_time': array([0.00197005, 0.00199533, 0.00199914]),\n  'test_accuracy': array([0.91176471, 0.96969697, 0.93939394]),\n  'train_accuracy': array([0.96969697, 0.95522388, 0.97014925]),\n  'test_balanced_accuracy': array([0.90909091, 0.97222222, 0.93333333]),\n  'train_balanced_accuracy': array([0.97222222, 0.95514148, 0.97101449])},\n {'index': 1,\n  'min_weight_fraction_leaf': 0.11807874354582698,\n  'criterion': 'entropy',\n  'max_depth': 9,\n  'max_leaf_nodes': 7,\n  'score': 0.9402852049910874,\n  'cv_scores': array([0.91176471, 0.96969697, 0.93939394]),\n  'fit_time': array([0.00200057, 0.0019865 , 0.00097251]),\n  'score_time': array([0.00200391, 0.00196981, 0.00400376]),\n  'test_accuracy': array([0.91176471, 0.96969697, 0.93939394]),\n  'train_accuracy': array([0.96969697, 0.95522388, 0.97014925]),\n  'test_balanced_accuracy': array([0.90909091, 0.97222222, 0.93888889]),\n  'train_balanced_accuracy': array([0.97222222, 0.95514148, 0.97101449])},\n {'index': 2,\n  'min_weight_fraction_leaf': 0.4566955700628974,\n  'criterion': 'entropy',\n  'max_depth': 10,\n  'max_leaf_nodes': 3,\n  'score': 0.690136660724896,\n  'cv_scores': array([0.67647059, 0.6969697 , 0.6969697 ]),\n  'fit_time': array([0.00200272, 0.00200343, 0.0009985 ]),\n  'score_time': array([0.00203657, 0.00199842, 0.004004  ]),\n  'test_accuracy': array([0.67647059, 0.6969697 , 0.6969697 ]),\n  'train_accuracy': array([0.6969697 , 0.68656716, 0.68656716]),\n  'test_balanced_accuracy': array([0.66666667, 0.66666667, 0.66666667]),\n  'train_balanced_accuracy': array([0.66666667, 0.66666667, 0.66666667])},\n {'index': 3,\n  'min_weight_fraction_leaf': 0.11807874354582698,\n  'criterion': 'gini',\n  'max_depth': 2,\n  'max_leaf_nodes': 7,\n  'score': 0.9402852049910874,\n  'cv_scores': array([0.91176471, 0.96969697, 0.93939394]),\n  'fit_time': array([0.00200033, 0.00199962, 0.00198102]),\n  'score_time': array([0.00200558, 0.00099778, 0.00100946]),\n  'test_accuracy': array([0.91176471, 0.96969697, 0.93939394]),\n  'train_accuracy': array([0.96969697, 0.95522388, 0.97014925]),\n  'test_balanced_accuracy': array([0.90909091, 0.97222222, 0.93333333]),\n  'train_balanced_accuracy': array([0.97222222, 0.95514148, 0.97101449])},\n {'index': 4,\n  'min_weight_fraction_leaf': 0.22963955365985156,\n  'criterion': 'entropy',\n  'max_depth': 9,\n  'max_leaf_nodes': 13,\n  'score': 0.9402852049910874,\n  'cv_scores': array([0.91176471, 0.96969697, 0.93939394]),\n  'fit_time': array([0.00200105, 0.00200391, 0.00099993]),\n  'score_time': array([0.00100136, 0.00099993, 0.00199938]),\n  'test_accuracy': array([0.91176471, 0.96969697, 0.93939394]),\n  'train_accuracy': array([0.96969697, 0.95522388, 0.97014925]),\n  'test_balanced_accuracy': array([0.90909091, 0.97222222, 0.93888889]),\n  'train_balanced_accuracy': array([0.97222222, 0.95514148, 0.97101449])},\n {'index': 5,\n  'min_weight_fraction_leaf': 0.22963955365985156,\n  'criterion': 'entropy',\n  'max_depth': 2,\n  'max_leaf_nodes': 13,\n  'score': 0.9402852049910874,\n  'cv_scores': array([0.91176471, 0.96969697, 0.93939394]),\n  'fit_time': array([0.00304174, 0.00198984, 0.00200129]),\n  'score_time': array([0.00296068, 0.00200129, 0.0019989 ]),\n  'test_accuracy': array([0.91176471, 0.96969697, 0.93939394]),\n  'train_accuracy': array([0.96969697, 0.95522388, 0.97014925]),\n  'test_balanced_accuracy': array([0.90909091, 0.97222222, 0.93333333]),\n  'train_balanced_accuracy': array([0.97222222, 0.95514148, 0.97101449])},\n {'index': 6,\n  'min_weight_fraction_leaf': 0.22963955365985156,\n  'criterion': 'gini',\n  'max_depth': 9,\n  'max_leaf_nodes': 13,\n  'score': 0.9402852049910874,\n  'cv_scores': array([0.91176471, 0.96969697, 0.93939394]),\n  'fit_time': array([0.00200057, 0.0010035 , 0.00200033]),\n  'score_time': array([0.00200343, 0.00300026, 0.00199842]),\n  'test_accuracy': array([0.91176471, 0.96969697, 0.93939394]),\n  'train_accuracy': array([0.96969697, 0.95522388, 0.97014925]),\n  'test_balanced_accuracy': array([0.90909091, 0.97222222, 0.93333333]),\n  'train_balanced_accuracy': array([0.97222222, 0.95514148, 0.97101449])}]"
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "evolved_estimator.logbook.chapters[\"parameters\"]\n",
+    "\n"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -14,6 +14,17 @@ Features:
   If it's not None, it will penalize individuals with more features than max_features, putting a "soft" upper bound
   to the number of features to be selected.
 
+* Class :class:`~sklearn_genetic.GASearchCV` now supports multi-metric evaluation the same way scikit-learn does,
+  you will see this reflected on the `logbook` and `cv_results` objects, where now you get results for each metric.
+  As in scikit-learn, if multi-metric is used, the `refit` parameter must be a str specifying the metric to evaluate the cv-scores.
+  See more in the :class:`~sklearn_genetic.GASearchCV` API documentation.
+
+^^^^^
+Docs:
+^^^^^
+
+* A new notebook called Iris_multimetric was added to showcase the new multimetric capabilities.
+
 ^^^^^^^^^^^^
 API Changes:
 ^^^^^^^^^^^^

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -14,16 +14,17 @@ Features:
   If it's not None, it will penalize individuals with more features than max_features, putting a "soft" upper bound
   to the number of features to be selected.
 
-* Class :class:`~sklearn_genetic.GASearchCV` now supports multi-metric evaluation the same way scikit-learn does,
+* Classes :class:`~sklearn_genetic.GASearchCV` and :class:`~sklearn_genetic.GAFeatureSelectionCV`
+  now support multi-metric evaluation the same way scikit-learn does,
   you will see this reflected on the `logbook` and `cv_results` objects, where now you get results for each metric.
   As in scikit-learn, if multi-metric is used, the `refit` parameter must be a str specifying the metric to evaluate the cv-scores.
-  See more in the :class:`~sklearn_genetic.GASearchCV` API documentation.
+  See more in the :class:`~sklearn_genetic.GASearchCV` and :class:`~sklearn_genetic.GAFeatureSelectionCV` API documentation.
 
 ^^^^^
 Docs:
 ^^^^^
 
-* A new notebook called Iris_multimetric was added to showcase the new multimetric capabilities.
+* A new notebook called Iris_multimetric was added to showcase the new multi-metric capabilities.
 
 ^^^^^^^^^^^^
 API Changes:

--- a/sklearn_genetic/genetic_search.py
+++ b/sklearn_genetic/genetic_search.py
@@ -14,6 +14,7 @@ from sklearn.metrics import check_scoring
 from sklearn.exceptions import NotFittedError
 from sklearn.model_selection._search import BaseSearchCV
 from sklearn.model_selection._split import check_cv
+from sklearn.metrics._scorer import _check_multimetric_scoring
 
 from .parameters import Algorithms, Criteria
 from .space import Space
@@ -81,11 +82,19 @@ class GASearchCV(BaseSearchCV):
     elitism : bool, default=True
         If True takes the *tournament_size* best solution to the next generation.
 
-    scoring : str or callable, default=None
-        A str (see model evaluation documentation) or
-        a scorer callable object / function with signature
-        ``scorer(estimator, X, y)`` which should return only
-        a single value.
+    scoring : str, callable, list, tuple or dict, default=None
+        Strategy to evaluate the performance of the cross-validated model on
+        the test set.
+        If `scoring` represents a single score, one can use:
+
+        - a single string;
+        - a callable that returns a single value.
+        If `scoring` represents multiple scores, one can use:
+
+        - a list or tuple of unique strings;
+        - a callable returning a dictionary where the keys are the metric
+          names and the values are the metric scores;
+        - a dictionary with metric names as keys and callables a values.
 
     n_jobs : int, default=None
         Number of jobs to run in parallel. Training the estimator and computing
@@ -107,8 +116,22 @@ class GASearchCV(BaseSearchCV):
         Evolutionary algorithm to use.
         See more details in the deap algorithms documentation.
 
-    refit : bool, default=True
-        Refit an estimator using the best found parameters on the whole dataset.
+    refit : bool, str, or callable, default=True
+        Refit an estimator using the best found parameters on the whole
+        dataset.
+        For multiple metric evaluation, this needs to be a `str` denoting the
+        scorer that would be used to find the best parameters for refitting
+        the estimator at the end.
+        The refitted estimator is made available at the ``best_estimator_``
+        attribute and permits using ``predict`` directly on this
+        ``GASearchCV`` instance.
+        Also for multiple metric evaluation, the attributes ``best_index_``,
+        ``best_score_`` and ``best_params_`` will only be available if
+        ``refit`` is set and all of them will be determined w.r.t this specific
+        scorer.
+        See ``scoring`` parameter to know more about multiple metric
+        evaluation.
+
         If ``False``, it is not possible to make predictions
         using this GASearchCV instance after fitting.
 
@@ -249,6 +272,8 @@ class GASearchCV(BaseSearchCV):
         self.best_score_ = None
         self.n_splits_ = None
         self.refit_time_ = None
+        self.refit_metric = "score"
+        self.metrics_list = None
         self.multimetric_ = False
         self.log_config = log_config
 
@@ -408,7 +433,7 @@ class GASearchCV(BaseSearchCV):
             return_train_score=self.return_train_score,
         )
 
-        cv_scores = cv_results["test_score"]
+        cv_scores = cv_results[f"test_{self.refit_metric}"]
         score = np.mean(cv_scores)
 
         # Uses the log config to save in remote log server (e.g MLflow)
@@ -420,13 +445,18 @@ class GASearchCV(BaseSearchCV):
             )
 
         # These values are used to compute cv_results_ property
+        current_generation_params["score"] = score
         current_generation_params["cv_scores"] = cv_scores
         current_generation_params["fit_time"] = cv_results["fit_time"]
         current_generation_params["score_time"] = cv_results["score_time"]
-        current_generation_params["score"] = score
 
-        if self.return_train_score:
-            current_generation_params["train_score"] = cv_results["train_score"]
+        for metric in self.metrics_list:
+            current_generation_params[f"test_{metric}"] = cv_results[f"test_{metric}"]
+
+            if self.return_train_score:
+                current_generation_params[f"train_{metric}"] = cv_results[
+                    f"train_{metric}"
+                ]
 
         index = len(self.logbook.chapters["parameters"])
         current_generation_params = {"index": index, **current_generation_params}
@@ -464,7 +494,18 @@ class GASearchCV(BaseSearchCV):
         # Make sure the callbacks are valid
         self.callbacks = check_callback(callbacks)
 
-        self.scorer_ = check_scoring(self.estimator, scoring=self.scoring)
+        if callable(self.scoring):
+            self.scorer_ = self.scoring
+            self.metrics_list = [self.refit_metric]
+        elif self.scoring is None or isinstance(self.scoring, str):
+            self.scorer_ = check_scoring(self.estimator, self.scoring)
+            self.metrics_list = [self.refit_metric]
+        else:
+            self.scorer_ = _check_multimetric_scoring(self.estimator, self.scoring)
+            self._check_refit_for_multimetric(self.scorer_)
+            self.refit_metric = self.refit
+            self.metrics_list = self.scorer_.keys()
+            self.multimetric_ = True
 
         # Check cv and get the n_splits
         cv_orig = check_cv(self.cv, y, classifier=is_classifier(self.estimator))
@@ -485,6 +526,7 @@ class GASearchCV(BaseSearchCV):
             logbook=self.logbook,
             space=self.space,
             return_train_score=self.return_train_score,
+            metrics=self.metrics_list,
         )
 
         self.history = {
@@ -497,8 +539,12 @@ class GASearchCV(BaseSearchCV):
 
         # Imitate the logic of scikit-learn refit parameter
         if self.refit:
-            self.best_index_ = self.cv_results_["rank_test_score"].argmin()
-            self.best_score_ = self.cv_results_["mean_test_score"][self.best_index_]
+            self.best_index_ = self.cv_results_[
+                f"rank_test_{self.refit_metric}"
+            ].argmin()
+            self.best_score_ = self.cv_results_[f"mean_test_{self.refit_metric}"][
+                self.best_index_
+            ]
             self.best_params_ = self.cv_results_["params"][self.best_index_]
 
             self.estimator.set_params(**self.best_params_)
@@ -884,6 +930,7 @@ class GAFeatureSelectionCV(BaseSearchCV):
         self.cv_results_ = None
         self.n_splits_ = None
         self.refit_time_ = None
+        self.refit_metric = "score"
         self.multimetric_ = False
         self.log_config = log_config
 

--- a/sklearn_genetic/plots.py
+++ b/sklearn_genetic/plots.py
@@ -54,7 +54,7 @@ def plot_fitness_evolution(estimator, metric="fitness"):
     )
     ax.set_title(f"{metric.capitalize()} average evolution over generations")
 
-    ax.set(xlabel="generations", ylabel=f"fitness ({estimator.scoring})")
+    ax.set(xlabel="generations", ylabel=f"fitness ({estimator.refit_metric})")
     return ax
 
 

--- a/sklearn_genetic/plots.py
+++ b/sklearn_genetic/plots.py
@@ -88,7 +88,7 @@ def plot_search_space(estimator, height=2, s=25, features: list = None):
     if features:
         stats = df[features]
     else:
-        variables = [*estimator.space.parameters, "score"]
+        variables = [*estimator.space.parameters, estimator.refit_metric]
         stats = df[variables]
 
     g = sns.PairGrid(stats, diag_sharey=False, height=height)
@@ -145,7 +145,7 @@ def plot_parallel_coordinates(estimator, features: list = None):
 
     df = logbook_to_pandas(estimator.logbook)
     param_grid = estimator.space.param_grid
-    score = df["score"]
+    score = df[estimator.refit_metric]
     if features:
         non_categorical_features = []
         for feature in features:

--- a/sklearn_genetic/tests/test_genetic_search.py
+++ b/sklearn_genetic/tests/test_genetic_search.py
@@ -7,7 +7,9 @@ from sklearn.model_selection import train_test_split
 from sklearn.utils.validation import check_is_fitted
 from sklearn.tree import DecisionTreeRegressor
 from sklearn.cluster import KMeans
-from sklearn.metrics import accuracy_score
+from sklearn.metrics import accuracy_score, balanced_accuracy_score
+from sklearn.metrics import make_scorer
+
 import numpy as np
 
 from .. import GASearchCV
@@ -487,4 +489,154 @@ def test_param_grid_one_param():
     assert "std_test_score" in cv_result_keys
     assert "rank_test_score" in cv_result_keys
     assert "std_fit_time" in cv_result_keys
+    assert "params" in cv_result_keys
+
+
+def test_expected_ga_multimetric():
+    clf = SGDClassifier(loss="log", fit_intercept=True)
+    scoring = {
+        "accuracy": "accuracy",
+        "balanced_accuracy": make_scorer(balanced_accuracy_score),
+    }
+
+    generations = 6
+    evolved_estimator = GASearchCV(
+        clf,
+        cv=3,
+        scoring=scoring,
+        population_size=6,
+        generations=generations,
+        tournament_size=3,
+        elitism=True,
+        keep_top_k=4,
+        param_grid={
+            "l1_ratio": Continuous(0, 1),
+            "alpha": Continuous(1e-4, 1, distribution="log-uniform"),
+            "average": Categorical([True, False]),
+            "max_iter": Integer(700, 1000),
+        },
+        verbose=False,
+        algorithm="eaSimple",
+        n_jobs=-1,
+        return_train_score=True,
+        refit="accuracy",
+    )
+
+    evolved_estimator.fit(X_train, y_train)
+
+    assert check_is_fitted(evolved_estimator) is None
+    assert "l1_ratio" in evolved_estimator.best_params_
+    assert "alpha" in evolved_estimator.best_params_
+    assert "average" in evolved_estimator.best_params_
+    assert len(evolved_estimator) == generations + 1  # +1 random initial population
+    assert len(evolved_estimator.predict(X_test)) == len(X_test)
+    assert evolved_estimator.score(X_train, y_train) >= 0
+    assert len(evolved_estimator.decision_function(X_test)) == len(X_test)
+    assert len(evolved_estimator.predict_proba(X_test)) == len(X_test)
+    assert len(evolved_estimator.predict_log_proba(X_test)) == len(X_test)
+    assert evolved_estimator.score(X_test, y_test) == accuracy_score(
+        y_test, evolved_estimator.predict(X_test)
+    )
+    assert bool(evolved_estimator.get_params())
+    assert len(evolved_estimator.hof) == evolved_estimator.keep_top_k
+    assert "gen" in evolved_estimator[0]
+    assert "fitness_max" in evolved_estimator[0]
+    assert "fitness" in evolved_estimator[0]
+    assert "fitness_std" in evolved_estimator[0]
+    assert "fitness_min" in evolved_estimator[0]
+
+    cv_results_ = evolved_estimator.cv_results_
+    cv_result_keys = set(cv_results_.keys())
+
+    assert "param_l1_ratio" in cv_result_keys
+    assert "param_alpha" in cv_result_keys
+    assert "param_average" in cv_result_keys
+    assert "std_fit_time" in cv_result_keys
+    assert "mean_score_time" in cv_result_keys
+    assert "params" in cv_result_keys
+
+    for metric in scoring.keys():
+
+        assert f"split0_test_{metric}" in cv_result_keys
+        assert f"split1_test_{metric}" in cv_result_keys
+        assert f"split2_test_{metric}" in cv_result_keys
+        assert f"split0_train_{metric}" in cv_result_keys
+        assert f"split1_train_{metric}" in cv_result_keys
+        assert f"split2_train_{metric}" in cv_result_keys
+        assert f"mean_test_{metric}" in cv_result_keys
+        assert f"std_test_{metric}" in cv_result_keys
+        assert f"rank_test_{metric}" in cv_result_keys
+        assert f"mean_train_{metric}" in cv_result_keys
+        assert f"std_train_{metric}" in cv_result_keys
+        assert f"rank_train_{metric}" in cv_result_keys
+
+
+def test_expected_ga_callable_score():
+    clf = SGDClassifier(loss="log", fit_intercept=True)
+    generations = 6
+    scoring = make_scorer(accuracy_score)
+    evolved_estimator = GASearchCV(
+        clf,
+        cv=3,
+        scoring=scoring,
+        population_size=6,
+        generations=generations,
+        tournament_size=3,
+        elitism=False,
+        keep_top_k=4,
+        param_grid={
+            "l1_ratio": Continuous(0, 1),
+            "alpha": Continuous(1e-4, 1, distribution="log-uniform"),
+            "average": Categorical([True, False]),
+            "max_iter": Integer(700, 1000),
+        },
+        verbose=False,
+        algorithm="eaSimple",
+        n_jobs=-1,
+        return_train_score=True,
+    )
+
+    evolved_estimator.fit(X_train, y_train)
+
+    assert check_is_fitted(evolved_estimator) is None
+    assert "l1_ratio" in evolved_estimator.best_params_
+    assert "alpha" in evolved_estimator.best_params_
+    assert "average" in evolved_estimator.best_params_
+    assert len(evolved_estimator) == generations + 1  # +1 random initial population
+    assert len(evolved_estimator.predict(X_test)) == len(X_test)
+    assert evolved_estimator.score(X_train, y_train) >= 0
+    assert len(evolved_estimator.decision_function(X_test)) == len(X_test)
+    assert len(evolved_estimator.predict_proba(X_test)) == len(X_test)
+    assert len(evolved_estimator.predict_log_proba(X_test)) == len(X_test)
+    assert evolved_estimator.score(X_test, y_test) == accuracy_score(
+        y_test, evolved_estimator.predict(X_test)
+    )
+    assert bool(evolved_estimator.get_params())
+    assert len(evolved_estimator.hof) == evolved_estimator.keep_top_k
+    assert "gen" in evolved_estimator[0]
+    assert "fitness_max" in evolved_estimator[0]
+    assert "fitness" in evolved_estimator[0]
+    assert "fitness_std" in evolved_estimator[0]
+    assert "fitness_min" in evolved_estimator[0]
+
+    cv_results_ = evolved_estimator.cv_results_
+    cv_result_keys = set(cv_results_.keys())
+
+    assert "param_l1_ratio" in cv_result_keys
+    assert "param_alpha" in cv_result_keys
+    assert "param_average" in cv_result_keys
+    assert "split0_test_score" in cv_result_keys
+    assert "split1_test_score" in cv_result_keys
+    assert "split2_test_score" in cv_result_keys
+    assert "split0_train_score" in cv_result_keys
+    assert "split1_train_score" in cv_result_keys
+    assert "split2_train_score" in cv_result_keys
+    assert "mean_test_score" in cv_result_keys
+    assert "std_test_score" in cv_result_keys
+    assert "rank_test_score" in cv_result_keys
+    assert "mean_train_score" in cv_result_keys
+    assert "std_train_score" in cv_result_keys
+    assert "rank_train_score" in cv_result_keys
+    assert "std_fit_time" in cv_result_keys
+    assert "mean_score_time" in cv_result_keys
     assert "params" in cv_result_keys

--- a/sklearn_genetic/utils/cv_scores.py
+++ b/sklearn_genetic/utils/cv_scores.py
@@ -6,7 +6,7 @@ def select_dict_keys(dictionary, keys):
     return {key: dictionary[key] for key in keys}
 
 
-def create_gasearch_cv_results_(logbook, space, return_train_score):
+def create_gasearch_cv_results_(logbook, space, return_train_score, metrics):
     cv_results = {}
     n_splits = len(logbook.chapters["parameters"].select("cv_scores")[0])
 
@@ -15,44 +15,57 @@ def create_gasearch_cv_results_(logbook, space, return_train_score):
             parameter
         )
 
-    for split in range(n_splits):
-        cv_results[f"split{split}_test_score"] = [
-            cv_scores[split]
-            for cv_scores in logbook.chapters["parameters"].select("cv_scores")
-        ]
-
-    cv_results["mean_test_score"] = logbook.chapters["parameters"].select("score")
-    cv_results["std_test_score"] = [
-        np.nanstd(cv_scores)
-        for cv_scores in logbook.chapters["parameters"].select("cv_scores")
-    ]
-
-    cv_results["rank_test_score"] = rankdata(
-        -np.array(cv_results["mean_test_score"]), method="min"
-    ).astype(int)
-
-    if return_train_score:
+    # Keys that are extended per metric in multimetric
+    for metric in metrics:
 
         for split in range(n_splits):
-            cv_results[f"split{split}_train_score"] = [
+            cv_results[f"split{split}_test_{metric}"] = [
                 cv_scores[split]
-                for cv_scores in logbook.chapters["parameters"].select("train_score")
+                for cv_scores in logbook.chapters["parameters"].select(f"test_{metric}")
             ]
 
-        cv_results["mean_train_score"] = [
+        cv_results[f"mean_test_{metric}"] = [
             np.nanmean(cv_scores)
-            for cv_scores in logbook.chapters["parameters"].select("train_score")
+            for cv_scores in logbook.chapters["parameters"].select(f"test_{metric}")
         ]
-
-        cv_results["std_train_score"] = [
+        cv_results[f"std_test_{metric}"] = [
             np.nanstd(cv_scores)
-            for cv_scores in logbook.chapters["parameters"].select("train_score")
+            for cv_scores in logbook.chapters["parameters"].select(f"test_{metric}")
         ]
 
-        cv_results["rank_train_score"] = rankdata(
-            -np.array(cv_results["mean_train_score"]), method="min"
+        cv_results[f"rank_test_{metric}"] = rankdata(
+            -np.array(cv_results[f"mean_test_{metric}"]), method="min"
         ).astype(int)
 
+        if return_train_score:
+
+            for split in range(n_splits):
+                cv_results[f"split{split}_train_{metric}"] = [
+                    cv_scores[split]
+                    for cv_scores in logbook.chapters["parameters"].select(
+                        f"train_{metric}"
+                    )
+                ]
+
+            cv_results[f"mean_train_{metric}"] = [
+                np.nanmean(cv_scores)
+                for cv_scores in logbook.chapters["parameters"].select(
+                    f"train_{metric}"
+                )
+            ]
+
+            cv_results[f"std_train_{metric}"] = [
+                np.nanstd(cv_scores)
+                for cv_scores in logbook.chapters["parameters"].select(
+                    f"train_{metric}"
+                )
+            ]
+
+            cv_results[f"rank_train_{metric}"] = rankdata(
+                -np.array(cv_results[f"mean_train_{metric}"]), method="min"
+            ).astype(int)
+
+    # These values are only one even with multi-metric
     cv_results["mean_fit_time"] = [
         np.nanmean(fit_time)
         for fit_time in logbook.chapters["parameters"].select("fit_time")


### PR DESCRIPTION
This PR implements multi-metric evaluation for both `GASearchCV` and `GAFeatureSelectionCV`.

You will see this reflected on the `logbook` and `cv_results_` objects, where now you get results for each metric.
As in scikit-learn, if multi-metric is used, the `refit` parameter must be a string specifying the metric to evaluate the cv-scores.
See more in the `GASearchCV` and `GAFeatureSelectionCV` API documentation.

This implements the required feature in issue #63 
