### PR TITLE
Adjust two tests for scikit-learn 1.6

### DIFF
--- a/sklearn_genetic/tests/test_feature_selection.py
+++ b/sklearn_genetic/tests/test_feature_selection.py
@@ -194,7 +194,7 @@ def test_negative_criteria():
     evolved_estimator = GAFeatureSelectionCV(
         clf,
         cv=3,
-        scoring="max_error",
+        scoring="neg_max_error",
         population_size=5,
         generations=generations,
         tournament_size=3,

--- a/sklearn_genetic/tests/test_genetic_search.py
+++ b/sklearn_genetic/tests/test_genetic_search.py
@@ -259,7 +259,7 @@ def test_negative_criteria():
     evolved_estimator = GASearchCV(
         clf,
         cv=3,
-        scoring="max_error",
+        scoring="neg_max_error",
         population_size=5,
         generations=generations,
         tournament_size=3,


### PR DESCRIPTION
Scoring "max_error" was renamed to "neg_max_error" in https://github.com/scikit-learn/scikit-learn/pull/29462.

Fixes #160.