### PR TITLE
Add the support to pass parameters needed by the estimator during fitting

### DIFF
--- a/sklearn_genetic/genetic_search.py
+++ b/sklearn_genetic/genetic_search.py
@@ -565,7 +565,7 @@ class GASearchCV(BaseSearchCV):
             self.estimator.set_params(**self.best_params_)
 
             refit_start_time = time.time()
-            self.estimator.fit(self.X_, self.y_, fit_params)
+            self.estimator.fit(self.X_, self.y_, **fit_params)
             refit_end_time = time.time()
             self.refit_time_ = refit_end_time - refit_start_time
 


### PR DESCRIPTION
Hi, 

First of all, thanks for this great library! While trying to use it, I noticed that the `fit` methods of both `GASearchCV` and `GAFeatureSelectionCV` don't accept `fit_params` that may be needed by the estimator. I have updated the methods to accept this parameters so that users can pass parameters need for fitting the estimator.