### PR TITLE
GAFeatureSelectionCV as a scikit-learn FeatureSelection algorithm

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -174,13 +174,15 @@ Example: Feature Selection
     evolved_estimator.fit(X_train, y_train)
 
     # Features selected by the algorithm
-    features = evolved_estimator.best_features_
+    features = evolved_estimator.support_
     print(features)
 
     # Predict only with the subset of selected features
-    y_predict_ga = evolved_estimator.predict(X_test[:, features])
+    y_predict_ga = evolved_estimator.predict(X_test)
     print(accuracy_score(y_test, y_predict_ga))
 
+    # Transform the original data to the selected features
+    X_reduced = evolved_estimator.transform(X_test)
 
 Changelog
 #########

--- a/docs/api/gafeatureselectioncv.rst
+++ b/docs/api/gafeatureselectioncv.rst
@@ -1,6 +1,6 @@
 
-FeatureSelectionCV
-------------------
+GAFeatureSelectionCV
+--------------------
 
 .. currentmodule:: sklearn_genetic
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -94,7 +94,7 @@ as it is usually advised to look further which distribution works better for you
    :caption: API Reference:
 
    api/gasearchcv
-   api/featureselectioncv
+   api/gafeatureselectioncv
    api/callbacks
    api/schedules
    api/plots

--- a/docs/notebooks/Iris_feature_selection.ipynb
+++ b/docs/notebooks/Iris_feature_selection.ipynb
@@ -2,51 +2,49 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "# Iris Feature Selection"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "is_executing": true
+    }
+   },
    "outputs": [],
    "source": [
     "import matplotlib.pyplot as plt\n",
     "from sklearn_genetic import GAFeatureSelectionCV\n",
     "from sklearn_genetic.plots import plot_fitness_evolution\n",
-    "from sklearn.model_selection import train_test_split, StratifiedKFold\n",
+    "from sklearn.model_selection import train_test_split\n",
     "from sklearn.svm import SVC\n",
     "from sklearn.datasets import load_iris\n",
     "from sklearn.metrics import accuracy_score\n",
     "import numpy as np\n"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "### Import the data and split it in train and test sets\n",
     "Random noise is added to simulate useless variables\n"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
+   "metadata": {},
    "outputs": [
     {
      "data": {
-      "text/plain": "(150, 14)"
+      "text/plain": [
+       "(150, 14)"
+      ]
      },
      "execution_count": 2,
      "metadata": {},
@@ -61,49 +59,35 @@
     "\n",
     "X = np.hstack((X, noise))\n",
     "X.shape"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "### Split the training and test data"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
+   "metadata": {},
    "outputs": [],
    "source": [
     "X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.33, random_state=0)"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "### Define the GAFeatureSelectionCV options\n"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
+   "metadata": {},
    "outputs": [],
    "source": [
     "clf = SVC(gamma='auto')\n",
@@ -119,142 +103,199 @@
     "    keep_top_k=2,\n",
     "    elitism=True,\n",
     ")"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "### Fit the model and see some results"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INSTANCE\n",
-      "True\n",
       "gen\tnevals\tfitness \tfitness_std\tfitness_max\tfitness_min\n",
-      "0  \t30    \t0.558444\t0.155441   \t0.893333   \t0.253333   \n",
-      "1  \t54    \t0.659333\t0.132948   \t0.893333   \t0.333333   \n",
-      "2  \t54    \t0.742667\t0.0867111  \t0.893333   \t0.586667   \n",
-      "3  \t55    \t0.805778\t0.0740117  \t0.893333   \t0.653333   \n",
-      "4  \t52    \t0.873333\t0.0435125  \t0.906667   \t0.746667   \n",
-      "5  \t53    \t0.896222\t0.00659592 \t0.913333   \t0.893333   \n",
-      "6  \t55    \t0.901111\t0.0131186  \t0.953333   \t0.893333   \n",
-      "7  \t54    \t0.911778\t0.0206332  \t0.953333   \t0.893333   \n",
-      "8  \t50    \t0.926444\t0.0210455  \t0.953333   \t0.893333   \n",
-      "9  \t51    \t0.941333\t0.020177   \t0.966667   \t0.913333   \n",
-      "10 \t49    \t0.955556\t0.00978787 \t0.966667   \t0.913333   \n",
-      "11 \t55    \t0.959111\t0.00660714 \t0.966667   \t0.953333   \n",
-      "12 \t57    \t0.965333\t0.004      \t0.966667   \t0.953333   \n",
-      "13 \t55    \t0.966444\t0.00271257 \t0.973333   \t0.953333   \n",
-      "14 \t58    \t0.966667\t6.66134e-16\t0.966667   \t0.966667   \n",
-      "15 \t53    \t0.966889\t0.0011967  \t0.973333   \t0.966667   \n",
-      "16 \t56    \t0.967556\t0.00226623 \t0.973333   \t0.966667   \n",
-      "17 \t53    \t0.969556\t0.00330357 \t0.973333   \t0.966667   \n",
-      "18 \t51    \t0.971111\t0.0031427  \t0.973333   \t0.966667   \n",
-      "19 \t58    \t0.972889\t0.00166296 \t0.973333   \t0.966667   \n",
-      "20 \t54    \t0.973333\t3.33067e-16\t0.973333   \t0.973333   \n"
+      "0  \t30    \t0.550444\t0.153446   \t0.86       \t0.293333   \n",
+      "1  \t60    \t0.636889\t0.119365   \t0.86       \t0.473333   \n",
+      "2  \t60    \t0.698667\t0.11242    \t0.873333   \t0.46       \n",
+      "3  \t60    \t0.707556\t0.103876   \t0.873333   \t0.486667   \n",
+      "4  \t60    \t0.723556\t0.144086   \t0.9        \t0.366667   \n",
+      "5  \t60    \t0.745556\t0.152637   \t0.913333   \t0.366667   \n",
+      "6  \t60    \t0.792889\t0.108402   \t0.873333   \t0.513333   \n",
+      "7  \t60    \t0.749111\t0.16456    \t0.873333   \t0.413333   \n",
+      "8  \t60    \t0.728889\t0.179747   \t0.966667   \t0.373333   \n",
+      "9  \t60    \t0.728222\t0.158994   \t0.893333   \t0.42       \n",
+      "10 \t60    \t0.785556\t0.134892   \t0.94       \t0.48       \n",
+      "11 \t60    \t0.733556\t0.175942   \t0.94       \t0.44       \n",
+      "12 \t60    \t0.784889\t0.150554   \t0.94       \t0.413333   \n",
+      "13 \t60    \t0.818444\t0.148101   \t0.966667   \t0.413333   \n",
+      "14 \t60    \t0.871778\t0.116272   \t0.966667   \t0.453333   \n",
+      "15 \t60    \t0.801556\t0.184163   \t0.966667   \t0.386667   \n",
+      "16 \t60    \t0.810222\t0.163994   \t0.966667   \t0.393333   \n",
+      "17 \t60    \t0.814222\t0.148949   \t0.966667   \t0.44       \n",
+      "18 \t60    \t0.72    \t0.182525   \t0.966667   \t0.366667   \n",
+      "19 \t60    \t0.783556\t0.156269   \t0.966667   \t0.42       \n",
+      "20 \t60    \t0.803778\t0.146694   \t0.966667   \t0.486667   \n"
      ]
     }
    ],
    "source": [
     "evolved_estimator.fit(X, y)\n",
-    "features = evolved_estimator.best_features_\n",
+    "features = evolved_estimator.support_\n",
     "\n",
     "# Predict only with the subset of selected features\n",
-    "y_predict_ga = evolved_estimator.predict(X_test[:, features])\n",
+    "y_predict_ga = evolved_estimator.predict(X_test)\n",
     "accuracy = accuracy_score(y_test, y_predict_ga)"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[ True  True  True  True False False False False False False False False\n",
+      "[False False  True  True False False False False False False False False\n",
       " False False]\n",
-      "accuracy score:  0.98\n"
+      "accuracy score:  0.96\n"
      ]
     }
    ],
    "source": [
-    "print(evolved_estimator.best_features_)\n",
+    "#Best features found\n",
+    "print(evolved_estimator.support_)\n",
     "print(\"accuracy score: \", \"{:.2f}\".format(accuracy))"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 7,
+   "metadata": {},
    "outputs": [
     {
      "data": {
-      "text/plain": "<Figure size 720x720 with 1 Axes>",
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAmMAAAJdCAYAAAB+uHCgAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/MnkTPAAAACXBIWXMAAAsTAAALEwEAmpwYAABWFUlEQVR4nO3dd3xUVf7/8fdMeg+EJPTekaaggK6ICIhS7OKq6FrXtayoq9hWxLLKuquurH5FV92fYmWxgLuI4uoqoKIgIAYCJISSkJ5MeiYz5/dHYCS0UDJzp7yej0cezNw75XNyk8ybc84912aMMQIAAIAl7FYXAAAAEMoIYwAAABYijAEAAFiIMAYAAGAhwhgAAICFCGMAAAAWIowBLaRPnz6aPHmypk6d6vm6//77JUlTp06Vw+FQRUWFpk+fbnGl2Llzp4YOHdrs47744gs9++yzkqRly5bp0Ucf9XZpIWPu3Ln67LPPJEnPPvusPvjgA2sLAiwUbnUBQDD55z//qdatWx+w/cMPP5TUGALWr1/v67JwjNavX6/y8nJJ0tixYzV27FiLKwoe3377rXr27ClJ+v3vf29xNYC1CGOAD/Tp00crV67Uvffeq9raWk2dOlULFy7UkCFDdMMNN2j58uUqKCjQ9OnTdfXVV0uS3nvvPb311ltyu91KTk7Wgw8+qB49euj777/XE088IbfbLUm68cYbNWHChENu35fb7dbjjz+utWvXqqqqSsYYPfroo+rdu7dGjx6tTz75RKmpqZKkSy65RDfffLNGjhypp556SqtWrZLL5VL//v31wAMPKD4+XmeeeaYGDRqkTZs26Y477lB4eLhefPFF1dfXq6SkROedd55uv/12SdK8efO0YMECxcXFadiwYVq2bJk+//xz1dfXH/L19/fCCy9o6dKlcrvd6tChgx566CFVV1dr2rRp+uqrrxQZGSmXy6UxY8bolVdeUXx8vGbNmqVdu3bJGKPzzjtP1113XZPXfO6551RaWqo//vGPTe5PnTpVb7/9tlwulxISEtSlSxd98sknevHFF7V79+6Dvu7OnTt19dVXa/To0Vq7dq3Ky8s1Y8YMnXPOOQe05bPPPtPcuXPlcrkUHx+ve++9VyeccILGjBmjuXPnauDAgZKkGTNmaPjw4fr1r3990Panp6fryiuvVFJSkrKysnTZZZfpyiuv9LyPy+XSnDlz9PnnnyshIUGDBg3S1q1b9frrr6uiokKPPfaYMjMz5XQ6NXLkSN19990KDw/XwIEDj/pnc+bMmSorK9OOHTt0xhln6KKLLtLs2bNVXV2tgoIC9e3bV88884wWLFign376SXPmzFFYWJiWLVumXr166dprr9X333+vOXPmqKamRhEREbr99tt1+umna+HChfr0009lt9uVk5OjiIgIPfnkk+rdu7eWLl2qF154QTabTWFhYbr77rs1fPjwo/kVBaxlALSI3r17m0mTJpkpU6Z4voqKijz7iouLzY4dO8yQIUOaPOf11183xhizfv16c8IJJ5ja2lrz7bffml//+temurraGGPMV199ZSZOnGiMMWb69Olm8eLFxhhjMjIyzKxZsw67fV+rV682t956q3G5XMYYY1588UVz4403GmOMufvuu83LL79sjDFmy5Yt5owzzjAul8s899xz5oknnjBut9sYY8xf/vIX89BDDxljjBkzZoyZO3euMcYYt9ttrrjiCpOdnW2MMWb37t2mX79+pri42Pzvf/8zEyZMMOXl5cbtdpt7773XjBkzxhhjDvv6+3r//ffN7bffbpxOpzHGmLfffttcd911xhhjLr/8cvOf//zHGGPMF198YaZNm+bZ/sorrxhjjHE4HGby5Mlm8eLFTY7D3/72N/Pwww973mff+/ve/te//mVuuOGGZl+3d+/e5vPPPzfGGLNkyRJzxhlnHNCWLVu2mFGjRpnt27cbY4xZsWKFOfXUU01FRYV59tlnPe9ZVlZmTj75ZONwOA7b/iuuuMLce++9B7yPMca89dZb5vLLLze1tbWmrq7OXHPNNeaKK64wxhgzc+ZM8//+3/8zxhjT0NBg7rrrLjNv3jxjzLH9bN5zzz3mqquu8rz3E088YT744ANjjDH19fVm0qRJZsmSJZ6a9x6ze+65x7z88sumpKTEjBw50vz444/GGGMyMzPNySefbLZv327+9a9/mZNOOsnk5eUZY4yZPXu2ufvuu40xxowdO9asWbPGU89zzz130O8F4K/oGQNa0KGGKQ9n79DXgAEDVF9fr+rqan3xxRfKycnRtGnTPI8rLy9XWVmZJk6cqNmzZ+vzzz/XqFGjdMcdd0jSIbfva+jQoUpKStLbb7+tHTt26Ntvv1VcXJwk6eKLL9bDDz+sa6+9Vv/61790wQUXyG6364svvlBFRYVWrFghSXI6nUpJSfG85rBhwyRJNptN//d//6cvvvhCixcv1tatW2WMUU1Njb788kudffbZSkxMlCRdfvnl+uabbySp2dff67///a/Wr1+vCy+8UFJjL19NTY2n9vfff19nn322Fi5cqIsvvljV1dVavXq1XnnlFUlSQkKCLrjgAv3vf//T4MGDj+oY7au5142IiNDo0aMlSf3791dZWdkBr/HNN99oxIgR6tSpkyRp5MiRat26tX766SddeOGFuuiiizRz5kwtXrxYY8aMUUJCwmHbv+9x2N+XX36pqVOnKioqSpJ06aWX6vXXX5fU+L1fv369FixYIEmqra1t8tyj/dmUpJNOOsmz/Q9/+IOWL1+ul156Sdu2bVNBQYGqq6sP+b1dt26dOnfu7Dk+vXr10oknnqjvvvtONptNAwYMUNu2bT3f208//VSSdO655+qWW27R6NGjdeqpp+r6668/5HsA/ogwBlhs74ekzWaTJBlj5Ha7NXXqVP3hD3+Q1PjBW1BQoKSkJE2bNk1jxozR8uXL9dVXX2nu3Ln66KOPDrk9ISHB815ffPGFHnvsMf3mN7/R2LFj1b17d3300UeSGj/MGxoatG7dOi1evFhvv/22573vu+8+T8CoqqpSXV2d5zVjY2MlNYaU888/X2eddZaGDRumCy+8UJ999pmMMQoPD5fZ5zK4YWFhntvNvf6+j7vuuuv061//WpJUX1/vmc919tln609/+pO2bt2qVatW6YknnpDL5Wrynntfo6Ghock2m83W5HFOp/Nwh0tut/uwrxsRESG73e557YPZ//l7tzU0NKhDhw7q37+/vvjiCy1cuFD33Xdfs+2XfjkO+wsPb/pnfm9te1/z2WefVY8ePSRJDoejSc1H+7O5fx133HGHXC6XJk6cqDPOOEN5eXkHbfu+9Rzq+xIREaHo6GjP9n2P24wZM3TRRRfp66+/1sKFCzVv3jwtXLiwSVsBf8ZPKuBD4eHhBw0J+zv11FP18ccfq6CgQJL01ltv6aqrrpIkTZs2TRkZGbrgggv0yCOPyOFwqLy8/JDb97V8+XKNGTNGv/71rzVw4EB99tlncrlcnv0XX3yxHnnkEfXp00ft27eXJJ122mmaP3++6uvr5Xa79eCDD+qvf/3rATXn5OSosrJSt99+u84880x99913nueMHj1aS5cuVUVFhSR5emKO5vVPO+00LViwQJWVlZIaz8C7++67JTWGhnPPPVczZ87U+PHjFRMTo/j4eA0ePFjz58+XJFVUVOiDDz7QqFGjmrxuq1attGHDBhljVF1dra+//tqzLyws7IDwdqSvezgjRozQ8uXLtWPHDknSypUrlZeX5+kRuuSSS/TSSy+ptrbW09N0uPYfzujRo/XRRx+pvr5eDQ0Nev/99z37TjvtNL322msyxqi+vl433XST3njjjcO+3uF+Nvf39ddf6+abb9Y555wjm82mtWvXen7eDva9HTx4sLKzs7Vu3TpJ0ubNm7Vq1SqdfPLJh6ynoaFBZ555pqqrq3XZZZfpoYce0tatWw94bcCf0TMG+FBqaqr69++viRMn6q233jrk4371q1/p+uuv1zXXXCObzab4+HjNnTtXNptNd911lx5//HE988wzstvtuuWWW9SxY8dDbt/XtGnTdNddd2ny5MkKCwvTsGHDPBPC7Xa7zjvvPP31r39tEoZ+97vf6cknn9T5558vl8ulfv36aebMmQfU3KdPH51xxhmaOHGiEhMT1blzZ/Xs2VM5OTn61a9+pUsuuUSXXnqpoqOj1atXL8XExBzV61988cXKz8/XJZdcIpvNpnbt2umJJ55osv+NN97QrFmzPNueeuopzZ49WwsXLlR9fb0mT56sCy64QLt27fI8ZsqUKfrqq680fvx4paena+jQoZ6wPHLkSN16662KiIjQgAEDjup1D6dnz5566KGHdMstt8jlcik6Olr/93//5+nFPPPMM/Xwww83GW5rrv2HcsEFFyg7O1vnnXeeYmNj1bFjR8/3/v7779djjz2myZMny+l0atSoUQec4LC/w/1s7m/GjBm6+eablZSUpJiYGA0fPlzbt2+XJI0ZM0ZPPvlkk57I1q1b69lnn9Ujjzyi2tpa2Ww2/elPf1K3bt20Zs2ag9YTHh6u++67T3fddZfCw8Nls9n0+OOPKzIystnvDeAvbKa5/6IDwHFav3691qxZ41lj7dVXX9XatWv1zDPPWFtYCPj6669VXFysqVOnSpIeffRRRUVFeYYZAViPMAbA6yorK3XfffcpKyvL06vzyCOPKD093erSgl5+fr5mzpyp4uJiuVwu9e3bV7NmzWoylxCAtQhjAAAAFmICPwAAgIUIYwAAABYijAEAAFiIMAYAAGChgF5nrLS0Sm63d88/SEmJV3FxpVffw1/R9tBsuxTa7Q/ltkuh3X7aHpptl7zffrvdplat4g65P6DDmNttvB7G9r5PqKLtoSuU2x/KbZdCu/20PXRZ2X6GKQEAACxEGAMAALAQYQwAAMBChDEAAAALEcYAAAAsRBgDAACwEGEMAADAQoQxAAAACxHGAAAALEQYAwAAsBBhDAAAwEKEMQAAAAsRxgAAACxEGAMAALAQYQwAAMBChDEAAAALEcYAAAAsRBgDAACwEGEMAADAQoQxAAAAC4VbXQAAAMDRchsjl8uoweWWy20av1xuNez51+Vq3Nbg3nN7z+MaXEYu997bjf+OGd7F0rYQxgAAgE85G1yqqHbu+aqXo7peFdVOz7+Ve25X1jjV4HI3Bqj9wpQxLVePSzadMahdy73gUSKMAQCA4+JscKtiT5Cq2C9Y7bt977baetdBXyfMblNCbIQSYiOVGBuhNknRigi3KzzMrjC7TWF2u8LCbAoP23PbbvtlX9g+t/fbHhZmV/g+z2/cbld4mE3hdrv69GijoqJKH3/XfkEYAwAAkiRjjOqdblXVOlVZ0/hVVdvwy+09X5U1TlXWOlVR5VRFTb1q6g4druJjI5QYG6mE2Ah1T05qErYS9mzfuz8mKlw2m83HrZYl77kvwhgAAEGoweVuDE61DZ4AVbUnRDXe/mV7XYNbZRW1qqxpUIPLfcjXjIywKz4mQvHREYqLiVC39jFKiIloDFhxkUqIiVRi3C8hK9aicBVoCGMAAASIBpdbjqp6lVXWq7yqTuVV9XJU1qu8au9XncorG+daHWooUGrssYqLidgTrMLVNiVWHVPjGu/HRCguOnyf2xF7HhuuiPAwH7Y2dBDGAACwkNsYVdY49wlVjSGrvLJejqp9glZlnapqGw76GvExEUqKi1RiXKR6dkhSfGxEkzC1b8iKi4lQdGRYkx6r1NQEFRZW+KrJ2A9hDACAI+R2Gzldbjkb9nztud2w936Dq+n+fR7jbHCrzun6JWDt6d1yVDnlPsipgZERdiXHRSkxPlLtUmLVt3OykuIilRQfpcS4yMbbewJYeBjLhgYywhgA4IgZY1Tf4FZtXYNq612qc7rkNkZud+O+xttGxjT2+Oz9d99tbreRUWOwaXxM4/M9t432PL7x9r6v67nvbrrP7Hm+57aMzJ7Xdxt5bh+uHnuYXdXV9QcNW3u/XO7jW0/BbrMpMS5CSXFRSoqPVKf0eE+oSoqPahKw9u+9QvAijAFAkHMbo7p6l2rrXaqtbwxRe8NUzd779S7V1DXIFmZXaXmNaut+eWzNnufV7NnWkus7HQ+bJLvdJpvNJrtNstltsu+9bbPt2aeDbGu8b7fbZJNNdnvjY6KiwmW32xQfGamIcHvjV5j9l9v73A8/7P4wRYTbFRm+z2P3PC5sz/sD+yKMAUCQMMZoV1GV1m8t1rqtxSooq1FNXYPq6l06kvxks0mxUeGKigxTdGS4YiLDFB0ZpuT4KEVH7dm259/oyDDFRIYrMsIu+94Q1CT87Llt33v7l9DTJAztve15TNPg5Lm95/m2fV67pUMN86ZgFcIYAASwOqdLG3NKtW5PACt21EqSOqXFa0DX1ocMUdGRYYqJavw3OjJM0VHhigy3Ky0tkUAC+BhhDAACTFFZjdbuCV8bt5fK2eBWVESY+ndtpUmjumhg9xS1Toy2ukwAR4gwBgB+rsHl1pad5Y29X1nFyi2qkiSlJcdo9OD2GtQzRX06tVJEOGfUAYGIMAYAfshRVa/1WcVau7VYG7JLVFPXoDC7Tb07Jev0Qe00qGcbtW0da3WZAFoAYQwA/IDbGOXsrtgz96tI2/IqZCQlxUdqWJ9UDerRRv27tlJMFH+2gWDDbzUAWKS6tkE/byvxDD86quplk9S9faKm/qqbBvdoo07p8bKzFAIQ1AhjAOADxhiVVtQpt6hKOwoqtT6rWJt3lsvlNoqNCtcJ3VtrUI8UndA9RYmxkVaXC8CHCGMA0II8oau4SrmFVdpVVNV4u6haNXW/XFewQ2qcxp/cSYN7tFGPDokKszP5HghVhDEAOAbGGJVV1mtXUaVyCxsD166iA0NXfEyEOrSJ04gB6erQJk7tU+LUPjWO3i8AHoQxADiMvaErt2hv2KpsNnS1T4lrDF6ELgBHgDAGAHs4G9z6MbNAG7YUKbeoyhPA9g9d7dvEaUT/dLVvsyd0tYlTYhyhC8CxIYwBgKStueV65eMM5RVXSzowdO0NXoQuAC2NMAYgpDkbXPrgq2wt+W67WiVEaeZVw9U2MUoJsREtfiFqADgYwhiAkJWV69A/Pv5ZecXVOn1wO10yppe6dGrFhbIB+BRhDEDIcTa49OHX2/Sfb3OUHB+lOy4ZrBO6p1hdFoAQRRgDEFKy8xz6x8cZyi2q0q8GtdOlZ/ZSbDR/CgFYh79AAEKCs8GtD7/O9vSGzbhksAbSGwbADxDGAAS9fXvDThvUTtPoDQPgR/hrBCBoORvc+mh5tv7zzXYlxUfq9osHa1APesMA+BfCGICglJ3n0CsfZ2hXUZVOG9hO08b2VGx0hNVlAcABCGMAgsqBvWGDNKhHG6vLAoBDIowBCBrbdjfODdtVSG8YgMBBGAMQ8JwNbi1aka1/r9yuxLgIesMABBTCGICAlrO7Qi9//LN2FVbp1BPaatpZvRRHbxiAAEIYAxCQGlxufbR8m/69MkeJcRH6/UWDNLgnvWEAAg9hDEDAydldoX98/LN20hsGIAgQxgAEjAaXW4uWb9PHK3OUEBeh2y4apCH0hgEIcIQxAAGhsTcsQzsLKzXqhLa6jN4wAEGCMAbAr7ndRv/5NkcffJWt+NgI3XbhIA3pRW8YgOBBGAPgtwrLavTy4p+1eWe5hvdN05UT+ig+ht4wAMGFMAbA7xhjtHz9br35WaZsNun6Sf01YkC6bDab1aUBQIsjjAHwKxXV9fp/Szbph8xC9emUrGsn9VObpBirywIAryGMAfAb67OK9crHGaqsceriMT00YXhn2e30hgEIboQxAJarc7r03n+36PPVu9ShTZxmXDJYndMTrC4LAHyCMAbAUtt2OzTvo5+1u6Ra44d30oWjuysiPMzqsgDAZwhjACzhcrv172+266Ovs5UYF6k/TBuifl1bW10WAPgcYQyAzxWU1ejlRT9ry65yndI/XVeM780CrgBCFmEMgM8YY/T1ujy9uWyz7DabbpjcXyMGtLW6LACwFGEMgE84quv1z/9s1JrNRerbOVnXnttfKUnRVpcFAJYjjAHwunVbi/TKvzequtapS8b01PiTO8nOAq4AIIkwBsCL6pwuvfv5Fv13zS51TI3TXZcOUce0eKvLAgC/QhgD4BXZeQ7NW/SzCkqqdfbJnXX+6d0VEW63uiwA8DuEMQAtyuV26+OVOVq0fJuS4iP1h8uGqm+XVlaXBQB+izAGoMUUlFbrpcU/a+suh0YMSNcV43orliUrAOCwCGMAjpsxRl+ty9Nbn21WmN2m304doJP7pVtdFgAEBMIYgOPiqKrXP5c0LlnRr0srXXtuP7VOZMkKADhShDEAx2xNZqFeW7JRNXUuTTuzp84azpIVAHC0CGMAjlp1bYPeWpap5et3q3N6vO6+rL86pLJkBQAcC8IYgKOyMadU//j4Z5VW1GvyqK6afGpXhYexZAUAHCvCGIAj4mxw6V9fZmnpqh1KbxWje688UT3aJ1ldFgAEPMIYgGZt2+3Qy4szlFtUpTNP7KCLz+ipqMgwq8sCgKBAGANwSPsu4JoYF6k7Lh2sE7qlWF0WAAQVwhiAg8orrtLLizOUnefQiP7punx8b8WxgCsAtDjCGIAm3MZo8ddZenXRBkWE21nAFQC8jDAGwKPEUatX/p2hn7eVamD3FP3mnL5Kjo+yuiwACGqEMQAyxuibn/P1xtJMud1GN180WCf2aC0bC7gCgNcRxoAQV1Fdr9c/2aTvNxWqZ4ckXTepnwb0TldhYYXVpQFASCCMASFs7ZYivfafjaqsceqiM3ro7JM7y26nNwwAfIkwBoSgmroGvfP5Fv1vba46psZpxiWD1Tk9weqyACAkEcaAEJO5o0wvL/5ZxeW1mjiis847rbsiwrmcEQBYhTAGhAhng1sffJWlJd9uV0pStO65/ET17pRsdVkAEPIIY0AI2J5foZcX/6ydhVUaPaS9LhnTUzFR/PoDgD/grzEQxNxuo/98m6MPvspWXEyEfn/RIA3u2cbqsgAA+yCMAUHIbYxWbyrUh8uztauwSsP6pOrKCX2UEBtpdWkAgP0QxoAgsn8Ia5cSq9+dd4JO6pPKAq4A4KcIY0AQOFgIu2FKf53cN511wwDAzxHGgAC2N4R9tDxbOwlhABCQCGNAANo/hLVtHasbJvfXyf0IYQAQaAhjQABxG6M1mYX68Ott2llYSQgDgCBAGAMCwP4hLL11rK6f3F+nEMIAIOARxgA/1hjCivTR8mztKCCEAUAwIowBfuiAENYqRtdP6q+T+6cpzM51JAEgmBDGAD9CCAOA0EMYA/yAMUZrNhfpo6+ztX1PCLtuUj+d0j+dEAYAQc6rYWzRokV64YUX5HQ6dfXVV+vyyy9vsv/LL7/UU089JUnq3bu3Zs+erbi4OG+WBPiV/UNYGiEMAEKO18JYfn6+nn76aS1cuFCRkZGaNm2aTjnlFPXs2VOS5HA4NHPmTL3++uvq2bOnXnrpJT399NN64IEHvFUS4DfKq+qVkVOiJd9s94Swa8/tpxEDCGEAEGq8FsZWrFihESNGKDk5WZI0YcIELVmyRLfccoskadu2bWrfvr0nnI0ZM0bXXXcdYQxBx22McouqtGVnuTbvLNfWXeUqKKuRJEIYAMB7YaygoECpqame+2lpaVq3bp3nfteuXbV7925t3LhRffv21X/+8x8VFRV5qxzAZ+rqXcrKc2jLrnJt2RO+qusaJEmJsRHq2TFZZwztoJ4dk9StXQIhDABCnNfCmDHmgG022y/rIiUmJurJJ5/Ugw8+KLfbrUsuuUQRERFH9R4pKfHHXeeRSE1N8Mn7+CPa3rzi8hr9nF2ijdtK9PO2EmXtKpfb3fjz37ltgn41tIP6dW2tft1aq11KXJPfA3/GsQ9dodx+2h66rGy/18JYenq6vv/+e8/9goICpaWlee67XC61bdtW7733niRpw4YN6tSp01G9R3FxpedDz1tSUxNUWFjh1ffwV7T9wLa73UY7Cys9vV6bd5ar2FErSYoMt6tbu0RNPKWzenVMUo8OSYqL3uc/GMaoqKjSV004Lhz70Gy7FNrtp+2h2XbJ++23222H7UDyWhgbNWqUnnvuOZWUlCgmJkZLly7VI4884tlvs9l0zTXX6L333lNaWppeeeUVnXPOOd4qBzgmNXUNjUOOO8u1ZWeZtuY6VFvvkiQlxUeqV4ckjRveSb06JqlTWrzCwxhyBAAcHa/2jM2YMUPTp0+X0+nURRddpEGDBun666/XbbfdpoEDB2r27Nm67rrrVF9fr5EjR+raa6/1VjnAEXNU1ev95eu1dlOBdhRWyhjJJqlDarxGDmirnh2T1KtDklKSogNmyBEA4L9s5mCTuwIEw5TeFYptr651as6ba5RbXK1eHZPUq2OSenZMUo/2SYqJCp01kkPx2O8Vym2XQrv9tD002y4F8TAlEGjqnC49u2CddhVV6Y/XjlCnlBirSwIAhAAmuACSGlxuPf/+T9qys1w3TBmgE/umNf8kAABaAGEMIc/tNnp58c9an1Ws6Wf30XCCGADAhwhjCGnGGL3xaaa+yyjQxWf00OghHawuCQAQYghjCGkL/5elL9bs0sQRnTVxRBerywEAhCDCGELWkm+36+OVORo9pL0uGt3D6nIAACGKMIaQ9L+1uXr3v1s0vG+arhzfh/XCAACWIYwh5Hy/sUD/XLJRJ3Rvresn95fdThADAFiHMIaQsiG7RPMWbVCP9km6+byBXL4IAGA5PokQMrbsKtdzC9epbes4/f7iQYqKDLO6JAAACGMIDTsLKvXse2uVHBelOy8drLjoCKtLAgBAEmEMIaCgrEZ/eedHRYTbdde0IUqKj7K6JAAAPAhjCGqlFXV66q01anC5dee0oWqTzPUmAQD+hTCGoFVZ49Rf3/1RFTVOzbhkiDq0ibO6JAAADkAYQ1CqrW/Qs++tVX5JtW67YKC6t0+0uiQAAA6KMIag42xw6+8L1ysrz6HfTj1B/bq2trokAAAOiTCGoOJyuzVv0QZt2Faq30zspxN7p1pdEgAAh0UYQ9AwxuifSzbph02Fmja2l04b1M7qkgAAaBZhDEHBGKN3/7tFX6/L05RTu2r88E5WlwQAwBEhjCEo/PubHH3y3Q6NPbGjpp7WzepyAAA4YoQxBLz/rtmlf32ZpRED0nXZuF6y2bjwNwAgcBDGENC+/Tlfb3yySYN7pOiac/rJThADAAQYwhgC1rqtRXp58c/q1SlZN513gsLD+HEGAAQePr0QkDJ3lOn5939Sx9R43XbhIEVGhFldEgAAx4QwhoCTs7tCzy5Yq9aJ0Zpx6WDFRodbXRIAAMeMMIaAkl9Sraff/VExUeG6a9oQJcZGWl0SAADHhTCGgPLGp5lyG+nOS4eodWK01eUAAHDcCGMIGFW1Tm3MKdXpg9urXUqc1eUAANAiCGMIGOu2FMvlNlxvEgAQVAhjCBirMwuVHB+pru0SrC4FAIAWQxhDQKh3urQ+u1hDe6eysCsAIKgQxhAQNmSXqN7pZogSABB0CGMICKs3Fyo2Klx9OiVbXQoAAC2KMAa/53K7tXZLsQb3TOGSRwCAoMMnG/xe5o5yVdY4GaIEAAQlwhj83prMQkWE23VCtxSrSwEAoMURxuDXjDFas7lQA7q2VlQkFwMHAAQfwhj8Wk5+hYoddQxRAgCCFmEMfm11ZpFsNmlIrzZWlwIAgFcQxuDX1mQWqk+nZMXHRFhdCgAAXkEYg9/KL6nWrqIqDWWIEgAQxAhj8FurMwslSSf2IowBAIIXYQx+a/XmQnVJT1BKUrTVpQAA4DWEMfilsso6bd3l0Im9mbgPAAhuhDH4pTWbiySJJS0AAEGPMAa/tCazUGmtYtS+TZzVpQAA4FWEMfid6toGZeSU6sTeqbLZbFaXAwCAVxHG4HfWbS2Sy20YogQAhATCGPzO6s1FSoqLVPf2iVaXAgCA1xHG4FecDS6tzyrW0F5tZGeIEgAQAghj8CsbtpWqrt7FECUAIGQQxuBXVmcWKiYqTH27tLK6FAAAfIIwBr/hdhv9uLlIg3q0UXgYP5oAgNDAJx78xuadZaqscTJECQAIKYQx+I3VmUUKD7PrhG6trS4FAACfIYzBLxhjtGZzofp3baWYqHCrywEAwGcIY/ALOwoqVVReyxAlACDkEMbgF1ZnFspmk4b0amN1KQAA+BRhDH5hdWaRenVIUmJspNWlAADgU4QxWK6grEY7CysZogQAhCTCGCy3elOhJBHGAAAhiTAGy63eXKjOafFqkxxjdSkAAPgcYQyWKq+q19ad5RpKrxgAIEQRxmCpHzcXyoghSgBA6CKMwVKrM4uUmhytjqlxVpcCAIAlCGOwTE1dgzJySjS0V6psNpvV5QAAYAnCGCyzPqtYDS7DECUAIKQRxmCZ1ZmFSoyNUM8OSVaXAgCAZQhjsISzwa11W4s1pFcb2e0MUQIAQhdhDJbIyClVbb2LIUoAQMgjjMESqzMLFR0Zpn5dWltdCgAAliKMwefcbqMfNxdqUI8URYTzIwgACG18EsLntuaWy1Ht1NBeDFECAEAYg8+tzixUeJhNg3qkWF0KAACWI4zBp4wxWp1ZqH5dWismKtzqcgAAsBxhDD61q7BKhWW1Gtq7jdWlAADgFwhj8KnVmYWyScwXAwBgD8IYfGp1ZqF6dExSUlyk1aUAAOAXCGPwmcKyGm0vqNSJ9IoBAOBBGIPPrNlcJEk6kfliAAB4EMbgM6szC9UxNU5prWKtLgUAAL9BGINPOKrrtXlnGdeiBABgP4Qx+MTazUUyhrMoAQDYH2EMPrE6s1ApidHqnB5vdSkAAPgVwhi8rqauQRu2lerE3qmy2WxWlwMAgF8hjMHrNmSXqMHl5ixKAAAOgjAGr1udWaj4mAj16phsdSkAAPgdwhi8qsHl1tqtxRrSq43sdoYoAQDYH2EMXrUxp1Q1dQ2sug8AwCEQxuBVqzcXKSoiTAO6tbK6FAAA/BJhDF7jNkZrNhdqYPfWiggPs7ocAAD8EmEMXpOV61B5Zb2Gsuo+AACHRBiD16zJLFSY3abBPVKsLgUAAL9FGINXGGO0OrNQfbu0Umx0hNXlAADgtwhj8Ircoirll9ZwYXAAAJpBGINXrN5cJEka0pNV9wEAOBzCGLxidWaherRPVKuEKKtLAQDArxHG0OKKy2uVs7uCIUoAAI4AYQwtbvXmQkliSQsAAI4AYQwtbk1modq3iVPb1rFWlwIAgN8jjKFFVdY4lbmjXCf2ZuI+AABHgjCGFvXj5iK5jdFQLgwOAMARIYyhRa3ZXKjWiVHq2jbB6lIAAAgIhDG0mLp6l37KLtHQXqmy2WxWlwMAQEAgjKHF/JRdLGeDmyUtAAA4CoQxtJjVmUWKiw5X705JVpcCAEDAIIyhRTS43Fq3tUhDerZRmJ0fKwAAjhSfmmgRGTmlqqpt0Il9GKIEAOBoEMbQIr7LyFdMVJhO6JZidSkAAASU8OYesGnTJn366afKzs6W3W5X9+7dNWHCBHXv3t0X9SEANLjcWp1ZpKG9UhURTr4HAOBoHPKTs6SkRLfddpvuvPNOVVdXa/jw4RoyZIgcDod+//vf6/bbb1dRUdFhX3zRokU655xzNG7cOM2fP/+A/Rs2bNCFF16oKVOm6MYbb5TD4Tj+FsHnNmSXqKauQSf3S7O6FAAAAs4he8buu+8+XXfddRo2bNgB++655x59++23uv/++/Xiiy8e9Pn5+fl6+umntXDhQkVGRmratGk65ZRT1LNnT89jHnvsMd12220aPXq0nnjiCf3jH//QjBkzWqBZ8KXvMgoUGxWu/l1bW10KAAAB55A9Y88///xBg9hep5xyil544YVD7l+xYoVGjBih5ORkxcbGasKECVqyZEmTx7jdblVVVUmSampqFB0dfbT1w2LOBpd+3FKoE3unKjyMIUoAAI7WIT897XuWJzj//PP13nvvqaam5pCPOZiCggKlpv5yZl1aWpry8/ObPGbmzJm6//77ddppp2nFihWaNm3aUTcA1vopu0Q1dS6GKAEAOEbNTuB/8MEH9c477+jZZ5/V+PHjddlll6lXr17NvrAx5oBt+14ip7a2Vvfff7/++c9/atCgQXr11Vd1zz33aN68eUdcfEpK/BE/9nikpobudRaba/u6TzKVEBupXw3rHHQ9Y6F83KXQbn8ot10K7fbT9tBlZfubDWMnnniiTjzxRDkcDi1atEg33XST0tLSdOWVV2rixImHfF56erq+//57z/2CggKlpf3Se5KZmamoqCgNGjRIknTppZfq2WefParii4sr5XYfGPpaUmpqggoLK7z6Hv6qubbXO136ZkOeTumXrtKSKh9W5n2hfNyl0G5/KLddCu320/bQbLvk/fbb7bbDdiAdUVeGw+HQhx9+qHfffVcJCQmaOHGiPvzwQ919992HfM6oUaO0cuVKlZSUqKamRkuXLtXpp5/u2d+lSxft3r1bWVlZkqRly5Zp4MCBR9ou+IH1WcWqq3dpOEOUAAAcs2Z7xu688059+eWXGjNmjGbNmqWhQ4dKki677DKNGjXqkM9LT0/XjBkzNH36dDmdTl100UUaNGiQrr/+et12220aOHCg/vSnP+n222+XMUYpKSl6/PHHW65l8LpVGwuUEBuhvp2TrS4FAICA1WwY69Wrl+6//361bt102YLw8HC99dZbh33u5MmTNXny5CbbXnrpJc/t0aNHa/To0UdTL/xEndOlH7cUadQJ7bgWJQAAx6HZT9EzzjhDM2fOlNS4Gv/UqVM9Q4s9evTwbnXwW+u2Fqve6dbwvgxRAgBwPJoNY7NmzdLFF18sSerTp49uvfVWPfTQQ14vDP5tVUa+EuMi1adTstWlAAAQ0JoNYzU1NRo3bpzn/llnnaXKykqvFgX/VlvfoHVbizWsT6rsdlvzTwAAAIfUbBiz2WzatGmT5/7WrVsPu9grgt/aLcWqb2CIEgCAltDsBP7f//73uuKKK9S7d29JUlZWlp566imvFwb/tWpjgZLiI9WLIUoAAI5bs2FszJgxWrJkiVavXq2wsDANHjxYKSkpvqgNfqimrnGI8owh7WW3MUQJAMDxOqLxxvz8fLVq1UoJCQnavHmz3n33XW/XBT/145YiNbjcLPQKAEALabZn7IEHHtCyZctUW1ur9PR0bd++XSeddJIuueQSX9QHP7Mqo0CtEqLUo0OS1aUAABAUmu0ZW7FihZYtW6bx48dr3rx5eu211xQdHe2L2uBnqmud+im7WMP7pjFECQBAC2k2jKWmpio2Nlbdu3dXZmamTj75ZJWWlvqiNviZNZuL1OAynEUJAEALajaMRUREaNWqVerRo4f+97//qaKigjAWolZtLFBKYpS6t0+0uhQAAIJGs2HsD3/4g95++22NHj1aGRkZGjFihKZMmeKL2uBHqmqd2pBdouF902VjiBIAgBbT7AT+n376SX/5y18kSe+9954cDocSE+kZCTWrMwvlchvOogQAoIU12zP21ltvNblPEAtNqzIK1CYpWl3bJlhdCgAAQaXZnrFu3brpgQce0LBhwxQbG+vZPn78eK8WBv9RWePUz9tKNeGUTgxRAgDQwpoNY2VlZSorK1NOTo5nm81mI4yFkNWZhXIbo5P7pltdCgAAQafZMPb666/7og74se8y8pXWKkad0+OtLgUAgKDTbBh79NFHD7r9gQceaPFi4H8c1fXKyCnVOSO6MEQJAIAXNDuBPzk52fMVFxenNWvW+KIu+InVmwpljHRyP4YoAQDwhmZ7xm655ZYm92+88UbdeOONXisI/uW7jHy1bR2rjqlxVpcCAEBQarZnbH+xsbEqKCjwRi3wM6WOWm3aUabhfdMYogQAwEuOas6YMUYbNmxQ9+7dvVoU/MOKdbl7hihZ6BUAAG9pNowlJyc3uT9lyhQuhxQivlqbq/Zt4tQhlbMoAQDwlmaHKW+88UZ17txZt9xyiy699FLV19c3WfwVwam0ok4/ZxdreF96xQAA8KZmw9js2bP1xRdfND7YbtcPP/ygxx9/3Nt1wWLfbyqQMSKMAQDgZc0OU65Zs0aLFy+WJKWkpOjZZ5/V1KlTvV4YrLVqY4G6tktU+zacRQkAgDc12zPmdDpVX1/vud/Q0ODVgmC9Ekettuws12lD2ltdCgAAQa/ZnrEzzjhD1157raZOnSqbzabFixdr9OjRvqgNFvl+Y+PSJacN7iDJWFsMAABBrtkwdvfdd+vNN9/UsmXLFB4ervHjx+vSSy/1RW2wyKqNBeqcFq8OqfEqLKywuhwAAIJas2HMGKOkpCS98MILKiws1Mcff+yLumCRovIabc116MLRrCUHAIAvNDtnbNasWZxNGUK+31goibMoAQDwlWZ7xn788UfOpgwhqzbmq0vbBKW1Yi05AAB8gbMp4VFQVqPsvAoufwQAgA9xNiU89p5FObwPYQwAAF85orMp58+f7zmbcty4cZo2bZovaoOPrcooUPf2iWqTHGN1KQAAhIxmw1hYWJimT5+u6dOne7ZVV1dzfcogk19arZz8Cl16Zk+rSwEAIKQ0G8Y+++wz/e1vf1N1dbWMMXK73SorK9OaNWt8UR98ZFXGniFKzqIEAMCnmg1jc+bM0e2336633npL119/vT777DPFxXG9wmDzXUaBenZIUuvEaKtLAQAgpDR7NmVMTIzOOeccDRkyRFFRUZo1a5a++eYbX9QGH8krrtLOwkp6xQAAsECzYSwyMlL19fXq3LmzMjIyZLfbmyx1gcC3amOBbJKGEcYAAPC5Zocpx44dqxtuuEFPPPGEpk2bph9++EHJyck+KA2+siqjQL06JqlVQpTVpQAAEHKaDWO//e1vNWXKFLVt21bPP/+8Vq1apUmTJvmiNvjArsJK7Sqq0uXjeltdCgAAIemQw5Tvvfee53b79u0lSf3799dVV12llJQUSdI777zj5fLgbXuHKE/qk2p1KQAAhKRDhrGGhgZdeumlmj9/vnJzcz3bd+3apbfeeksXXnihnE6nT4qEdxhjtGpjgfp0TlZyPEOUAABY4ZDDlJdddplGjx6tF198UXPnzlVFRYUkKTExUePHj9ezzz6rjh07+qxQtLxdhVXKK67WWSdxHAEAsMph54y1b99eDz/8sB5++GGVlpbKbrcrKSnJV7XBy77bmC+bTTqJa1ECAGCZZifw79WqVStv1gEfM8ZoVUaB+nZupcS4SKvLAQAgZDW7zhiC046CSuWX1mh4P3rFAACwEmEsRH2XUSC7zaaTenMWJQAAVjqqMLZjxw6tWrXKW7XARxrPosxXv66tlBDLECUAAFZqNoy9+eabuvPOO1VSUqJp06bpgQce0F/+8hdf1AYvycmvUGFZLdeiBADADzQbxhYsWKB7771XS5Ys0dixY/Xxxx9r+fLlvqgNXvJdRoHC7DadyBAlAACWazaM2Ww2tWnTRitXrtSIESMUHh4ut9vti9rgBXvPouzftbXiYyKsLgcAgJDXbBiLjIzUSy+9pO+++06nnnqq3nzzTcXExPiiNnhBVp5DxQ6GKAEA8BfNhrHHHntM27Zt05NPPqmkpCT98MMPevTRR31RG7xglWeIso3VpQAAAB3Boq/du3fXY489JqnxbMpp06apR48eXi8MLc9tjL7fVKATurVWbDRDlAAA+APOpgwhWbscKnHU6eR+6VaXAgAA9uBsyhDy3cZ8hYfZNaQXQ5QAAPgLzqYMEW5j9P3GAg3s3loxUUd8SVIAAOBlnE0ZIrbsLFdZZT3XogQAwM9wNmWIWJVRoIhwuwb3YIgSAAB/ckRnUz744IPKycmRMUaPPfaYoqOjfVEbWojb3XgW5aDuKQxRAgDgZ5rtGfvxxx911lln6cYbb1R+fr5Gjx6t1atX+6I2tJDMHWUqr2KIEgAAf9RsGJszZ45ee+01JScnq23btpozZ45n3TEEhnVZxQqz2zSoR4rVpQAAgP00G8Zqa2vVs2dPz/3Ro0fL5XJ5tSi0rI05perRPlHRkQxRAgDgb5oNY+Hh4SovL5fNZpMkZWVleb0otJzqWqdy8ivUt0srq0sBAAAH0WxXyU033aQrrrhCRUVFuuOOO7R8+XLNnj3bF7WhBWzaUSZjpH6EMQAA/FKzYWzMmDHq3r27li9fLrfbrd/97ndNhi3h3zJyShURblf39klWlwIAAA7iiCYRhYeHa8iQITLGqK6uThs2bNCAAQO8XRtawMacMvXskKSI8GZHpAEAgAWaDWN//vOf9cYbbygl5Zcz8Ww2m5YtW+bVwnD8KqrrtbOwUuef3t3qUgAAwCE0G8b+85//aOnSpUpPT/dFPWhBm7aXSZL6dWa+GAAA/qrZsat27doRxAJUxvZSRUWEqWu7BKtLAQAAh9Bsz9jIkSM1Z84cjR07tsllkJgz5v825pSqV6ckhYcxXwwAAH/VbBhbuHChJGnJkiWebcwZ839llXXKK67WaYPaWV0KAAA4jGbD2Jtvvqm2bds22bZ582avFYSWsXF7qSSpL/PFAADwa4ccvyorK1NZWZluuOEGlZeXq6ysTOXl5SoqKtLNN9/syxpxDDbmlComKlxd0pkvBgCAPztkz9idd96p5cuXS5JOOeUUz/awsDCNGzfO+5XhuGzMKVOfTsmy221WlwIAAA7jkGHsH//4hyTp3nvv1Z/+9CefFYTjV1xeq4KyGp15UkerSwEAAM04ZBjbunWrevTooSuuuEIbNmw4YD9nU/qvvfPFuB4lAAD+75BhbM6cOXrxxRd16623HrCPsyn9W0ZOqeJjItQhNc7qUgAAQDMOGcb69esnqTGUDRs2zGcF4fgYY7Rxe6n6dk6W3cZ8MQAA/N0hz6ZcvHix8vPzNXv2bM/ZlPt+wT8VltWoxFGnvgxRAgAQEA7ZM3bqqafqjDPOkDGmydmUUuMwZUZGhteLw9HLyGG+GAAAgeSQPWMPP/ywMjIydNJJJ2njxo1Nvghi/mvj9jIlxUWqbetYq0sBAABHoNmLFs6fP98XdaAFGGOUkVOqvl1aycZ8MQAAAgJXkA4iecXVclTVM0QJAEAAIYwFkV+uR5lsbSEAAOCIEcaCSEZOqVISo5SaHGN1KQAA4AgRxoKE2xht2l6mvp2ZLwYAQCAhjAWJnQWVqqxxsr4YAAABhjAWJDZuL5Mk9e1MGAMAIJAQxoLExpxSpSXHKCUp2upSAADAUSCMBQG322jTjjKGKAEACECEsSCQk1+hmroG9e2SbHUpAADgKBHGgsDGvdejZL4YAAABhzAWBDK2l6pdSqyS4qOsLgUAABwlwliAa3C5tXlHOfPFAAAIUISxALctr0J1ThdDlAAABCjCWIDL2HM9yj5cjxIAgIBEGAtwG3NK1SktXgmxkVaXAgAAjgFhLIA5G1zasqucVfcBAAhghLEAtnWXQ84Gt/oxeR8AgIBFGAtgG7eXymaTendKtroUAABwjAhjASwjp1Rd0hMUGx1udSkAAOAYEcYCVJ3TpaxcB0OUAAAEOMJYgNqys1wut2GxVwAAAhxhLEBl5JQqzG5Tr45JVpcCAACOA2EsQG3cXqpu7RIVHcl8MQAAAhlhLADV1DVoW14FQ5QAAAQBwlgAytxRJrcx6sclkAAACHiEsQCUkVOq8DCbenRgvhgAAIHOqxOOFi1apBdeeEFOp1NXX321Lr/8cs++jIwMzZw503O/pKRESUlJWrx4sTdLCgobt5eqZ4ckRUaEWV0KAAA4Tl4LY/n5+Xr66ae1cOFCRUZGatq0aTrllFPUs2dPSVK/fv304YcfSpJqamp08cUXa9asWd4qJ2hU1ji1I79SU0/rZnUpAACgBXhtmHLFihUaMWKEkpOTFRsbqwkTJmjJkiUHfeyLL76o4cOHa9iwYd4qJ2hs2l4mIzF5HwCAIOG1nrGCggKlpqZ67qelpWndunUHPM7hcOjdd9/VokWLjvo9UlLij6vGI5WamuCT9zkSOV9nKyoyTCcP6qCIcO9P+fOntvtaKLddCu32h3LbpdBuP20PXVa232thzBhzwDabzXbAtkWLFumss85SSkrKUb9HcXGl3O4D36clpaYmqLCwwqvvcTTWbCxQz/aJKiut8vp7+VvbfSmU2y6FdvtDue1SaLeftodm2yXvt99utx22A8lrXSvp6ekqKiry3C8oKFBaWtoBj/vss890zjnneKuMoOKoqteuoiqGKAEACCJeC2OjRo3SypUrVVJSopqaGi1dulSnn356k8cYY7RhwwYNHTrUW2UElY3bSyUxXwwAgGDi1Z6xGTNmaPr06TrvvPM0adIkDRo0SNdff73Wr18vqXE5i4iICEVFRXmrjKCyMadU0ZFh6to2tMf1AQAIJl5dZ2zy5MmaPHlyk20vvfSS53ZKSoqWL1/uzRKCSsb2MvXulKwwO2v1AgAQLPhUDxClFXXKL6lWP4YoAQAIKoSxALExZ898sc6EMQAAgglhLEBk5JQqLjpcndJ9s7YaAADwDcJYgNi4vVR9OreS/SBrtQEAgMBFGAsAhWU1KiqvVd/OyVaXAgAAWhhhLADsnS/G5H0AAIIPYSwAbNxeqsTYCLVvE2d1KQAAoIURxvycMUYZOaXq26XVQa/tCQAAAhthzM/ll9aorLKeJS0AAAhShDE/51lfjPliAAAEJcKYn8vIKVWrhCilt4qxuhQAAOAFhDE/ZozRxu2l6ts5mfliAAAEKcKYH9tVVKWKaidDlAAABDHCmB/zrC/G5H0AAIIWYcyPZeSUqk1StNokM18MAIBgRRjzU25jlLmjjCFKAACCHGHMT+3Ir1RVbQNDlAAABDnCmJ/KYH0xAABCAmHMT23cXqr01rFqlRBldSkAAMCLCGN+yOV2K3NHmfrRKwYAQNAjjPmhbbsrVFvvUt/OyVaXAgAAvIww5oc816Nk8j4AAEGPMOaHNuaUqkNqnBLjIq0uBQAAeBlhzM80uNzavLOcXjEAAEIEYczPZOU6VN/gZvI+AAAhgjDmZzbmlMomqQ+T9wEACAmEMT+TkVOqzukJiouOsLoUAADgA4QxP1LvdGlrbrn6dkm2uhQAAOAjhDE/snVXuRpchsn7AACEEMKYH8nYXiq7zabenZKtLgUAAPgIYcyPbMwpU9d2CYqJCre6FAAA4COEMT9RW9+g7DwHS1oAABBiCGN+YvPOcrnczBcDACDUEMb8xMacUoXZberZMcnqUgAAgA8RxvxERk6perRPVFREmNWlAAAAHyKM+YHqWqdy8ivUl/liAACEHMKYH9i0o0zGiMn7AACEIMKYH9iYU6aIcLu6t2e+GAAAoYYw5gcyckrVs0OSIsI5HAAAhBo+/S1WUV2vnYWVzBcDACBEEcYstml7mSTmiwEAEKoIYxbL2F6qqIgwdW2bYHUpAADAAoQxi2XuKFOvjkkKD+NQAAAQikgAFqqpa1BuYZW6t0+0uhQAAGARwpiFtudXyEiEMQAAQhhhzEJZeQ5JUtd2hDEAAEIVYcxC2bkOtUmKVmJspNWlAAAAixDGLJSd52CIEgCAEEcYs0h5ZZ2KHXXqxhAlAAAhjTBmkey8CkkijAEAEOIIYxbJynPIbrOpSzqLvQIAEMoIYxbJznOoQ2qcoiLDrC4FAABYiDBmAWOMsnMdDFECAADCmBUKSmtUXdfAmZQAAIAwZoW9i712p2cMAICQRxizQHauQ1ERYWrfJs7qUgAAgMUIYxbIznOoS9sE2e02q0sBAAAWI4z5WIPLrZz8SoYoAQCAJMKYz+0srFSDy61uTN4HAAAijPlcdm7j5P1u7VjsFQAAEMZ8LivPocTYCKUkRltdCgAA8AOEMR/LzqtQt3aJstmYvA8AAAhjPlVT16C8oirmiwEAAA/CmA9t210hIxZ7BQAAvyCM+VD2npX3uxLGAADAHoQxH8rOdSitVYziYyKsLgUAAPgJwpgPZeU5GKIEAABNEMZ8pLSiTqUVdepGGAMAAPsgjPnItj3zxTiTEgAA7Isw5iNZeQ6F2W3qnBZvdSkAAMCPEMZ8JDvPoY6p8YqMCLO6FAAA4EcIYz7gNqZx5X2GKAEAwH4IYz6QX1KtmroGLg4OAAAOQBjzgazcxsn7LGsBAAD2Rxjzgew8h6Iiw9QuJc7qUgAAgJ8hjPlAdp5D3domyG63WV0KAADwM4QxL3M2uLU9v5LFXgEAwEERxrxsR0GlXG5DGAMAAAdFGPOy7D0r73dnWQsAAHAQhDEvy8p1KCkuUq0SoqwuBQAA+CHCmJdl5znUrV2ibDYm7wMAgAMRxryoutap3SXVrLwPAAAOiTDmRdm7KySx2CsAADg0wpgXZe9Zeb8rl0ECAACHQBjzouw8h9JbxyouOsLqUgAAgJ8ijHmJMUZZuQ51p1cMAAAcBmHMS0or6lReVc9irwAA4LAIY16yd7FXzqQEAACHQxjzkqw8h8LsNnVOY5gSAAAcGmHMS7JzHeqcHq+IcL7FAADg0EgKXuB2G23bXcF8MQAA0CzCmBfklVSrtt5FGAMAAM0ijHnB3sVeuzN5HwAANIMw5gXZeQ7FRIUpvXWs1aUAAAA/Rxjzgqw8h7q2TZTdZrO6FAAA4OcIYy3M2eDSzoJKhigBAMARIYy1sO35lXK5DZP3AQDAESGMtbCsvSvvE8YAAMARIIy1sOw8h1olRKlVQpTVpQAAgABAGGth2bkOesUAAMARI4y1oMoap/JLa9StHdejBAAAR4Yw1oK27d6z2Cs9YwAA4AgRxlpQdq5DNkld2hLGAADAkSGMtaCsXIfapsQqNjrc6lIAAECAIIy1EGOMsvMcDFECAICjQhhrIcWOWjmqnerGyvsAAOAoEMZaSHZehSQWewUAAEeHMNZCsnMdCg+zqVNavNWlAACAAEIYayFZeQ51Tk9QeBjfUgAAcORIDi3A5XZr225W3gcAAEfPq2Fs0aJFOuecczRu3DjNnz//gP1ZWVm68sorNWXKFF177bUqLy/3Zjlek1dUrXqnmzMpAQDAUfNaGMvPz9fTTz+tN998Ux9++KHeeecdbdmyxbPfGKObbrpJ119/vT766CP169dP8+bN81Y5XpWV17jyPmdSAgCAo+W1MLZixQqNGDFCycnJio2N1YQJE7RkyRLP/g0bNig2Nlann366JOm3v/2tLr/8cm+V41XZeQ7FRoUrrVWM1aUAAIAA47Wl4gsKCpSamuq5n5aWpnXr1nnub9++XW3atNE999yjn3/+Wb1799aDDz54VO+RkuKbMxdTUw9/4e8dBVXq3aWV0tOCr2esubYHs1BuuxTa7Q/ltkuh3X7aHrqsbL/Xwpgx5oBtNpvNc7uhoUHfffed3njjDQ0cOFDPPPOMnnjiCT3xxBNH/B7FxZVyuw98n5aUmpqgwsKKQ+6vc7q0Lc+hc0Z2PuzjAlFzbQ9modx2KbTbH8ptl0K7/bQ9NNsueb/9drvtsB1IXhumTE9PV1FRked+QUGB0tLSPPdTU1PVpUsXDRw4UJI0adKkJj1ngWJ7foXcxnAmJQAAOCZeC2OjRo3SypUrVVJSopqaGi1dutQzP0yShg4dqpKSEm3cuFGS9Pnnn2vAgAHeKsdrsnP3TN4njAEAgGPgtWHK9PR0zZgxQ9OnT5fT6dRFF12kQYMG6frrr9dtt92mgQMH6u9//7seeOAB1dTUqG3btpozZ463yvGarDyHWidGKTk+yupSAABAAPJaGJOkyZMna/LkyU22vfTSS57bgwcP1oIFC7xZgtdl57HYKwAAOHaswH8cKqrrVVhWy2KvAADgmBHGjkN2XuOZF/SMAQCAY0UYOw7ZeQ7ZbFLXdqG9NgsAADh2hLHjkJ3nUPs2cYqO9OrUOwAAEMQIY8fIGKOsXCbvAwCA40MYO0ZF5bWqrHEyeR8AABwXwtgxys5jsVcAAHD8CGPHKCvXoYhwuzqkxlldCgAACGCEsWOUnedQl/QEhYfxLQQAAMeOJHEMXG63cnZXMEQJAACOG2HsGOwqrFJ9g1vd2rO+GAAAOD6EsWOwd/I+Z1ICAIDjRRg7Btl5DsVFhys1OcbqUgAAQIAjjB2DrNwKdWufKJvNZnUpAAAgwBHGjlJdvUu7iioZogQAAC2CMHaUtu12yBgWewUAAC2DMHaUsvMqJBHGAABAyyCMHaWsPIfaJEUrMS7S6lIAAEAQIIwdpexcB71iAACgxRDGjkJ5Vb2KHbWEMQAA0GIIY0fBs9hre8IYAABoGYSxo5Cd65DNJnVJ5zJIAACgZRDGjkJ2nkMd2sQrKjLM6lIAAECQIIwdIWOMsvMc6s7FwQEAQAsijB2hgrIaVdU2MHkfAAC0KMLYEcrObZy8TxgDAAAtiTB2hLLyHIoMt6tDapzVpQAAgCBCGDtC2XkOdWmboDA73zIAANBySBZHoMHlVs7uSoYoAQBAiyOMHYFdhVVqcLlZ7BUAALQ4wtgRyMpj8j4AAPAOwtgRyM51KD4mQm2Soq0uBQAABBnC2BFoXOw1UTabzepSAABAkCGMNaO61qncoiqGKAEAgFcQxpqxdWe5jJgvBgAAvIMw1ozM7aWSpG7tuCYlAABoeYSxZmTuKFVacowSYiOtLgUAAAQhwlgzMreXqRvriwEAAC8hjB1GWWWdispqmC8GAAC8hjB2GNl7FnvtThgDAABeQhg7jOw8h+x2mzqnx1tdCgAACFKEscPIznWoa7tERUaEWV0KAAAIUoSxQ3Abo+y8CvXu3MrqUgAAQBAjjB1CbZ1LNXUNGtCttdWlAACAIEYYO4TY6HDNvu4UjT6xo9WlAACAIEYYO4wObeK4ODgAAPAqwhgAAICFCGMAAAAWIowBAABYiDAGAABgIcIYAACAhQhjAAAAFiKMAQAAWIgwBgAAYCHCGAAAgIUIYwAAABYijAEAAFiIMAYAAGAhwhgAAICFCGMAAAAWIowBAABYiDAGAABgIcIYAACAhQhjAAAAFiKMAQAAWIgwBgAAYCHCGAAAgIXCrS7geNjttqB6H39E20NXKLc/lNsuhXb7aXvo8mb7m3ttmzHGeO3dAQAAcFgMUwIAAFiIMAYAAGAhwhgAAICFCGMAAAAWIowBAABYiDAGAABgIcIYAACAhQhjAAAAFiKMAQAAWIgwJmnRokU655xzNG7cOM2fP/+A/RkZGbrwwgs1YcIE3X///WpoaLCgSu+ZO3euzj33XJ177rmaM2fOQfePGTNGU6dO1dSpUw/6PQpU06dP17nnnutp29q1a5vsX7FihSZPnqzx48fr6aeftqhK73jvvfc87Z46dapOOukkzZ49u8ljgvHYV1ZWatKkSdq5c6ekIzvGubm5uvzyy3X22WfrpptuUlVVlS9LbjH7t/2dd97RpEmTNHnyZN17772qr68/4DkffPCBTjvtNM/PQCD/Huzf/nvvvVfjx4/3tO3TTz894DnB8vd/37Z/+eWXTX73R4wYoRtvvPGA5wTDsT/Y55tf/s6bELd7924zZswYU1paaqqqqszkyZPN5s2bmzzm3HPPNWvWrDHGGHPvvfea+fPnW1Cpdyxfvtxceumlpq6uztTX15vp06ebpUuXNnnMjTfeaFavXm1Rhd7jdrvNqaeeapxO50H319TUmNGjR5vt27cbp9NprrnmGvPFF1/4uErfyMzMNOPGjTPFxcVNtgfbsf/xxx/NpEmTzIABA8yOHTuO+BjfcMMNZvHixcYYY+bOnWvmzJnj69KP2/5tz8rKMuPGjTMVFRXG7Xabu+++27z66qsHPG/27Nlm0aJFvi+4he3ffmOMmTRpksnPzz/s84Lh7//B2r5XQUGBGTt2rMnOzj7geYF+7A/2+bZo0SK//J0P+Z6xFStWaMSIEUpOTlZsbKwmTJigJUuWePbv2rVLtbW1GjJkiCTpggsuaLI/0KWmpmrmzJmKjIxURESEevToodzc3CaP+emnn/TSSy9p8uTJmj17turq6iyqtmVlZWXJZrPp+uuv15QpU/TGG2802b9u3Tp16dJFnTp1Unh4uCZPnhxUx35fs2bN0owZM9S6desm24Pt2L/77rt66KGHlJaWJunIjrHT6dSqVas0YcIESYH7N2D/tkdGRmrWrFmKj4+XzWZT7969D/jdl6T169frgw8+0JQpU3TXXXepvLzc16W3iP3bX11drdzcXD344IOaPHmy/va3v8ntdjd5TrD8/d+/7fuaM2eOpk2bpq5dux6wL9CP/cE+37Zt2+aXv/MhH8YKCgqUmprquZ+Wlqb8/PxD7k9NTW2yP9D16tXL84dm27Zt+ve//63Ro0d79ldVValfv36655579P7778vhcOj555+3qNqW5XA4NHLkSP3973/Xa6+9prffflvLly/37G/uZyNYrFixQrW1tZo4cWKT7cF47B977DENGzbMc/9IjnFpaani4+MVHh4uKXD/Buzf9g4dOmjUqFGSpJKSEs2fP19jx4494Hmpqam69dZb9eGHH6pdu3YHDGUHiv3bX1xcrBEjRujxxx/Xu+++q++//14LFixo8pxg+fu/f9v32rZtm7777jtNnz79oM8L9GN/sM83m83ml7/zIR/GjDEHbLPZbEe8P1hs3rxZ11xzje65554m/0OKi4vTSy+9pC5duig8PFzXXHONvvzyS+sKbUFDhw7VnDlzFBsbq9atW+uiiy5q0rZQOfZvv/22fvOb3xywPZiP/V5HcoyD/ecgPz9fV111lS688EKdcsopB+z/+9//rsGDB8tms+m6667T//73PwuqbHmdOnXS3//+d6WkpCgmJkZXXnnlAT/fwX7s33nnHf36179WZGTkQfcHy7Hf9/Otc+fOB+z3h9/5kA9j6enpKioq8twvKCho0pW7//7CwsKDdvUGsh9++EFXX3217rzzTp1//vlN9uXm5jb536IxxvO/hUD3/fffa+XKlZ77+7etuZ+NYFBfX69Vq1bpzDPPPGBfMB/7vY7kGLdu3VqVlZVyuVySgutvwNatW3XZZZfp/PPP180333zA/oqKCr322mue+8H0M7Bp0yZ98sknnvsHa1uw//1ftmyZzjnnnIPuC5Zjv//nm7/+zod8GBs1apRWrlypkpIS1dTUaOnSpTr99NM9+zt06KCoqCj98MMPkhrPLtl3f6DLy8vTzTffrKeeekrnnnvuAfujo6P15z//WTt27JAxRvPnz9e4ceMsqLTlVVRUaM6cOaqrq1NlZaXef//9Jm0bPHiwsrOzlZOTI5fLpcWLFwfVsZcaP5C6du2q2NjYA/YF87Hf60iOcUREhIYNG6Z///vfkoLnb0BlZaWuvfZa/f73v9c111xz0MfExsbq5Zdf9pxl/MYbbwTNz4AxRo8//rjKy8vldDr1zjvvHNC2YP77X1JSotraWnXq1Omg+4Ph2B/s881vf+e9enpAgPjoo4/Mueeea8aPH2/mzZtnjDHmuuuuM+vWrTPGGJORkWEuvPBCc/bZZ5s77rjD1NXVWVlui3rkkUfMkCFDzJQpUzxfb775ZpP2L1myxPP9mTlzZlC1/+mnnzZnn322GT9+vHnttdeMMcZMmTLF7N692xhjzIoVK8zkyZPN+PHjzWOPPWbcbreV5ba4jz/+2Nx+++1NtoXCsR8zZoznrLJDHeP77rvPfPbZZ8YYY3bu3GmuuOIKM3HiRHPNNdeYsrIyy2o/Xnvb/uqrr5oBAwY0+d1/5plnjDFN275q1Spz3nnnmbPPPtv89re/NQ6Hw8ryj9u+x/6NN94wEydONOPGjTN//vOfPY8J1r//+7Z97dq15uKLLz7gMcF07A/1+eaPv/M2Yw4yOAoAAACfCPlhSgAAACsRxgAAACxEGAMAALAQYQwAAMBChDEAAAALEcYA4Ai89957mj9/viTprbfe0rx58yyuCECwCLzldAHAAj/88IN69eolSbrsssssrgZAMCGMAfBL8+bN04IFCxQXF6dhw4Zp2bJlWrJkiZ566imtWrVKLpdL/fv31wMPPKD4+HideeaZOv/887Vy5Url5eVp4sSJuvvuuyVJn3/+uV544QU5nU5FR0frnnvu0dChQ/Xcc8/pxx9/VEFBgfr06aOZM2fqj3/8o4qLi1VYWKgOHTromWee0erVq/X5559r+fLlio6OVklJiUpLS/XHP/5Rmzdv1uzZs1VWViabzaZrrrlG5513nr799ls9/fTT6tSpkzZv3qz6+nr98Y9/1IgRI/T999/riSeekNvtliTdeOONmjBhgpXfbgAWYpgSgN/56quvtHDhQi1YsEALFy5UVVWVpMaAFhYWpoULF+qjjz5SWlqannrqKc/zqqur9eabb+rtt9/WG2+8oR07dmjbtm16+umnNW/ePH3wwQd65JFHdOutt6q6ulqStGvXLr3//vt66qmn9PHHH2vIkCF65513tGzZMkVHR+vDDz/UuHHjdOaZZ+rqq6/W5Zdf7nm/hoYG3XTTTbryyiu1aNEivfTSS/rrX/+qNWvWSJLWrVuna665Rh988IEuuugizZ07V5L03HPP6Te/+Y0WLlyoxx9/XN98842vvrUA/BA9YwD8zpdffqmzzz5biYmJkqTLL79c33zzjb744gtVVFRoxYoVkiSn06mUlBTP88aOHSup8QLPKSkpKi8v19q1a1VQUKCrr77a8zibzabt27dLkoYMGeK5APJVV12l77//Xq+++qq2bdumzZs3a/DgwYesc9u2baqrq9P48eM97zt+/Hh99dVXOuWUU9S+fXv169dPktS/f3+9//77kqSJEydq9uzZ+vzzzzVq1CjdcccdLfFtAxCgCGMA/E54eLj2vVJbWFiYJMntduu+++7T6NGjJUlVVVWqq6vzPC4qKspz22azyRgjt9utkSNH6plnnvHsy8vLU1pamj799NMmF0n/85//rHXr1unCCy/UKaecooaGBh3uinF7hxn3ZYxRQ0ODpMaLre9fjyRNmzZNY8aM0fLly/XVV19p7ty5+uijj5SQkHBE3x8AwYVhSgB+Z/To0Vq6dKkqKiokSQsWLJAknXbaaZo/f77q6+vldrv14IMP6q9//ethX2vEiBFavny5tm7dKqmx123KlClNQtxeX3/9ta666iqdd955SklJ0YoVK+RyuSQ1BsK9IWuvbt26KSIiQkuXLpUk5efn65NPPtGoUaMOW9O0adOUkZGhCy64QI888ogcDofKy8uP4DsDIBjRMwbA74wcOVKXXHKJLr30UkVHR6tXr16KiYnR7373Oz355JM6//zz5XK51K9fP82cOfOwr9WrVy/Nnj1bd9xxh4wxCg8P1wsvvNCkR2yvm2++WXPmzNHzzz+vsLAwnXjiiZ7hzNNPP12PPPJIk8dHRETo+eef16OPPqrnnntOLpdLN998s0aMGKFvv/32kDXdddddevzxx/XMM8/IbrfrlltuUceOHY/hOwUgGNjM4frgAcAC69ev15o1azR9+nRJ0quvvqq1a9c2GWoEgGBBGAPgdyorK3XfffcpKytLNptN7dq10yOPPKL09HSrSwOAFkcYAwAAsBAT+AEAACxEGAMAALAQYQwAAMBChDEAAAALEcYAAAAsRBgDAACw0P8HKEb86Xv8I/IAAAAASUVORK5CYII=\n"
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYoAAAEXCAYAAACzhgONAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8qNh9FAAAACXBIWXMAAAsTAAALEwEAmpwYAABDC0lEQVR4nO3deXhV5bX48e/JRAiQQEIYwhyGxTxPoiAVnIdqtbVq1Q5ea1vbe2sH22r7a+2tt7P1ttZ6ta12cKizVdSqoECZkTHAEggJQwYgCYQMZDrn98fewWNITs5Jzs64Ps/DQ/a8zs7JXnu/77vf1xcIBDDGGGOaEtPeARhjjOnYLFEYY4wJyRKFMcaYkCxRGGOMCckShTHGmJAsURhjjAkprr0DMOERkQCwE6gLmr1JVW8Tka3AYiAAvKiqF7R9hKaeiIwEdqpq72bWuxyYp6o/EJGrgKWq+rW2iLGrE5EfANtU9WURuQ/Yp6p/ae+4OitLFJ3Lx1T1eMOZqjodzlyg5rZxTKbl5gCpAKr6CvBK+4bTpVwA7AJQ1R+0cyydniWKLsB92kgH/gz0dJ8wZgHlwE+BC4EM4EFV/Y27zReAL+MUPxYBd6rqHhE5D/g1EIvzhPI/qvp8U/MbxBEDPADMB/oAPuA2nCehQ8A4VS1w110H/Ah4B/gZcL677y3A11S1VERygPXAVOB7QI37fwIwAHhCVb/v7u87wBeAU8BK4GpVHSkiCU3tv5HzeA9wrXtOctzz0xtYA2SoarWIxAK5wEVAKfAwMNL9rE+o6i8a7POHQH9VvTN4GvgrcAcQKyIngb3Adap6hYgMbWy/7o3AO8AyYB5OkrlHVZ9p5LNcDfw/9zOXAncBm9zYr1HVTe56TwPvqerDjX1+Vc0TkXeBYmA88LCq/jboOLHAL4CrgJPu72uiqi4WkRTgQWAKEO/G/i1VrRWR00T+3Xzc/cyjgVeBPwIPub+jDGArcD3O92A28AsRqQM+jvOE90sRWejGmwRUA/eq6hsi8lngGsAPjHWX3aKqO0XkE8C97rI69zOsbHjOuzKro+hcVojI1qB/Axos/xxQqarTVbUO6AEcV9VzgeuAn4pIooicD9wKLFTVGcDPgRfcffwI+LWqzgI+j3NnFmp+sHk4f7DnqOpE4AngO6p6EngR+AyAiEwABgNvAt8BaoFZqjoNyMO5gNTbqaoTgJeAbwC3qupsnGT0XRHpLyIXA5/FuUOfhZOk6jW3f9yYbsG5oM11n9CWAY+p6gdAFs6FEJwEkaOqu4C/AytUdQpwLvAZEfl0I+flLKq6HvgD8Iyq3tNgcaj9ZgJvqupc4G6c313DzzLe3fe1qjoV+AHwMs4F9U845woR6YdzoX6yqc8ftNsSVZ0YnCRct+Gc88nAOTgX8XoPAJvd78wMnAR5l7usJd9NgCRVnaSqdwP/gZNEzwHGAKOAy1X1IZyk+C1VfTHovKQBzwH/6Z6XW4G/icgod5Xzga+q6mTg38C33Pm/wEmas4Hv4xTzdiv2RNG5NFr01IyX3f/fx/nj7AVcjvOHtUZE6tdLFZFU4B/AQyJyJfA2zh08IeafoaprReRe4IsiMhrnD+qUu/hRnLvkX+IktD+rql9ErgD6Ahe6sSQAR4N2u8rdd8A99hUiciMwAeduuxdwGfCsqp4AEJGHgCXu9s3tn6D15gKb3PVice4662P/LM5F5nPAYyLSC+cifpEb30n3jvdSYF0j+w9LGPutwbmIg/M7TW1kNxcA76hqtruP5SJyFOeC/idgo4jcBdwA/NM9RqjPD+7voRGXAX9R1dNu/I8A9fUsVwBz3ScEgJ4Nto30uwmwOmj7u3F+r98GxuHcpISqF5qHU1exHkBVs0Tk33xYv7dZVQ8HxfQJ9+engRdF5DXgLRpJzl2dPVF0fZXgXGjdaR/OReCv7pPHdGAmzqN6iao+gnNn+RZwMbBdRFKamh98ILdy9jV38mWcu1qfe/zVQJyIzAVuxLlg4cbyn0GxzMW5w6xX5u67F06x0UycP+Jv4Vw0fThPDL6gbYIr/Jvbf/B6PwtabzbOBRucBDHPfRI6HydpxjQ4Ju68+AbzAg3WS2jk2A33EWq/1arqb2Lfwes3Ni9eVXNxzt8VOEnvUXd5qM8P7u+hEc2d+08G7XMecGfQ8oi+m43E8RRwO05x2gPu52rsfNRr8rwEx+M6c27dJ75zcZ5SPgusdYtZu41u9WG7gVqcMu9QfywA/wJuEJHB7vQdOOXHiMgaYIaqPo7zR9gX6NfU/Ab7vRDnDvVhYCNwNc4ffr3HgN8C21X1oDvvTeBOEUlw//geBf6nkZjHAsk4Zcr/xLlg93D3/xpwbVDi+gLOH3ok+38TuE1Ekt3p+3DqEXDvlp8GHgeeV9UKVT2Fc4f/Ffe8pQC34CTSYMeAWSLic5PdRUHLammQWCLYbyjLgYtEJNPdxwXAMJz6A3DOwd04xTj/bu7zN+M1nKKxHiISh3MhDT73X3c/ew+cyvo7G9/NGU1+NxtxMXCfW0cTwElE9d+3s84tznkV92YFEZkELALebSoYEYlz68p6qeofcOpOJjSy7y7NEkXXko9zV7XbLY9tlKq+iVPB+5aIbMe5w/+Ee2f3beA+EdkCrAB+pKo5IeYH+wNwvrvPtcB+YFTQ3dcTwHQ+Wvb9Y5yK0y04rVR8OHURDW3HqcDcIyLv49QZ7ALGqOpynIvfWhHZBKQAFRHu/zF3/+tEJAunAv2zQcsfxXkaCY79JmCJiOwANgDP4ySTYH/HSRZ7cYqM1gYtewe4SkQalvuHs98mufUnXwZeEJGdOHUyV7p1ReBcsEfiVAbXa+7zN+VxnAS0BafSv5oPz/3XcIqTduD8/nbQTLFNM9/Nhr6HUyS0Cee79x5OsRXAP4FfisitQfs+DnwS+K17bp8EPufWQzUVTy3wXzj1OO8DzwKfV9WqUJ+jq/FZN+OmsxOR2cACVf1fd/ounPcTrm/fyLo+EbkIGKCqf3OnHwROu5XNpouwymzTFXwA3C0it+MUQRzEKR4z3ssCviUi38K5nmwDvtS+IZlosycKY4wxIVkdhTHGmJAsURhjjAmpq9VR9MB5Ozefj7bnNsYY07RYnN4SNgJntejqaoliDk2/QWqMMSa0hXz07Xeg6yWKfICSknL8/pZV0qel9aaoqKmXUNuPxRUZiysyFldkulpcMTE++vXrBe41tKGulijqAPz+QIsTRf32HZHFFRmLKzIWV2S6aFyNFtlbZbYxxpiQLFEYY4wJyRKFMcaYkCxRGGOMCckShTHGmJAsURhjPGN9yXUNliiMMZ4oLj3N1x5cxWY91t6hmFayRGGM8cSbGw5RfrqW97Yeae9QTCtZojDGRF1ZZQ0rt+WREBdDVk4xJ8ur2zsk0wqWKIwxUbfi/cNU1dTx+csnEAjAxt2F7R2SaQVLFMaYqKquqePtzYeZOjqNuRMGMmxAb9bvskTRmVmiMMZE1eod+ZyqqOHSecMBmD9xIPvzSjl6orKdIzMtZYnCGBM1dX4/b244SGZGMuOG9QVg3sSBAPZU0YlZojDGRM1mPcaxE6e5dN4IfD4fAKnJiYwb1pd1WQX2XkUnZYnCGBMVgUCAZetyGZSaxIxx/T+ybP7EgeQXVXDoaMcbw8E0zxKFMSYqduWUcLCwjEvmDSfGfZqoN3v8AGJjfKyz4qdOyRKFMSYqXl+fS0rvBM6ZNOisZb17xjN5VCrrdxXit+KnTsfTEe5E5EbgXiABeEBVH2qwfCbwiLv8EPAZVT0hIouAF915AFtU9XNexmqMabmcglJ25ZTwycWjiY9r/P5z3qSBbNtfxN5DJ5Dh/do4QtManj1RiMgQ4CfAecA04HYRmdhgtQeBH6jqNECBb7rz5wC/VNXp7j9LEsZ0YK+vO0jPHrGcP31Ik+vMGJNOj/hYa/3UCXlZ9LQUWK6qxapaDjwHXNdgnVgg2f05CahvaD0HuFBEtojIKyIyzMM4jTGtcLSkgk16lMUzhpCU2HQhRY+EWGaM68/GPUeprfO3YYSmtbwsesoA8oOm84G5Dda5C3hLRH4DlAPz3PkngKdU9WURuQN4Gjg33AOnpfVuYciO9PQ+rdreKxZXZCyuyLQ0rmdXZhMbE8OnL55AanJiyHUvPmcU67IKOVRUydxG6jKiGZfXulNcXiYKXyPzztxGiEhP4I/AElXdICJ3AX8BLlfVO+rXU9U/iMhPRSRFVU+Gc+CiojL8/pZVmKWn9+HYsVMt2tZLFldkLK7ItDSu0vJq3t5wkAWTB1JXVcOxYzUh1x/SL5HePeN5c+0BRg3o5VlcXutqccXE+ELeYHtZ9HQECL5lGAzkBU1PBipVdYM7/QiwWERiROQeEYltsL/Q30BjTJt7e/Mhamv9XDJvRFjrx8XGMGf8ALbuPc7p6lqPozPR4mWieBtYIiLpIpIEXAu8EbR8HzBMRMSd/jiwUVX9wDXu+ojILcB6Va3wMFZjTIQqq2pZvvkIM8elMyg1Kezt5k8aSHWtny17j3sYnYkmzxKFqh4B7gFWAFuBJ90ipmUiMltVS4DPAv8Qke3A54H61k23Av8lIlnuvNu8itMY0zKrtuVRUVXLJfOHR7Td6CEppCUnWuunTsTT9yhU9UngyQbzLgv6+XXg9Ua2ywIWeBmbMablauv8vLnxEDKsL6MzUiLaNsbnY97Egbyx/iClFdUkJyV4FKWJFnsz2xgTsfW7Cik5VcWl88Orm2ho/sSB+AMBNu05GuXIjBcsURhjIuIPBHh9/UGGpvdmSmZqi/YxdEBvhqT3sr6fOglLFMaYiGzfV0Te8XIunT/8TFfiLTF/4kD2HT7JcRvQqMOzRGGMicjr63NJS+7BnPEDWrWfeRPcAY1sPO0OzxKFMSZs+w6fZO/hk1w0dzhxsa27fPTv25MxQ1Os+KkTsERhjAnbsnW59O4Zz6KpGVHZ3/yJAzlyrJzDNqBRh2aJwhgTliPHy9m67zgXzBxCj4SGHSe0zOzxA4jx2YBGHZ0lCmNMWN5cf5CEuBiWzBoatX0mJyUwyQY06vAsURhjmlVcepq1WQUsnJpBnyi/IDd/0kCKSk+z/0hYfX6admCJwhjTrLc2HSIQgIvnRn9omBlj+5MQF2PFTx2YJQpjTEjlp2t4d2secycMoH/fnlHff2JCHNPH9mfjbhvQqKOyRGGMCendLUeoqq7jknmRdf4XifkTB1FWWcOunGLPjmFazhKFMaZJNbV1vLXpMJNHpTJ8oHcjuk3OTKVXYpwVP3VQliiMMU16dU0upeXVLe78L1xxsTHMHj+ALR8cp6q6ztNjmchZojDGNGp3bgmvrsnh3MmDmDCin+fHmz9xIFU1dWzdZwMadTSejkdhjOmcSsur+b9/ZjEwNYmbLhrXJsccO6wv/fr0YF1WAfMmDmyTY9arrKqloLiCvOPl5BWVExvj45qFma3q9LArsURhjPkIfyDAH1/bTXllLV//5DQSE9rmMlE/oNFbGw9RVllD757xUT9GWWXNmWSQf7zC+b+onOLSqrPWnTt+IEMH9I56DJ2RJQpjzEf8a8MhdmQX8ZmLxnlagd2Y+e7Id5v2HGXxjCEt3k/F6VoOFJSSd7yc/KIK8t3kcKqi5sw6CfExDE7thQzry+C0XgxO60VG/yTiYmO4+w9r2ZVbYonCZYnCGHPG/ryTPP/efmZJOh9rxYW6pYYN6M3gtCTW7SqMOFFU19SxbX8R63cVsn3/cWrrnC5BknrEkdG/F9PH9Cej/4cJITU5kZgmipYG9uvJrpxiLpoT/RcMOyNLFMYYACpO1/DIy1n07d2Dz106vl3K530+H/MnDeLFldkUl54mPT30E02d38/unBLW7Srk/Q+Ocbq6jpReCXxsxlCmjUljSP9eJPdKiPizTBiZytqsAmrr/K3uTr0rsERhjCEQCPD4G0pxaRXf/cxMkhKjXz8QrnkTB/LiymzW7y5ERqeftTwQCLD/SCnrdhWwcc9RTlXU0LNHHHPGD2DexIGMH96PmJjWJbmJI/rx7pYj5OSfYszQlFbtqyvwNFGIyI3AvUAC8ICqPtRg+UzgEXf5IeAzqnpCRPoCfwcygWPAp1S1wMtYjenO3liXy6Y9R7lu8WhGD2nfC+OAvj0ZnZHMuqxCbrli8pn5h4+WsW5XIRt2F3L85Gni42KYPqY/8yYOZEpmGvFx0bvzHz+iHz5gV25xp0kUlVW1VFbVerJvzxKFiAwBfgLMAqqANSKyQlV3Ba32IPADVX1dRH4FfBMnsfw3sEpVLxeRm931rvcqVmO6s8NHy3jspR1MHpXqaTcdkZg3cSBPvr2XTbsL2fHBUdbvLuTIsXJifD4mjUrlmoWZTB/bn549vLmE9e4Zz/CBfdiVU8JV547y5BjRtPNAEX94KYulc4dz9bkjo75/L58olgLLVbUYQESeA64D7gtaJxZIdn9OAuo7erkcWOT+/BTwkIjEq2oNxpioqaqu4+GXd9KrZzy3XTGxycrdtjZnwkCeemcvP3psHQBjh6Zw80XjmDV+AMlR7ua8KRNG9uOtjYeoqq6L2kBN0RYIBHhr4yGeWbGPjP69uGrRaKiL/pvtXiaKDCA/aDofmNtgnbuAt0TkN0A5MK/htqpaKyKlQDqQ52G8xnQ7f3/7AwqKKvjxFxeQ3KttLsDhSOmVwGcuHEdMfByThqfQPyX6vdY2Z+KIfryx/iB7D59gcmZamx+/OTW1fv7y5h7+vaOAmePSue2KCQxMTeLYsVNRP5aXiaKxW5MzfQiLSE/gj8ASVd0gIncBf8F5mgi5bXPS0lrX9rm5lhbtxeKKjMUV2rvvH2b19nyuXzqOaePOrjRub5+6eEK7Hv+c5J7EPb+DnKPlfGzeyLOWt+fvsbj0ND97agOaW8INFwmfvlDOVOB7EZeXieIIsDBoejAffSKYDFSq6gZ3+hHgx0HbDgIOi0gcTvFUUbgHLioqw+9v2bCK6el9PMnIrWVxRcbiCq2wuILfPbuVsUNTWDozA6BDxNVQe5+v0RnJbN5dyBXzP1p3055xHcgv5Xcv7KD8dA1fvnoys8cPoKiorFVxxcT4Qt5ge9lA+G1giYiki0gScC3wRtDyfcAwERF3+uPARvfnZcAt7s/X41RsW/2EMVFQU+vnDy9nERfj44tXTSI2xt4TaMqEkf04WHiKssqOcflZm1XAT//+PjE+H9/7zCxmjx/QJsf17BuiqkeAe4AVwFbgSbeIaZmIzFbVEuCzwD9EZDvweeBz7ubfB+aLSBbwZeArXsVp2sfOA0UcPlrW3mF0S8++u4/cwlN8/vIJpCYntnc4HdrEEakEgD25Je0ah98f4NkV+3j0n7vIHJzM9z87u027V/H0PQpVfRJ4ssG8y4J+fh14vZHtioGrvIzNtJ/jJyt58NntpPRO4P7/mE9CfMdsUdIVbdl7jLc3HWbp7KHMGNvx6iU6mpGD+5CYEMuu3JI2u3tvqOJ0Lf/3zyy27y/iYzOGcMPSsW3+trg9c5o298rqHACKS6t4c+Oh9g2mGykuPc2fXtvNiIF9+OTiMe0dTqcQFxuDDOvL7nYaorWguIL//ssmsg4Uc/PFws0XS7t0KWKJwrSp/KJy/r0znyWzhjJzXDrL1uZysuzsLp5NdNX5/TzySha1/gB3fHxSVN9i7uomjEylsKSSopOn2/S4O7OL+PETmyirrOGbn57eLp001rNvi2lTL606QEJcLJfNH8EnPzaa2jo/L6zMbu+wuryXV+ew9/BJbr1YGJia1N7hdCoT3dH9duW2zVNFIBDgzQ0HeeDZbaQlJ/KDW2cjw70fYTAUSxSmzeQWnGLjnqNcOGcYyb0SGNgviSWzhrJ6ez4HCzte08xoqqmt455H1/Hyyv1tfuw9uSW8tiaH86YOZv6kQW1+/M5uSHovkpPi2d0GFdo1tXX88bXdPLN8HzPHpXPPzbPo37ftXzZsyBKFaTMvrsqmV2Icl8z9sI//q84dSa+e8TyzfB+BQMvefekM1u0qJL+ogmfeUk5Xe9NxW2MCgQDPLN9H/76J3LS0bYY07Wp8Ph8TRqayO6fE0++o3x/gl09vZc3OAq4+bxRfunpyh+k6xBKFaRN7D59g+/4iLp0/4iNdWCclxvPx80axO7eErfuOt2OE3gkEAryz6TDJSfGcqqhh5da264lm54FicgtPcfk5IzvMRaczmjCiHyfLq8krqvDsGFk5xew9fJKbLxrHVeeN6jD9boElCtMGAoEAz7+XTUqvBJbMHHrW8vOnZzA4LYl/LN9HbV3YPbV0Gh8cOsHBo2VcsyiTKaP78+bGQ9TUev85A4EA/1yTQ2pyDxZMtiKn1jhTT+Fh66dV2/Lo3TOe86ZmeHaMlrJEYTyXlVPMB4dOcMWCxu9q42JjuP6CMRSWVLLi/SPtEKG33t58mF6JccyfNIjrloyl5FQVa7O8H17lg0Mn2Hf4JJfOG2GjtLVS/749Se+byO4cb+opSsur2bL3OAsmD+qQLdI6XkSmS6l/mkhLTmTRtKbvlKZkpjFpZD9e+feBDtNdQjQUnTzN+x8cY9H0DHrExzJjXDojBvVh2dpc6vzePlW8uiaH5F4JLJw62NPjdBcTR6aih0o8+b2t2VlAnT/QYX9XliiMp97/4Bi5Baf4+HmjQt4p+Xw+rl8yloqqWl5ZfaANI/TW8vcP48PHBTOcIjefz8cV54zg6IlKNu055tlxs/NKycop4eK5w+zN9yiZMKIflVV15BREt4VeIBBg1fY8Rg9JZkh663q+9oolCuMZvz/ACyuzGZyWxDmTBza7/tD03pw/LYMVW46QX1TeBhF6q6qmjpXb8pg5rj9pKR/2qTRjXDqD05J4bW2uZ61oXl2TQ6/EOBZPb7+XtLqa8WfqKaJb/LT/SCn5RRUs7IB1E/UsURjPrNtVQH5RBdcszAy7h9KPL8wkPi6GZ1e0/fsG0bY2q4Dy07UsnT3sI/NjfD4umz+Cw8fK2L4/7N7zw3b4aBlb9x1n6exhng0V2h0lJyUwbEDvqHfnsXJbHj0SYpk7oX36kgqHJQrjido6Py+tOsCIgX2YKeF3PpfSK4ErFoxk677jnrYw8Vp9k9jhA3ozdmjKWcvnTRxIWnIir67NifpTxatrc0hMiGXJrLNbmJnWmTCiH/uOlFJVE53hRiuratmwp5B5EwaQmNBxk3rYiUJEEtxBhIxp1qpteRw/eZprFmVG3B78wtlD6Z+SyNPv7GvxAFTtbXduCUeOl7N09jB8jXz+uNgYLpk3nP1HSvng0ImoHbeguIKNu4/ysZlD6N0zvvkNTEQmjkylts7P7gPReRLcsLuQ6hp/hy52gmYShYgMEJFfi0gOcBo4LSJ7ReR+kQhuE023UlVTxytrchg7NIUpmakRbx8fF8t1i0dz+FgZq3fkN79BB/T2psP0SYpn3sSmixMWTh1MclI8r67Njdpxl63NJT4uhovnDG9+ZROxccNSiI3xsW1vdF4OXbktnyH9e5GZkRyV/XmlyUQhIjfjjBVRCFwG9MQZkvQaoBh4S0RubYsgTeey/P3DnCyr5trzRzd6Nx2OOeMHMGZoCi+szKayqu26vIiGoyUVbNt3nPOnDyE+rukWRwnxsVw0dzhZB4rJKSht9XGPn6xkbVYBi6ZlkNwrodX7M2dLTIgjMyOZrXtb32Lt8NEyDuSXsnBaRov/TtpKqCeKfsAcVf2Zqu5S1SpVrVDVnar6S2CWu44xZ1RW1bJsbS6TM1MZN6xvi/fj8/n49AVjKS2vZtm66N1xt4Xl7x8hJsYXVrfQH5sxhJ494ngtCk8Vr68/CMAl8+xpwksTRvRj/+ETlJ9u3fs+K7fnERvj45xJzbcIbG9NJgpV/V9VbfLNElWtU9XfeBKV6bTe3HCQ8tO1fGJRZqv3lZmRzPxJA3lzwyGOn6yMQnTeq6yqZdX2PGaPH0C/Pj2aXb9njziWzBrC+3qMvOMtbxJ8oqyKVdvyOXfKYBve1GMTR6YSCMCe3BMt3kdNrZ+1OwuYOS6dPkkd/+mv2cpsERksIq+JyAciMlBE3hSRjvn6oGlXpyqqeXPjIWZLOiMHRafM9brzRxPjg+fe7RzNZdfsLKCyqo6lEbQ4Wjp7GPFxMbzeiienf204RJ3fz2Xz7WnCa5kZySQmxLK7FeNTbNl7jPLTtSF7K+hIwmn19BDwElCJUzexFXjMu5BMZ7VsXS7VNXVcvbD1TxP1UpMTuXjucDbsPsq+Iyejtl8v+AMB3t58mFGDkxk95OwmsU1JTkpg0fQM1mYVcvxE5E9OZZU1rNhyhHkTBzKgnw1K5LW42BgmZaa16sW7ldvySEtOZMLIzlF6H06iGKmqjwJ+Va1R1bsBu20xH1Fcepp3Nh9hwaRBZPTvFdV9Xzp/OCm9E3jmnb0desyKrAPFFBZXsHR25O8vXDJ3OD4fvLHhYMTbvrXxEFU1dVx+zsiItzUtM21sOgXFFZScinwY32MnKtmVU8LCqYM7VFfioYSTKPwicmY9EekT5namG3l1jfPi2FXnjYr6vhMT4vjEokz255WyYffRqO8/Wt7edJiUXgnMGR/5G7apyYksmDyIVdvzOVleHfZ2FadreWfzYWaNS2dIlBO0adq0sc7bAS15KXT19nx8wHkdtAPAxoTzAt0LwN+BFBH5InAb8I9wdi4iNwL3AgnAA6r6UNCy6cDjQaunAyWqOllEbgF+htM0F+A1Vb0nnGOatne0pIJV2/M5f3oG6R4N23julMG8s/kwz727jxlj+3e4ju7yi8rZkV3E1eeNanGX3pfOH8Hq7fm8tfEQ1y0eHdY2K7YcpqKqlssXjGjRMU3LjBycTO+ezvCo504J/4Lv9wdYvSOfSZmpnarRQbPfaFW9H1gGbAQuBP4PuK+57URkCPAT4DxgGnC7iEwM2u9WVZ2uqtOBBUAJcIe7eA5wV/1ySxId28urDxAb4+OKBSM9O0aM21y2qLSKf2085NlxWmr55iPExfo4P4wmsU0ZlJrE7PEDWP7+YSrCaHpZVV3HmxsOMSUzLWqNB0x4YmJ8TBjRj925kQ2PuvNAMSWnqljUwd/EbqjZJwoR+Yuq3gL8NcJ9LwWWq2qxu5/ngOtoPMl8F3hPVVe703OAMSLyHWAH8FVV9X5kcxOx3PxS1mUVcsm84fTt3Xxz0NYYP6IfM8b257V1uSycOpgUj48XrorTtazemc/cCQNJaeWLbpefM4KNe47yzvtHuLKZxPvetjzKKmu4wp4m2sWEkf3YuOcoBcUVDE4Lr9hv1bY8+iTFM31sf4+ji65wnpGniUhLalwygOD+F/KBs2r5RKQvcDvwowbr/hCYDhwCfteC45s28Lc3dpPYI5ZL57fNxepTHxtDba2fZ1bsw99BKrZX78inqrquRZXYDQ0f2Iepo9OcCurqpjueq6n188b6XMYP78vYoX1bfVwTuYkRdjt+sryarfucUew624iD4dRR5ANZIrIOKKufqapfa2a7xpJLYy/w3QS8pKpnailV9Zr6n0Xk50B2GHGekZbWusE/0tP7tGp7r3S0uD44WMK6nQXcdMl4Rg2PvE+nlkhP78N1S8byzFsf4IuJ4es3zGyyK+22OF91/gDvbj3ChJGpzJkSXrFTc3HddOkE7v7dat7fX8RVixqvq3hjbQ4nyqr5xk2zovY5O9r3q15HjWvi2AEMSE0iu+AUnw4jxlU791HnD/DxxWM9/Uxe7DucRLHW/RepI8DCoOnBQF4j610N3F8/ISIpwOdV9QF3lg+I6F35oqKyFvc6mp7eh2PHojuCVTR0tLgCgQB/fHkHyb0SWDBhQJvGdtHMIfj8AZ5Zvpe7HniXr1479axK9LY6X1v3HqegqIKrzxsV1vHCiSu9dwLjhqbw3PK9zBnX/6y7zzq/n2feUkYNTiajb2JUPmdH+37V68hxHT9ehgxNYbMeo7CwlJiYpgteAoEAr685wJihKSTG4Nlnaun5ionxhbzBDqcy+0fAr4B3gX8Dv3bnNedtYImIpItIEnAt8EbwCm6R1iw+mojKgG+LyDx3+k7gxTCOZ9pIbZ2fP7++h105JVy/dFybD47j8/m4aM4wvv6paRSXVvHjJzaxJ7d9qrDe2nSIfn16MHNcdDtTvnzBSEpOVbF2Z8FZy9bvKuT4ydNcuWBkh+9MrqubMLIfFVW15BaGvjjvO3KSguKKDjsmdnPC6cJjDvAB8Bvg10CuiCxobjtVPQLcA6zAeZv7SVXdICLLRGS2u1o6UK2qp4O2qwM+BTwsIrtxEsm3I/lQxjunq2v57fM7WL09nysXjOTKKL6FHanJo9L4/q2z6ZMUz6+e2cqK9w+36fGPHCtjd24JF8wcEvUy58mjUhk+sDfL1uV+5OnYHwjw2tpchqb3ZtqYtKge00RuwginyLW59ylWbssjMSG2Re/YdATh3Ar+CrhJVVcAiMgFOAljfnMbquqTwJMN5l0W9PNRYFAj260CZoYRm2lDpeXV/ObZbeQWnuKWi4XFM4a0+x3twNQk7r1lNo+8ksVf//UBh46WceOF49rk2G9vPkx8XIwn/fX4fD6uOGckv39pJ5v0KHMnOD2Mvq/HyC+q4I6PT2r3c2+cERmHpvdid25Jk2/GV1bVsnHPUc6ZNKhDj2IXSji3Qcn1SQJAVZcD1qFMN1NYUsH9f91M3vFy7vzEFBa34n2BaOvZI46vXTuVy+aP4N2tefzyqS2caEHXCpEoq6xh7c4C5k8c6FnvnzPHpTMoNYnX1uYSCAQIBAK8ujaHgalJzJbOeWfaFU0YkcrewyepqW28ldr6TjKKXSjhduFxpu2jiIwEojNgrOkUsvNK+clfNlNRVcu3bpjBjLEdb3DDmBgf1y0eze1XTeRAwSnuevA9DjZTbtwaq7bnUV3rZ+nsYZ4dIybGx6Xzh3PoaBk7sovZkV3EwcIyLp8/ImTFqWlbE0b2o6bWz74jjQ8+tWpbHkPTezFqcMdsvRWOcBLFfcA6EfmriPwVWA/8t7dhmY5i677j/Pyp90lMiOV7N8+KqFfU9jB/4iC++5mZBPwB7v/bZjbuiX7fUHV+P8s3H2b88L4MG9C6ptjNOWfSIFKTe/Dq2hz+uSaHtORE5neCgW66ExnWlxifr9F6ikNHyziQf4qFUzv+KHahhNPq6SVgMbAGWAecr6rPexuW6Qje23qE3z6/ncFpvbjnltkMSu0cJY4jByXz6/86n+ED+vDwSzt5cWV2VF/O27r3OEWlVZ4+TdSLi43hkrnD2Xf4JPuPlHLZ/OGd7mWtrq5njzhGZfRhdyMt71ZtyyMu1sc5k8+qiu1Uwmn1NBWnSezDwErgaRERzyMz7SYQCPDSqmyeeEOZNCqVu2+c0equKdpav+REvnXDDM6bOph/rsnhoRd2RG3s7bc2HSYtOZHpY9qmG4aF0zLokxRPSu+ETtXjaHcycUQqB/JLqTj94XespraOtVnOKHa9e8a3Y3StF86tycO4AxWp6g6crjUe8TAm047q/H4ef30Pr/w7h3OnDOJr107ttC014uNi+Nyl47lh6Vi27Svi/r9t5mgLBgYKdrDwFB8cOsGSWUPbrJ6gR3wsX7t2Kl/9xFTi4zpWr7nGMXFkPwIB0EMfPlVs/sAZxW5hJxnFLpRwEkUvVT3zwptbFGVdVXZBVdV1/Pb5Haxy35H4/GUTOn0xh8/n48LZw/j69dM4caqKHz++ka17j3P8RCUnyqooq6yhqrqOOr8/rF5A3950mIT4GBZOa9s7+9FDUsjMsD+7jiozI4WEuJiP9Pu0als+/VMSmTCic4xiF0o4t4oBEZniPk0gIhOwVk9dTml5NQ8+t42cgg/fkehKJo1M5d5bZ/Pb53fwv89vb3QdHxAXF0NcbAzxsb6gn2OIjfURHxtDbuEpzpuaQa/Ezl2UYKIrPi6GscP6nqmnOHqikt25JVyzcFSnGcUulHASxfeBlSKyw50ej9ORn+kiCksqeOCZbZwoq+LOT0zpkM1fo2FgvyTuuXkWO7KLqKqpo7YuQG2tn9o6PzV1zv+1tQHn/zPznHXql8uwvlw6z0YCNmebOLIfz67Yz4myKmcUOx8RDWrUkTWbKFT1Vbfy+lygFlgf3NOr6dyy80p58LltBALwrRtmdPjmr63Vs0fcmbecjYmmiSNSgf1kHSjm3zvymZKZ1qlGsQslnFZPSUCmW0+RCfxUROyWqpPzB5zusX/+1Pv0iO8c70gY05ENG9ibXolxvLz6ACWnqjr1m9gNhVP09GcgW0Rqgf8E/gI8ClzsZWDGO4UlFTzx+h72HDzB+OF9+eJVkzrMaHHGdFYxPh/jR/Rjsx4jOSm+S3XaGE6TlkxV/S5wFfC4qv4QaJtRakxU1fn9vL4+lx/8cQO5hae49RLhWzfMsCRhTJTUj3q3YMrgTt9iMFg4TxT1b1pdDHxDRGIBb/stMFF3sPAUf359D7kFp5gxtj+fuUjo18cShDHRNFMGsG1/EUtmtn5Y3I4knETxbxHZhVORvQZ4B2dQItMJ1NTW8cq/c3hj/UF6JcbxpasnM1vSO3W/M8Z0VCm9EvivT05r7zCiLpxE8VXgHGCHqvpF5JfA696GZaJh7+ET/HnZHgqKKzh38iCuXzK203clYIxpe00mChG5TVUfc0ecW10/X1VfC1rndlX9P49jNBGqrKrlhfeyWf7+YVKTe3DXp6YxObPrVKwZY9pWqCeKOBFZC/wVeFVVDwK4Y1NcCnwBeML7EE0ktu8v4i9v7qGktIols4byifMzO21fTcaYjqHJK4iq/kFElgHfBX4oIik4vRyUAM8Dn1TVnDaJ0jTrVEU1T7+zl7VZhQxOS+K7N89ijL0XYYyJgpC3mu5TxJeAL4lIGuBX1bM7XTftJhAIsHHPUf7+1gdUnK7lygUjuWLBSOLjuk7TPGNM+wq7TEJVi7wMxESm5FQV63cVsjargENHyxg5qA/f/PQEz0dcM8Z0P1Z43YlUVtWyWY+xNquAPbklBIDMjGRuuVhYOG0wsTH2FGGMiT5PE4WI3Ajci/PS3gOq+lDQsunA40GrpwMlqjrZ7Uvqb8AAQIGbVLXMy1g7qto6PzsPFLPlDWXdznxqav0M6NuTK88dyTmTBjGwkwxPaozpvCJKFCIyChimqivDWHcI8BNgFlAFrBGRFaq6C0BVtwLT3XWTgA3AHe7mvwd+r6pPi8j3cbo6vzuSWDuzQCBAdl4pa7MK2LD7KGWVNfRJSmDh1MGcM2kQmRnJ9sKcMabNNJsoRORLwELga8Ba4KSIvOD2/xTKUmC5qha7+3kOuA64r5F1vwu8p6qrRSQeWARc7S57HHiPbpAoCosrWJtVwLqsQo6eqCQ+LoYZY/szf9IgFs8ZwYmS8vYO0RjTDYXzRPEF4HLgk8DLwFeAdTgX91AygPyg6XxgbsOVRKQvcDswxZ3VHyhV1dqg7SLqOCUtrXUVuunpfVq1faS2fXCMv76+Gz1Ygs8HU8f054aLx7Ng6mCSgkZSa+u4wmVxRcbiiozFFRkv4gprKFRVLRSRpcAzqlrrdgzYnMbKRvyNzLsJeCloMKRwt2tSUVEZfn/z4x83Jj29D8eOnWrRti1R5/fzy79vIjYmhk99bAzzJg4801lf+anTlJ863S5xhcviiozFFRmLKzItjSsmxhfyBjucZjJVIvJt4HzgLbcoKpwykCPAoKDpwUBeI+tdDTwdNH0MSA5KRk1t1yVs31fEibJqblw6lkvmDbceXY0xHU44ieILwDjgVvdlu/OA28LY7m1giYiku5XV1wJvBK8gIj6cyu619fNUtQZYBVzvzrqFLtwJ4Xvb8ujbO4GpXWiQE2NM1xLOmNmKmxjcVk+PqOqeMLY7IiL3ACtwmsc+pqob3G5BfqCqm3CaxFar6ukGm38ZeEJE7gUOAjdE8qE6i+MnK9mxv4grFoy0dyCMMR2Wl62eUNUngScbzLss6OejfLR4qn5+LrC4uf13dqu2OXX9C6cNbudIjDGmaeEWPX2dD1s9TQIu9DKo7qDO72fV9jymjE6jf0rP9g7HGGOaFE6iCKhqIc57Ee+4zVbDafVkQqivxD5/ekZ7h2KMMSF52erJhPDu1jz69enB1NFWiW2M6di8bPVkmnD8ZCU7s4tYONU68jPGdHzNXqXcVk9fBQ66zVlvC6fVk2naym354IOFU63YyRjT8TWbKERkPrAfeA0YAhwWkQVeB9ZVnanEzkwjLSWxvcMxxphmhVPu8QuciuwiVT0M3Aw86GlUXdi2fUWctEpsY0wnEk6iSKrvGhxAVZdhAx612HtWiW2M6WTCSRQ1ItIPCACIiHgbUtd1/IRVYhtjOp9wngz+G2c8iEEi8hRwEU634CZCK7dbJbYxpvMJp6+nV0VkD87b2LHAj4OLokx4auusEtsY0zmFW/5RgzNY0RogUURmehdS17R9v1OJvXj6kPYOxRhjIhJOp4A/w3mPojBodgDI9CqorujdrUfo16cHU0antncoxhgTkXDqKD4FjFHVLjt4kNeOn6gkK7uYK8+17sSNMZ1POFetQ5YkWmfl9jzwwaJpVoltjOl8wnmieEdEfo7TxXhl/UxVfd+zqLqQ2jo/q7blMzUzjdRkq8Q2xnQ+4SSKz7r/fzJontVRhGnbviJOlldzvlViG2M6qXASxUK3644zRGSSR/F0Oe9ZJbYxppNrMlGISP2V7TURWQz4cJ4kEoCXgLFeB9fZHTtRSdYBq8Q2xnRuoZ4onuLDIU+LgubXAS94FlEXsnKbVWIbYzq/JhOFql4MICJ/UtXPt11IXUNtnZ/V260S2xjT+YUqehrvDlD0u8bexLZWT6Ft23fcqcSeYZXYxpjOLVTR0y+BK4DnG1kWVqsnEbkRuBenXuMBVX2owXIBHgH6AQXAp1W1RERuAX7Gh2+Dv6aq9zR3vI6kvjvxKZlWiW2M6dxCJYot7v83q+rqSHcsIkOAnwCzgCpgjYisqO9Q0B1W9RXgP1X1DRH5KfAd4G5gDnCXqj4V6XE7gvpK7KvOG2WV2MaYTi9UorhRRB4GHgpq9XSGqhY3s++lwPL69UTkOeA64D53+UygXFXfcKfvB/q6P88BxojId4AdwFdVtSSsT9QB1FdiL5w6uL1DMcaYVguVKP4FHMJJEEUNlgVwuhwPJQPID5rOB+YGTY8BCkTkCWAGbkIIWvenwAacBPI74KZmjndGWlrvcFdtVHp6nxZvW1vnZ83OAuZMGISMTm9VHA21Ji4vWVyRsbgiY3FFxou4QrV6+hLwJRFZqaqLWrBvXyPz/A2OvRhYpKqbROTHwK+Bz6rqNfUrud2HZEdy4KKiMvz+QOQR45zkY8dOtWhbgM16lJJTVcyfOKBV+4l2XF6xuCJjcUXG4opMS+OKifGFvMFutgC9hUkC4AgwKGh6MBDcuWABsFdVN7nTTwFzRSRFRL4etJ4PZzyMTuHd+jGxM21MbGNM1+BlTevbwBIRSReRJOBa4I2g5WuAdBGZ5k5fCWwGyoBvi8g8d/6dwIsexhk19ZXYi6ZlEBPT2AOVMcZ0Pp4lClU9AtwDrAC2Ak+q6gYRWSYis1W1ErgGeFREsoALgG+oah3OGBgPi8hunFZT3/YqzmhauS0Pn1ViG2O6mHA6BWwxVX0SeLLBvMuCfl7PRyu46+evwmkV1Wk4Y2LnM210f3sT2xjTpVgj/yjZuvc4peXVnD/d+nUyxnQtliii5L1teaQm92CKVWIbY7oYSxRRcKqiml0HilkwebBVYhtjuhxLFFGQdaCYADBtjD1NGGO6HksUUbAju4jePeMZNSi5vUMxxpios0TRSv5AgB3ZxUzOTLViJ2NMl2SJopVy8k9RVlljldjGmC7LEkUr7cguwgdMHmXjThhjuiZLFK20I7uIURnJ9ElKaO9QjDHGE5YoWuFURTUH8kqt2MkY06VZomiFnW6zWEsUxpiuzBJFK9Q3ix05uGMOYGKMMdFgiaKF/P4AO7OLmZKZSozPmsUaY7ouSxQtdKCg1JrFGmO6BUsULbRjv9MsdpI1izXGdHGWKFpoR3axNYs1xnQLlihaoLSimpz8UhsX2xjTLViiaIGsbLdZ7GhLFMaYrs8SRQvsyC6iT1I8IwZZs1hjTNdniSJCfn+AnQeKmTzKmsUaY7oHSxQROtMs1oqdjDHdRJyXOxeRG4F7gQTgAVV9qMFyAR4B+gEFwKdVtUREhgN/AwYACtykqmVexhquHfuL8Plg8ihLFMaY7sGzJwoRGQL8BDgPmAbcLiITg5b7gFeAn6rqNGAL8B138e+B36vqeGAT8H2v4ozUjuwiMgcn07tnfHuHYowxbcLLoqelwHJVLVbVcuA54Lqg5TOBclV9w52+H3hIROKBRe76AI8Dn/QwzrA5zWJP2dvYxphuxcuipwwgP2g6H5gbND0GKBCRJ4AZwA7gq0B/oFRVa4O2G+phnGGzZrHGmO7Iy0TRWJMgf4NjLwYWqeomEfkx8Gvge81s16y0tN6RrH6W9PTGm73qEaVv7x7MnpzRLuNjNxVXe7O4ImNxRcbiiowXcXmZKI4AC4OmBwN5QdMFwF5V3eROP4VT3HQMSBaRWFWta2S7ZhUVleH3B1oUdHp6H44dO3XWfL8/wObdhUwd3Z+ioravV28qrvZmcUXG4oqMxRWZlsYVE+MLeYPtZR3F28ASEUkXkSTgWuCNoOVrgHQRmeZOXwlsVtUaYBVwvTv/FuB1D+MMy4H8UspP1zJltHUCaIzpXjxLFKp6BLgHWAFsBZ5U1Q0iskxEZqtqJXAN8KiIZAEXAN9wN/8yTiupXThPJfd6FWe4dmRbs1hjTPfk6XsUqvok8GSDeZcF/byej1Zw18/Pxam/6DC27y8iM8OaxRpjuh97MzsMpeXV5BRYs1hjTPdkiSIMOw8UAViiMMZ0S5YowrAju5hk6y3WGNNNWaJoht8fYGd2EZMz06y3WGNMt2SJohnZ9c1irdjJGNNNWaJoRn1vsZNG2fsTxpjuyRJFM7ZnFzE6I8WaxRpjui1LFCGcLK8mt+AUUzLtacIY031ZoghhZ7bbLNZ6izXGdGOWKELYkV1Ecq8Ehg+0ZrHGmO7LEkUT6vx+sg4UM2VUqjWLNcZ0a5YomnAg75TbW6wVOxljujdLFE3Y7vYWO3GkVWQbY7o3SxRN2JFdxOgh1izWGGMsUTTiZFmV2yzWip2MMcYSRSN2HigGYKolCmOMsUTRmPpmscMGNj2GrDHGdBeWKBqoq3ObxWZas1hjjAFLFGfRgyXWW6wxxgSxRNHA5j1HrbdYY4wJYomigc17Chk9JIVeidYs1hhjwBLFR5wsq2L/4ZPW2skYY4LEeblzEbkRuBdIAB5Q1YcaLP8B8AWgxJ31qKo+1NR8L2MFZ2xswOonjDEmiGeJQkSGAD8BZgFVwBoRWaGqu4JWmwN8WlXXNti8qfme2pFdRL8+PRhuzWKNMeYML4uelgLLVbVYVcuB54DrGqwzG7hbRLaLyO9EJLGZ+Z6p7y125vgB+KxZrDHGnOFlosgA8oOm84Gh9RMi0hvYAnwTmAn0Bb7f1HwP4wSgusZPbZ2fRdOHNr+yMcZ0I75AIODJjkXke0CSqt7rTt8GzFbVO5pYfwbwJ1WdEc78JowEDrQ05ppaP/FxVr9vjOm2RgE5DWd6WZl9BFgYND0YyKufEJHhwFJV/ZM7ywfUNDU/kgMXFZXh97csAaan9+HYsVMt2tZLFldkLK7IWFyR6WpxxcT4SEtrum7Wy0TxNvBDEUkHyoFrgduDllcCPxeRFTgZ7CvAiyHmG2OMaQeelbOo6hHgHmAFsBV4UlU3iMgyEZmtqseALwL/BBTnyeFXTc33Kk5jjDGhefoehao+CTzZYN5lQT8/DzzfyHaNzjfGGNP2rObWGGNMSJYojDHGhGSJwhhjTEie1lG0g1hwmnq1Rmu394rFFRmLKzIWV2S6UlxB28Q2ttyzF+7ayXnAqvYOwhhjOqmFwOqGM7taouiB06FgPlDXzrEYY0xnEYvzUvRGnE5cP6KrJQpjjDFRZpXZxhhjQrJEYYwxJiRLFMYYY0KyRGGMMSYkSxTGGGNCskRhjDEmJEsUxhhjQupqXXiERURuBO4FEoAHVPWhBsunA48CKcBK4A5VrW2DuP4f8Cl38jVV/XaD5T8AvgCUuLMebRi7R3EtBwby4UiDX1TV9UHLlwK/BnoCz9QPf9sGcd0G3Bk0axTwV1W9M2idNjtnIpIMrAGuUNWccM6LO6Lj34ABOOOv3KSqZR7HdTvwNSAAbML5fVY32OYW4GdAoTvrNVW9x+O4/oTzZnC5u8qPVPXFBttMx+O/zeC4gInA/UGLhwDrVfWKBtu0xfk66/rQVt+xbpcoRGQI8BNgFs4biGtEZIWq7gpa7W/Abaq6TkT+CPwH8LDHcS0FLgJm4PwBvyEi1zT4Q5kDfFpV13oZS4O4fMB4YHhjf5Ai0hP4E3A+cAh4TUQuVdXXvY5NVR8DHnPjmAS8BPywwWptcs5EZB7OBWycOx3uefk98HtVfVpEvg98H7jbw7jGAd/C+f6fAh7HGUXygQabzgHuUtWnohVLqLiCjrlIVfNDbOrp32bDuFR1GbDMXTYI+Dfw9UY29fp8NXZ9uAEnOXn+HeuORU9LgeWqWqyq5cBzwHX1C0VkBNBTVde5sx4HPtkGceUD31DValWtAXYDwxusMxu4W0S2i8jvRCSxDeISnC/m6yKyTUTubLB8LrBXVQ+4ieRvtM35auhh4HuqerzB/LY6Z/+Bc8GtHxe+2fMiIvHAIpzvIHjzXWsYVxXwJVUtVdUAsIOzv2fgXPhucX/nfxORfl7GJSK93DgedX9XPxKRj1yf2uhvs+H5CvYL4A+qureRZV6fr8auD+Noo+9Yd0wUGTgnvV4+MDSC5Z5Q1az6PwARGQtcj3sn487rDWwBvgnMBPri3Bl4rR/wDnA1sAS4Q0QuDFreLucrmHu31VNVn20wv83OmarepqrBHVKGc176A6VBT2pRP3cN41LVXFV9G8Adz/5O4OVGNs3HeTqbjnO3+jsv48Ip2lwOfB6Yj1ME9YUGm3n+XWskLuDM3+Ri4H+b2NTr89XY9cFPG33Hul3RE84Y3A35I1juKbcI5TXgm8F3Lm6Z4mVB6/0Kp2gjquWgDblFNvXFNuXu4/5lwFvuvHY9X64v4pTTfkR7nTNXOOel3c6dWwT7OvBHVX234XJVvSZo3Z8D2V7Go6rZQPAxfwvcglMMVK89v2u34xTfnNVhHrTd+Qq+PuDUGUqDVTz5jnXHJ4ojwKCg6cF89DGzueWeEZFzce7ev6OqTzRYNlxEPh80y8eHlctexnSeiCwJcdx2O18AIpKAU0b7SiPL2uWcucI5L8eAZBGJDbFO1InIeJyy9idU9ceNLE8RkeByeM/Pm4hMEZFrmzlme37XrgaebmxBW52vRq4PbfYd646J4m1giYiki0gScC3wRv1CVc0FTru/FHDuajyvmBWRYTiVsTeqamNfyErg5yIyyq1g/grwYiPrRVtf4BcikigifYBbGxx3PSAiMsb9Mt5IG5yvIFOBD9z6poba65xBGOfFLWtehVOMAG3wXXN/h/8C7lXVXzWxWhnwbbdiF5ziKa/Pmw/4jYj0c8vVb294zHb82+yPU7R5oIlVPD9fTVwf2uw71u0ShaoewSl6WAFsBZ5U1Q0iskxEZrur3QQ8ICK7gV40XS4ZTd8EEoFfi8hW998d9XGp6jGcIpZ/4jRx8wFN/aFHjaq+ivOouwXYDPxJVde68WWo6mngs8DzwC5gDx9WnLWFTOBw8Iz2PmcAoc6LiDwmIle5q34ZuF1EduGUy3vdtPg2nPqAbwZ9z+4LjktV63CaYT7s/g3MAr7d9C5bT1W3A/+D86SzC9ha34KoA/xtnvUdc+Nqy/N11vUB5/v1WdrgO2bjURhjjAmp2z1RGGOMiYwlCmOMMSFZojDGGBOSJQpjjDEhWaIwxhgTkiUKYzoAEblNRL7s/nyHiHynvWMypl537MLDmI7oPGAngKr+oZ1jMeYj7D0K0y25d+xfwOlqeyVOFw3j+LDb5liclwy/pqqlIpKD0/PmEpxeTp+pHy9ERK7kw/FNKnD66VorIj8EzsHpNmE78A3gEZwX3gYBuTgvap0L/BHnTfL7gXSgv6re6fbt8zsgDacX31+p6l9EZDFOd/nZwGSgB/AVVV0hIufh9H0V627zP6r6fFRPoOlWrOjJdDsicjHOG61zcN6i7eMu+g5QC8xS1Wk4feL8NGjT3qq6EFgAfNXtGmQszsX9MlWdgdP1xAtut9kAI4CZqvoZ4NPAWlU9B+dt3wrgZnfMkVdoMIiWiMS583+rqlOBS4H7ReQcd5V5OIljBk6i+aE7/0fAr1V1Fk5vrBe06oSZbs8ShemOLgOeVdUT7pgM9RfnK4CPA1vcLhKuxhnhrN7LcKYbmKNAKnAhzhPDO+42f8fpnXOMu826+i6eVfVBnIGy7sIZTGYy0DtEnOOARFV9wd0+D6e7hkvc5bmqutX9+X03HoB/AA+JyN9xEuH3wjkpxjTFEoXpjmr5aPfLde7/scB/qup0VZ2OM/jQdUHrVQb9HHD3EQu8U7+Nu9183PoGnA7jABCRnwH34fTo+X84nfM11g10vcb+PmOA+BDxoKqPAFNwuoK/GNguIikhjmNMSJYoTHf0GnBt0MXzCzgX2jeBO0UkQZzR1R7F6agulOXARW7X3YjIZTj1EY2NpHcx8BtV/SvOE8mFOIkGnOQV32B9BapF5BPuvjNwejt+ixBEZA0wQ1UfxykK64szAJUxLWKJwnQ7qrocJwmsFZFNQApOfcGPgRycSuxdOHfo32hmX1k4F+OnRWSbu4+rmuj2/D7glyKyGXgBWM2HRVSvA18Tke8G7bsGp/jrP0VkO04X+fep6opmPuK3gftEZAtOL8k/UtWcZrYxpknW6sl0O26X1QtU9X/d6buAeap6fegtjeme7D0K0x19ANwtIrfjFDkdxHkqMMY0wp4ojDHGhGR1FMYYY0KyRGGMMSYkSxTGGGNCskRhjDEmJEsUxhhjQrJEYYwxJqT/D/eliCiiI+UGAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
      },
-     "metadata": {},
+     "metadata": {
+      "needs_background": "light"
+     },
      "output_type": "display_data"
     }
    ],
    "source": [
     "plot = plot_fitness_evolution(evolved_estimator, metric=\"fitness\")\n",
-    "plt.show()\n"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[5.1, 2.4],\n",
+       "       [4. , 1. ],\n",
+       "       [1.4, 0.2],\n",
+       "       [6.3, 1.8],\n",
+       "       [1.5, 0.2],\n",
+       "       [6. , 2.5],\n",
+       "       [1.3, 0.3],\n",
+       "       [4.7, 1.5],\n",
+       "       [4.8, 1.4],\n",
+       "       [4. , 1.3],\n",
+       "       [5.6, 1.4],\n",
+       "       [4.5, 1.5],\n",
+       "       [4.7, 1.2],\n",
+       "       [4.6, 1.5],\n",
+       "       [4.7, 1.4],\n",
+       "       [1.4, 0.1],\n",
+       "       [4.5, 1.5],\n",
+       "       [4.4, 1.2],\n",
+       "       [1.4, 0.3],\n",
+       "       [1.3, 0.4],\n",
+       "       [4.9, 2. ],\n",
+       "       [4.5, 1.5],\n",
+       "       [1.9, 0.2],\n",
+       "       [1.4, 0.2],\n",
+       "       [4.8, 1.8],\n",
+       "       [1. , 0.2],\n",
+       "       [1.9, 0.4],\n",
+       "       [4.3, 1.3],\n",
+       "       [3.3, 1. ],\n",
+       "       [1.6, 0.4],\n",
+       "       [5.5, 1.8],\n",
+       "       [4.5, 1.5],\n",
+       "       [1.5, 0.2],\n",
+       "       [4.9, 1.8],\n",
+       "       [5.6, 2.2],\n",
+       "       [3.9, 1.4],\n",
+       "       [1.7, 0.3],\n",
+       "       [5.1, 1.6],\n",
+       "       [4.2, 1.5],\n",
+       "       [4. , 1.2],\n",
+       "       [5.5, 2.1],\n",
+       "       [1.3, 0.2],\n",
+       "       [5.1, 2.3],\n",
+       "       [1.6, 0.6],\n",
+       "       [1.5, 0.2],\n",
+       "       [3.5, 1. ],\n",
+       "       [5.5, 1.8],\n",
+       "       [5.7, 2.5],\n",
+       "       [5. , 1.5],\n",
+       "       [5.8, 1.8]])"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
     }
-   }
+   ],
+   "source": [
+    "# Convert the original input to the selected input\n",
+    "evolved_estimator.transform(X_test)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.6"
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -10,6 +10,8 @@ What's new in 0.9.1dev
 API Changes:
 ^^^^^^^^^^^^
 
+* `GAFeatureSelectionCV` now mimics the scikit-learn FeatureSelection algorithms API instead of Grid Search, this enables
+  easier implementation as one selection method that is closer to the scikit-learn API
 * Improved `GAFeatureSelectionCV` candidate generation when `max_features` is set, it also ensures
   there is at least one feature selected
 * `crossover_probability` and `mutation_probability` are now correctly passed to the mate and mutation

--- a/docs/tutorials/basic_usage.rst
+++ b/docs/tutorials/basic_usage.rst
@@ -251,22 +251,22 @@ During the training, the same log format is displayed as before:
 .. image:: ../images/basic_usage_train_log_5.PNG
 
 After fitting the model, we have some extra methods to use the model right away. It will use by default the best set of
-features it found, remember as the algorithm used only a subset, you have to select them from the
-``X_test array``, this is done like this:
+features it found, remember as the algorithm used only a subset, once you use method as `predict`, `predict_proba`,etc
+only the ``support_`` features will be used on those methods
 
 .. code:: python3
 
-    features = evolved_estimator.best_features_
+    features = evolved_estimator.support_ 
 
     # Predict only with the subset of selected features
-    y_predict_ga = evolved_estimator.predict(X_test[:, features])
+    y_predict_ga = evolved_estimator.predict(X_test)
     accuracy = accuracy_score(y_test, y_predict_ga)
 
 .. image:: ../images/basic_usage_accuracy_6.PNG
 
 In this case, we got an accuracy score in the test set of 0.98.
 
-Notice that the ``best_features_`` is a vector of bool values, each
+Notice that the ``support_`` is a vector of bool values, each
 position represents the index of the feature (column) and the value indicates
 if that features was selected (True) or not (False) by the algorithm.
 In this example, the algorithm, discarded all the noisy random variables we created

--- a/sklearn_genetic/algorithms.py
+++ b/sklearn_genetic/algorithms.py
@@ -16,6 +16,7 @@ def eaSimple(
     callbacks=None,
     verbose=True,
     estimator=None,
+    **kwargs
 ):
     """
     The base implementation is directly taken from: https://github.com/DEAP/deap/blob/master/deap/algorithms.py
@@ -205,6 +206,7 @@ def eaMuPlusLambda(
     callbacks=None,
     verbose=True,
     estimator=None,
+    **kwargs
 ):
     """
     The base implementation is directly taken from: https://github.com/DEAP/deap/blob/master/deap/algorithms.py
@@ -390,6 +392,7 @@ def eaMuCommaLambda(
     callbacks=None,
     verbose=True,
     estimator=None,
+    **kwargs
 ):
     """
     The base implementation is directly taken from: https://github.com/DEAP/deap/blob/master/deap/algorithms.py
@@ -564,3 +567,8 @@ def eaMuCommaLambda(
     eval_callbacks(**callbacks_end_args)
 
     return population, logbook, n_gen
+
+
+algorithms_factory = {"eaSimple": eaSimple,
+                      "eaMuPlusLambda": eaMuPlusLambda,
+                      "eaMuCommaLambda": eaMuCommaLambda}

--- a/sklearn_genetic/genetic_search.py
+++ b/sklearn_genetic/genetic_search.py
@@ -17,7 +17,7 @@ from sklearn.metrics._scorer import _check_multimetric_scoring
 
 from .parameters import Algorithms, Criteria
 from .space import Space
-from .algorithms import eaSimple, eaMuPlusLambda, eaMuCommaLambda
+from .algorithms import algorithms_factory
 from .callbacks.validations import check_callback
 from .schedules.validations import check_adapter
 from .utils.cv_scores import (
@@ -596,40 +596,9 @@ class GASearchCV(BaseSearchCV):
             The number of generations that the evolutionary algorithm ran
         """
 
-        if self.algorithm == Algorithms.eaSimple.value:
-
-            pop, log, gen = eaSimple(
-                pop,
-                self.toolbox,
-                cxpb=self.crossover_adapter,
-                stats=stats,
-                mutpb=self.mutation_adapter,
-                ngen=self.generations,
-                halloffame=hof,
-                callbacks=self.callbacks,
-                verbose=self.verbose,
-                estimator=self,
-            )
-
-        elif self.algorithm == Algorithms.eaMuPlusLambda.value:
-
-            pop, log, gen = eaMuPlusLambda(
-                pop,
-                self.toolbox,
-                mu=self.population_size,
-                lambda_=2 * self.population_size,
-                cxpb=self.crossover_adapter,
-                stats=stats,
-                mutpb=self.mutation_adapter,
-                ngen=self.generations,
-                halloffame=hof,
-                callbacks=self.callbacks,
-                verbose=self.verbose,
-                estimator=self,
-            )
-
-        elif self.algorithm == Algorithms.eaMuCommaLambda.value:
-            pop, log, gen = eaMuCommaLambda(
+        selected_algorithm = algorithms_factory.get(self.algorithm, None)
+        if selected_algorithm:
+            pop, log, gen = selected_algorithm(
                 pop,
                 self.toolbox,
                 mu=self.population_size,
@@ -1228,40 +1197,9 @@ class GAFeatureSelectionCV(BaseSearchCV):
             The number of generations that the evolutionary algorithm ran
         """
 
-        if self.algorithm == Algorithms.eaSimple.value:
-
-            pop, log, gen = eaSimple(
-                pop,
-                self.toolbox,
-                cxpb=self.crossover_adapter,
-                stats=stats,
-                mutpb=self.mutation_adapter,
-                ngen=self.generations,
-                halloffame=hof,
-                callbacks=self.callbacks,
-                verbose=self.verbose,
-                estimator=self,
-            )
-
-        elif self.algorithm == Algorithms.eaMuPlusLambda.value:
-
-            pop, log, gen = eaMuPlusLambda(
-                pop,
-                self.toolbox,
-                mu=self.population_size,
-                lambda_=2 * self.population_size,
-                cxpb=self.crossover_adapter,
-                stats=stats,
-                mutpb=self.mutation_adapter,
-                ngen=self.generations,
-                halloffame=hof,
-                callbacks=self.callbacks,
-                verbose=self.verbose,
-                estimator=self,
-            )
-
-        elif self.algorithm == Algorithms.eaMuCommaLambda.value:
-            pop, log, gen = eaMuCommaLambda(
+        selected_algorithm = algorithms_factory.get(self.algorithm, None)
+        if selected_algorithm:
+            pop, log, gen = selected_algorithm(
                 pop,
                 self.toolbox,
                 mu=self.population_size,

--- a/sklearn_genetic/genetic_search.py
+++ b/sklearn_genetic/genetic_search.py
@@ -861,6 +861,8 @@ class GAFeatureSelectionCV(MetaEstimatorMixin, SelectorMixin, BaseEstimator):
         parameters for the model.
     n_splits_ : int
         The number of cross-validation splits (folds/iterations).
+    n_features_in_ : int
+        Number of features seen (selected) during fit.
     refit_time_ : float
         Seconds used for refitting the best model on the whole dataset.
         This is present only if ``refit`` is not False.
@@ -1089,6 +1091,7 @@ class GAFeatureSelectionCV(MetaEstimatorMixin, SelectorMixin, BaseEstimator):
         """
         Main method of GAFeatureSelectionCV, starts the optimization
         procedure with to find the best features set
+
         Parameters
         ----------
         X : array-like of shape (n_samples, n_features)
@@ -1334,21 +1337,108 @@ class GAFeatureSelectionCV(MetaEstimatorMixin, SelectorMixin, BaseEstimator):
 
     @available_if(_estimator_has("decision_function"))
     def decision_function(self, X):
+        """Call decision_function on the estimator with the best found features.
+       Only available if ``refit=True`` and the underlying estimator supports
+       ``decision_function``.
+
+       Parameters
+       ----------
+       X : indexable, length n_samples
+           Must fulfill the input assumptions of the
+           underlying estimator.
+
+       Returns
+       -------
+       y_score : ndarray of shape (n_samples,) or (n_samples, n_classes) \
+               or (n_samples, n_classes * (n_classes-1) / 2)
+           Result of the decision function for `X` based on the estimator with
+           the best found parameters.
+       """
         return self.estimator.decision_function(self.transform(X))
 
     @available_if(_estimator_has("predict"))
     def predict(self, X):
+        """Call predict on the estimator with the best found features.
+        Only available if ``refit=True`` and the underlying estimator supports
+        ``predict``.
+
+        Parameters
+        ----------
+        X : indexable, length n_samples
+            Must fulfill the input assumptions of the
+            underlying estimator.
+
+        Returns
+        -------
+        y_pred : ndarray of shape (n_samples,)
+            The predicted labels or values for `X` based on the estimator with
+            the best found parameters.
+        """
         return self.estimator.predict(self.transform(X))
 
     @available_if(_estimator_has("predict_log_proba"))
     def predict_log_proba(self, X):
+        """Call predict_log_proba on the estimator with the best found features.
+        Only available if ``refit=True`` and the underlying estimator supports
+        ``predict_log_proba``.
+
+        Parameters
+        ----------
+        X : indexable, length n_samples
+            Must fulfill the input assumptions of the
+            underlying estimator.
+
+        Returns
+        -------
+        y_pred : ndarray of shape (n_samples,) or (n_samples, n_classes)
+            Predicted class log-probabilities for `X` based on the estimator
+            with the best found parameters. The order of the classes
+            corresponds to that in the fitted attribute :term:`classes_`.
+        """
         return self.estimator.predict_log_proba(self.transform(X))
 
     @available_if(_estimator_has("predict_proba"))
     def predict_proba(self, X):
+        """Call predict_proba on the estimator with the best found features.
+        Only available if ``refit=True`` and the underlying estimator supports
+        ``predict_proba``.
+
+        Parameters
+        ----------
+        X : indexable, length n_samples
+            Must fulfill the input assumptions of the
+            underlying estimator.
+
+        Returns
+        -------
+        y_pred : ndarray of shape (n_samples,) or (n_samples, n_classes)
+            Predicted class probabilities for `X` based on the estimator with
+            the best found parameters. The order of the classes corresponds
+            to that in the fitted attribute :term:`classes_`.
+        """
         return self.estimator.predict_proba(self.transform(X))
 
     @available_if(_estimator_has("score"))
     def score(self, X, y):
+        """Return the score on the given data, if the estimator has been refit.
+        This uses the score defined by ``scoring`` where provided, and the
+        ``best_estimator_.score`` method otherwise.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Input data, where `n_samples` is the number of samples and
+            `n_features` is the number of features.
+        y : array-like of shape (n_samples, n_output) \
+            or (n_samples,), default=None
+            Target relative to X for classification or regression;
+            None for unsupervised learning.
+
+        Returns
+        -------
+        score : float
+            The score defined by ``scoring`` if provided, and the
+            ``best_estimator_.score`` method otherwise.
+        """
         return self.estimator.score(self.transform(X), y)
 

--- a/sklearn_genetic/schedules/base.py
+++ b/sklearn_genetic/schedules/base.py
@@ -38,4 +38,4 @@ class BaseAdapter(ABC):
         """
         Run one iteration of the transformation
         """
-        raise NotImplementedError("Scheduler must override step()")
+        raise NotImplementedError("Scheduler must override step()")  # pragma: no cover

--- a/sklearn_genetic/tests/test_feature_selection.py
+++ b/sklearn_genetic/tests/test_feature_selection.py
@@ -52,18 +52,18 @@ def test_expected_ga_results():
     )
 
     evolved_estimator.fit(X_train, y_train)
-    features = evolved_estimator.best_features_
+    features = evolved_estimator.support_
 
     assert check_is_fitted(evolved_estimator) is None
     assert features.shape[0] == X.shape[1]
     assert len(evolved_estimator) == generations + 1  # +1 random initial population
-    assert len(evolved_estimator.predict(X_test[:, features])) == len(X_test)
-    assert evolved_estimator.score(X_train[:, features], y_train) >= 0
-    assert len(evolved_estimator.decision_function(X_test[:, features])) == len(X_test)
-    assert len(evolved_estimator.predict_proba(X_test[:, features])) == len(X_test)
-    assert len(evolved_estimator.predict_log_proba(X_test[:, features])) == len(X_test)
-    assert evolved_estimator.score(X_test[:, features], y_test) == accuracy_score(
-        y_test, evolved_estimator.predict(X_test[:, features])
+    assert len(evolved_estimator.predict(X_test)) == len(X_test)
+    assert evolved_estimator.score(X_train, y_train) >= 0
+    assert len(evolved_estimator.decision_function(X_test)) == len(X_test)
+    assert len(evolved_estimator.predict_proba(X_test)) == len(X_test)
+    assert len(evolved_estimator.predict_log_proba(X_test)) == len(X_test)
+    assert evolved_estimator.score(X_test, y_test) == accuracy_score(
+        y_test, evolved_estimator.predict(X_test)
     )
     assert bool(evolved_estimator.get_params())
     assert len(evolved_estimator.hof) == evolved_estimator.keep_top_k
@@ -159,18 +159,18 @@ def test_expected_algorithms_callbacks(algorithm, callback):
     )
 
     evolved_estimator.fit(X_train, y_train, callbacks=callback)
-    features = evolved_estimator.best_features_
+    features = evolved_estimator.support_
 
     assert check_is_fitted(evolved_estimator) is None
     assert features.shape[0] == X.shape[1]
     assert len(evolved_estimator) <= generations + 1  # +1 random initial population
-    assert len(evolved_estimator.predict(X_test[:, features])) == len(X_test)
-    assert evolved_estimator.score(X_train[:, features], y_train) >= 0
-    assert len(evolved_estimator.decision_function(X_test[:, features])) == len(X_test)
-    assert len(evolved_estimator.predict_proba(X_test[:, features])) == len(X_test)
-    assert len(evolved_estimator.predict_log_proba(X_test[:, features])) == len(X_test)
-    assert evolved_estimator.score(X_test[:, features], y_test) == accuracy_score(
-        y_test, evolved_estimator.predict(X_test[:, features])
+    assert len(evolved_estimator.predict(X_test)) == len(X_test)
+    assert evolved_estimator.score(X_train, y_train) >= 0
+    assert len(evolved_estimator.decision_function(X_test)) == len(X_test)
+    assert len(evolved_estimator.predict_proba(X_test)) == len(X_test)
+    assert len(evolved_estimator.predict_log_proba(X_test)) == len(X_test)
+    assert evolved_estimator.score(X_test, y_test) == accuracy_score(
+        y_test, evolved_estimator.predict(X_test)
     )
     assert bool(evolved_estimator.get_params())
     assert len(evolved_estimator.hof) == evolved_estimator.keep_top_k
@@ -208,11 +208,9 @@ def test_negative_criteria():
     )
 
     evolved_estimator.fit(X_train_b, y_train_b)
-    features = evolved_estimator.best_features_
 
     assert check_is_fitted(evolved_estimator) is None
-    assert len(evolved_estimator.predict(X_test_b[:, features])) == len(X_test_b)
-    assert evolved_estimator.score(X_train_b[:, features], y_train_b) <= 0
+    assert len(evolved_estimator.predict(X_test_b)) == len(X_test_b)
 
 
 def test_wrong_criteria():
@@ -348,27 +346,27 @@ def test_expected_ga_max_features():
     )
 
     evolved_estimator.fit(X_noise_train, y_train)
-    features = evolved_estimator.best_features_
+    features = evolved_estimator.support_
 
     assert check_is_fitted(evolved_estimator) is None
     assert features.shape[0] == X_noise_train.shape[1]
     assert sum(features) <= max_features
     assert len(evolved_estimator) == generations + 1  # +1 random initial population
-    assert len(evolved_estimator.predict(X_noise_test[:, features])) == len(
+    assert len(evolved_estimator.predict(X_noise_test)) == len(
         X_noise_test
     )
-    assert evolved_estimator.score(X_noise_train[:, features], y_train) >= 0
-    assert len(evolved_estimator.decision_function(X_noise_test[:, features])) == len(
+    assert evolved_estimator.score(X_noise_train, y_train) >= 0
+    assert len(evolved_estimator.decision_function(X_noise_test)) == len(
         X_noise_test
     )
-    assert len(evolved_estimator.predict_proba(X_noise_test[:, features])) == len(
+    assert len(evolved_estimator.predict_proba(X_noise_test)) == len(
         X_noise_test
     )
-    assert len(evolved_estimator.predict_log_proba(X_noise_test[:, features])) == len(
+    assert len(evolved_estimator.predict_log_proba(X_noise_test)) == len(
         X_noise_test
     )
-    assert evolved_estimator.score(X_noise_test[:, features], y_test) == accuracy_score(
-        evolved_estimator.predict(X_noise_test[:, features]), y_test
+    assert evolved_estimator.score(X_noise_test, y_test) == accuracy_score(
+        evolved_estimator.predict(X_noise_test), y_test
     )
     assert bool(evolved_estimator.get_params())
     assert len(evolved_estimator.hof) == evolved_estimator.keep_top_k
@@ -424,18 +422,18 @@ def test_expected_ga_multimetric():
     )
 
     evolved_estimator.fit(X_train, y_train)
-    features = evolved_estimator.best_features_
+    features = evolved_estimator.support_
 
     assert check_is_fitted(evolved_estimator) is None
     assert features.shape[0] == X.shape[1]
     assert len(evolved_estimator) == generations + 1  # +1 random initial population
-    assert len(evolved_estimator.predict(X_test[:, features])) == len(X_test)
-    assert evolved_estimator.score(X_train[:, features], y_train) >= 0
-    assert len(evolved_estimator.decision_function(X_test[:, features])) == len(X_test)
-    assert len(evolved_estimator.predict_proba(X_test[:, features])) == len(X_test)
-    assert len(evolved_estimator.predict_log_proba(X_test[:, features])) == len(X_test)
-    assert evolved_estimator.score(X_test[:, features], y_test) == accuracy_score(
-        y_test, evolved_estimator.predict(X_test[:, features])
+    assert len(evolved_estimator.predict(X_test)) == len(X_test)
+    assert evolved_estimator.score(X_train, y_train) >= 0
+    assert len(evolved_estimator.decision_function(X_test)) == len(X_test)
+    assert len(evolved_estimator.predict_proba(X_test)) == len(X_test)
+    assert len(evolved_estimator.predict_log_proba(X_test)) == len(X_test)
+    assert evolved_estimator.score(X_test, y_test) == accuracy_score(
+        y_test, evolved_estimator.predict(X_test)
     )
     assert bool(evolved_estimator.get_params())
     assert len(evolved_estimator.hof) == evolved_estimator.keep_top_k
@@ -487,18 +485,18 @@ def test_expected_ga_callable_score():
     )
 
     evolved_estimator.fit(X_train, y_train)
-    features = evolved_estimator.best_features_
+    features = evolved_estimator.support_
 
     assert check_is_fitted(evolved_estimator) is None
     assert features.shape[0] == X.shape[1]
     assert len(evolved_estimator) == generations + 1  # +1 random initial population
-    assert len(evolved_estimator.predict(X_test[:, features])) == len(X_test)
-    assert evolved_estimator.score(X_train[:, features], y_train) >= 0
-    assert len(evolved_estimator.decision_function(X_test[:, features])) == len(X_test)
-    assert len(evolved_estimator.predict_proba(X_test[:, features])) == len(X_test)
-    assert len(evolved_estimator.predict_log_proba(X_test[:, features])) == len(X_test)
-    assert evolved_estimator.score(X_test[:, features], y_test) == accuracy_score(
-        y_test, evolved_estimator.predict(X_test[:, features])
+    assert len(evolved_estimator.predict(X_test)) == len(X_test)
+    assert evolved_estimator.score(X_train, y_train) >= 0
+    assert len(evolved_estimator.decision_function(X_test)) == len(X_test)
+    assert len(evolved_estimator.predict_proba(X_test)) == len(X_test)
+    assert len(evolved_estimator.predict_log_proba(X_test)) == len(X_test)
+    assert evolved_estimator.score(X_test, y_test) == accuracy_score(
+        y_test, evolved_estimator.predict(X_test)
     )
     assert bool(evolved_estimator.get_params())
     assert len(evolved_estimator.hof) == evolved_estimator.keep_top_k
@@ -558,18 +556,18 @@ def test_expected_ga_schedulers():
     )
 
     evolved_estimator.fit(X_train, y_train)
-    features = evolved_estimator.best_features_
+    features = evolved_estimator.support_
 
     assert check_is_fitted(evolved_estimator) is None
     assert features.shape[0] == X.shape[1]
     assert len(evolved_estimator) == generations + 1  # +1 random initial population
-    assert len(evolved_estimator.predict(X_test[:, features])) == len(X_test)
-    assert evolved_estimator.score(X_train[:, features], y_train) >= 0
-    assert len(evolved_estimator.decision_function(X_test[:, features])) == len(X_test)
-    assert len(evolved_estimator.predict_proba(X_test[:, features])) == len(X_test)
-    assert len(evolved_estimator.predict_log_proba(X_test[:, features])) == len(X_test)
-    assert evolved_estimator.score(X_test[:, features], y_test) == accuracy_score(
-        y_test, evolved_estimator.predict(X_test[:, features])
+    assert len(evolved_estimator.predict(X_test)) == len(X_test)
+    assert evolved_estimator.score(X_train, y_train) >= 0
+    assert len(evolved_estimator.decision_function(X_test)) == len(X_test)
+    assert len(evolved_estimator.predict_proba(X_test)) == len(X_test)
+    assert len(evolved_estimator.predict_log_proba(X_test)) == len(X_test)
+    assert evolved_estimator.score(X_test, y_test) == accuracy_score(
+        y_test, evolved_estimator.predict(X_test)
     )
     assert bool(evolved_estimator.get_params())
     assert len(evolved_estimator.hof) == evolved_estimator.keep_top_k

--- a/sklearn_genetic/tests/test_utils.py
+++ b/sklearn_genetic/tests/test_utils.py
@@ -1,0 +1,7 @@
+from ..utils.tools import check_bool_individual
+
+
+def test_bool_array():
+    assert sum(check_bool_individual([1, 1, 1, 0, 1, 0, 1, 0])) == 5
+    assert sum(check_bool_individual([0, 0, 0, 0, 0, 0])) == 1
+


### PR DESCRIPTION
This PR addresses the issue mentioned in #110 by updating the GAFeatureSelectionCV , now it inherits its methods from MetaEstimatorMixin, SelectorMixin, and BaseEstimator instead of BaseSearchCV, this allows to use the selected features out of the box without the necessity of explicitly selecting them like in the previous API (i.e X[:, features])