### PR TITLE
Add PR template and SECURITY.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## Summary
+
+<!-- What does this PR do? One or two sentences. -->
+
+## Related Issue
+
+Closes #<!-- issue number -->
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Documentation update
+- [ ] Refactor / cleanup
+- [ ] Other (describe):
+
+## Checklist
+
+- [ ] Tests pass locally (`pytest sklearn_genetic/`)
+- [ ] Code is formatted with Black (`black sklearn_genetic/`)
+- [ ] New functionality is covered by tests
+- [ ] Documentation updated if needed

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 .. -*- mode: rst -*-
 
-|Tests|_ |Codecov|_ |PythonVersion|_ |PyPi|_ |Conda|_ |Docs|_
+|Tests|_ |Codecov|_ |PythonVersion|_ |PyPi|_ |Conda|_ |Docs|_ |GoodFirstIssues|_
 
 .. |Tests| image:: https://github.com/rodrigo-arenas/Sklearn-genetic-opt/actions/workflows/ci-tests.yml/badge.svg?branch=master
 .. _Tests: https://github.com/rodrigo-arenas/Sklearn-genetic-opt/actions/workflows/ci-tests.yml
@@ -19,6 +19,9 @@
 
 .. |Docs| image:: https://img.shields.io/badge/docs-GitHub%20Pages-blue
 .. _Docs: https://sklearngeneticopt.rodrigo-arenas.com/
+
+.. |GoodFirstIssues| image:: https://img.shields.io/github/issues/rodrigo-arenas/Sklearn-genetic-opt/good%20first%20issue?label=good%20first%20issues&color=7057ff
+.. _GoodFirstIssues: https://github.com/rodrigo-arenas/Sklearn-genetic-opt/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22
 
 .. |Contributors| image:: https://contributors-img.web.app/image?repo=rodrigo-arenas/sklearn-genetic-opt
 .. _Contributors: https://github.com/rodrigo-arenas/Sklearn-genetic-opt/graphs/contributors

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.13.x  | :white_check_mark: |
+| < 0.13  | :x:                |
+
+## Reporting a Vulnerability
+
+Please **do not** open a public GitHub issue for security vulnerabilities.
+
+Report them privately via GitHub's [Security Advisories](https://github.com/rodrigo-arenas/Sklearn-genetic-opt/security/advisories/new) feature.
+
+Include:
+- A description of the vulnerability and its potential impact
+- Steps to reproduce
+- Any suggested fix (optional)
+
+You can expect an acknowledgement within **72 hours** and a resolution or update within **14 days**.


### PR DESCRIPTION
Adds two missing community health files:
- .github/pull_request_template.md: standardizes PR descriptions with a checklist
- SECURITY.md: documents how to report vulnerabilities privately