### PR TITLE
fix: add repr for space dimensions

### DIFF
--- a/sklearn_genetic/space/space.py
+++ b/sklearn_genetic/space/space.py
@@ -58,6 +58,12 @@ class Integer(BaseDimension):
         if self.distribution == IntegerDistributions.uniform.value:
             self.rvs = stats.randint.rvs
 
+    def __repr__(self):
+        return (
+            f"{self.__class__.__name__}(lower={self.lower}, upper={self.upper}, "
+            f"distribution={self.distribution!r})"
+        )
+
     def sample(self):
         """Sample a random value from the assigned distribution"""
 
@@ -115,6 +121,12 @@ class Continuous(BaseDimension):
             self.shifted_upper = self.upper - self.lower
         elif self.distribution == ContinuousDistributions.log_uniform.value:
             self.rvs = stats.loguniform.rvs
+
+    def __repr__(self):
+        return (
+            f"{self.__class__.__name__}(lower={self.lower}, upper={self.upper}, "
+            f"distribution={self.distribution!r})"
+        )
 
     def sample(self):
         """Sample a random value from the assigned distribution"""
@@ -174,6 +186,9 @@ class Categorical(BaseDimension):
 
         if self.distribution == CategoricalDistributions.choice.value:
             self.rvs = self.rng.choice if self.rng else random.choice
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}(choices={self.choices!r})"
 
     def sample(self):
         """Sample a random value from the assigned distribution"""

--- a/sklearn_genetic/space/space.py
+++ b/sklearn_genetic/space/space.py
@@ -188,7 +188,10 @@ class Categorical(BaseDimension):
             self.rvs = self.rng.choice if self.rng else random.choice
 
     def __repr__(self):
-        return f"{self.__class__.__name__}(choices={self.choices!r})"
+        if self.priors is None:
+            return f"{self.__class__.__name__}(choices={self.choices!r})"
+
+        return f"{self.__class__.__name__}(choices={self.choices!r}, priors={self.priors!r})"
 
     def sample(self):
         """Sample a random value from the assigned distribution"""

--- a/sklearn_genetic/space/tests/test_space.py
+++ b/sklearn_genetic/space/tests/test_space.py
@@ -16,6 +16,10 @@ from ..base import BaseDimension
             Categorical(["rbf", "linear", "poly"]),
             "Categorical(choices=['rbf', 'linear', 'poly'])",
         ),
+        (
+            Categorical(["a", "b"], priors=[0.8, 0.2]),
+            "Categorical(choices=['a', 'b'], priors=[0.8, 0.2])",
+        ),
     ],
 )
 def test_space_repr(space_object, expected_repr):

--- a/sklearn_genetic/space/tests/test_space.py
+++ b/sklearn_genetic/space/tests/test_space.py
@@ -5,6 +5,24 @@ from ..base import BaseDimension
 
 
 @pytest.mark.parametrize(
+    "space_object, expected_repr",
+    [
+        (
+            Continuous(0.01, 1.0, distribution="log-uniform"),
+            "Continuous(lower=0.01, upper=1.0, distribution='log-uniform')",
+        ),
+        (Integer(10, 200), "Integer(lower=10, upper=200, distribution='uniform')"),
+        (
+            Categorical(["rbf", "linear", "poly"]),
+            "Categorical(choices=['rbf', 'linear', 'poly'])",
+        ),
+    ],
+)
+def test_space_repr(space_object, expected_repr):
+    assert repr(space_object) == expected_repr
+
+
+@pytest.mark.parametrize(
     "data_object, parameters",
     [
         (Continuous, {"lower": 0.01, "upper": 0.5, "distribution": "log-uniform"}),


### PR DESCRIPTION
## Summary
- Add readable `__repr__` output for `Continuous`, `Integer`, and `Categorical` space dimensions.
- Add regression coverage for the expected repr strings.

## Why
The default object-address representation makes search-space definitions harder to inspect while debugging `param_grid` values.

## Test Plan
- [x] `pytest sklearn_genetic/space/tests/test_space.py::test_space_repr`
- [x] `black --check sklearn_genetic/space/space.py sklearn_genetic/space/tests/test_space.py`
- [x] `pytest sklearn_genetic/space/tests/test_space.py`
- [x] `pytest sklearn_genetic/`

Closes #206
