### PR TITLE
Improve invalid param_grid error messages

### DIFF
--- a/sklearn_genetic/space/space.py
+++ b/sklearn_genetic/space/space.py
@@ -200,7 +200,9 @@ def check_space(param_grid: dict = None):
     for key, value in param_grid.items():
         if not isinstance(value, BaseDimension):
             raise ValueError(
-                f"{key} must be a valid instance of Integer, Categorical or Continuous classes"
+                f"Invalid param_grid entry for '{key}': expected a space object "
+                f"(Continuous, Integer, or Categorical), got {type(value).__name__} instead.\n"
+                f"Example: param_grid = {{'{key}': Categorical([...])}}"
             )
 
 

--- a/sklearn_genetic/space/tests/test_space.py
+++ b/sklearn_genetic/space/tests/test_space.py
@@ -108,8 +108,21 @@ def test_check_space_fail():
         my_space = Space(param_grid)
     assert (
         str(excinfo.value)
-        == "max_depth must be a valid instance of Integer, Categorical or Continuous classes"
+        == "Invalid param_grid entry for 'max_depth': expected a space object "
+        "(Continuous, Integer, or Categorical), got range instead.\n"
+        "Example: param_grid = {'max_depth': Categorical([...])}"
     )
+
+
+def test_check_space_invalid_dimension_message_includes_type_and_example():
+    with pytest.raises(ValueError) as excinfo:
+        Space({"kernel": ["rbf", "linear"]})
+
+    message = str(excinfo.value)
+    assert "Invalid param_grid entry for 'kernel'" in message
+    assert "expected a space object (Continuous, Integer, or Categorical)" in message
+    assert "got list instead" in message
+    assert "Categorical([...])" in message
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #210.

This updates the validation error for invalid param_grid entries so it names the offending parameter, shows the expected space object types, includes the actual received type, and gives a short Categorical example.

I also updated the existing space validation test and added coverage for a plain list value, which is the confusing case described in the issue.

Validation:
- .venv/bin/python -m pytest sklearn_genetic/space/tests/test_space.py -q
- .venv/bin/python -m pytest sklearn_genetic/tests/test_genetic_search.py::test_no_param_grid sklearn_genetic/space/tests/test_space.py -q
- git diff --check