### PR TITLE
ci: commit conda recipe before rebase to avoid dirty-tree failure

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -202,11 +202,11 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git pull --rebase origin master
           git add conda.recipe/meta.yaml
           if git diff --staged --quiet; then
             echo "No changes to conda recipe."
           else
             git commit -m "ci: update conda recipe for ${{ github.ref_name }}"
+            git pull --rebase origin master
             git push origin HEAD:master
           fi


### PR DESCRIPTION
The conda-sync job ran `git pull --rebase` while the recipe update left an unstaged change, causing rebase to abort with exit code 128. Commit the recipe first so the working tree is clean before rebasing.