### PR TITLE
Add random_state in Space definition

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,7 +96,6 @@ Example: Hyperparameters Tuning
    from sklearn.model_selection import train_test_split, StratifiedKFold
    from sklearn.datasets import load_digits
    from sklearn.metrics import accuracy_score
-   import matplotlib.pyplot as plt
 
    data = load_digits()
    n_samples = len(data.images)

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -24,6 +24,12 @@ Features:
 * The `weighted_choice` function used in :class:`~sklearn_genetic.GAFeatureSelectionCV` was
   re-written to give more probability to a number of features closer to the `max_features` parameter
 
+* Add `random_state` parameter (default= ``None``) in :class:`~sklearn_genetic.space.Continuous`,
+  :class:`~sklearn_genetic.space.Categorical` and :class:`~sklearn_genetic.space.Integer` classes
+  to leave fixed the random seed during hyperparameters sampling.
+  Take into account that this only ensures that the space components are reproducible, not all the package.
+  This is due to the DEAP dependency, which doesn't seem to have a native way to set the random seed.
+
 What's new in 0.8.1
 -------------------
 

--- a/sklearn_genetic/algorithms.py
+++ b/sklearn_genetic/algorithms.py
@@ -3,7 +3,6 @@ from deap import tools
 from deap.algorithms import varAnd, varOr
 
 from .callbacks.validations import eval_callbacks
-from .schedules.base import BaseAdapter
 
 
 def eaSimple(

--- a/sklearn_genetic/space/space.py
+++ b/sklearn_genetic/space/space.py
@@ -13,7 +13,7 @@ class Integer(BaseDimension):
     """class for hyperparameters search space of integer values"""
 
     def __init__(
-        self, lower: int = None, upper: int = None, distribution: str = "uniform"
+        self, lower: int = None, upper: int = None, distribution: str = "uniform", random_state=None
     ):
         """
         Parameters
@@ -26,7 +26,8 @@ class Integer(BaseDimension):
 
         distribution : str, default="uniform"
             Distribution to sample initial population and mutation values, currently only supports 'uniform'.
-
+        random_state : int or None, RandomState instance, default=None
+            Pseudo random number generator state used for random dimension sampling.
         """
 
         if not isinstance(lower, int):
@@ -46,6 +47,8 @@ class Integer(BaseDimension):
         self.lower = lower
         self.upper = upper
         self.distribution = distribution
+        self.random_state = random_state
+        self.rng = None if not self.random_state else np.random.default_rng(self.random_state)
 
         if self.distribution == IntegerDistributions.uniform.value:
             self.rvs = stats.randint.rvs
@@ -53,14 +56,14 @@ class Integer(BaseDimension):
     def sample(self):
         """Sample a random value from the assigned distribution"""
 
-        return self.rvs(self.lower, self.upper + 1)
+        return self.rvs(self.lower, self.upper + 1, random_state=self.rng)
 
 
 class Continuous(BaseDimension):
     """class for hyperparameters search space of real values"""
 
     def __init__(
-        self, lower: float = None, upper: float = None, distribution: str = "uniform"
+        self, lower: float = None, upper: float = None, distribution: str = "uniform", random_state=None
     ):
         """
         Parameters
@@ -73,7 +76,8 @@ class Continuous(BaseDimension):
 
         distribution : {'uniform', 'log-uniform'}, default='uniform'
             Distribution to sample initial population and mutation values.
-
+        random_state : int or None, RandomState instance, default=None
+            Pseudo random number generator state used for random dimension sampling.
         """
 
         if not isinstance(lower, (int, float)):
@@ -94,6 +98,8 @@ class Continuous(BaseDimension):
         self.upper = upper
         self.distribution = distribution
         self.shifted_upper = self.upper
+        self.random_state = random_state
+        self.rng = None if not self.random_state else np.random.default_rng(self.random_state)
 
         if self.distribution == ContinuousDistributions.uniform.value:
             self.rvs = stats.uniform.rvs
@@ -104,14 +110,14 @@ class Continuous(BaseDimension):
     def sample(self):
         """Sample a random value from the assigned distribution"""
 
-        return self.rvs(self.lower, self.shifted_upper)
+        return self.rvs(self.lower, self.shifted_upper, random_state=self.rng)
 
 
 class Categorical(BaseDimension):
     """class for hyperparameters search space of categorical values"""
 
     def __init__(
-        self, choices: list = None, priors: list = None, distribution: str = "choice"
+        self, choices: list = None, priors: list = None, distribution: str = "choice", random_state=None
     ):
         """
         Parameters
@@ -124,7 +130,8 @@ class Categorical(BaseDimension):
 
         distribution: str, default='choice'
             Distribution to sample initial population and mutation values, currently only supports "choice".
-
+        random_state : int or None, RandomState instance, default=None
+            Pseudo random number generator state used for random dimension sampling.
         """
 
         if not choices or not isinstance(choices, list):
@@ -148,9 +155,11 @@ class Categorical(BaseDimension):
 
         self.choices = choices
         self.distribution = distribution
+        self.random_state = random_state
+        self.rng = None if not self.random_state else np.random.default_rng(self.random_state)
 
         if self.distribution == CategoricalDistributions.choice.value:
-            self.rvs = np.random.choice
+            self.rvs = self.rng.choice if self.rng else np.random.choice
 
     def sample(self):
         """Sample a random value from the assigned distribution"""


### PR DESCRIPTION
Add random_state parameter (default=None) in `Continuous`, `Categorical`, and `Integer` classes from the space definition to leave fixed the random seed during hyperparameters sampling. Take into account that this only ensures that the space components are reproducible, not all the package. This is due to the DEAP dependency, which doesn’t seem to have a native way to set the random seed.

This is due to the request for the issue #94 