### PR TITLE
fix(space): clearer error for invalid param_grid entries (#210)

### DIFF
--- a/sklearn_genetic/space/space.py
+++ b/sklearn_genetic/space/space.py
@@ -200,25 +200,35 @@ class Categorical(BaseDimension):
 
 
 def check_space(param_grid: dict = None):
-    """
+    """Validate that ``param_grid`` is a non-empty mapping of space objects.
 
     Parameters
     ----------
     param_grid: dict, default=None
-        Dictionary with the for {"hyperparameter_name": :obj:`~sklearn_genetic.space`}
+        Dictionary of the form {"hyperparameter_name": :obj:`~sklearn_genetic.space`}
 
-    Returns
-    -------
-        Raises a Value Error if the dictionary does not have valid space instances
+    Raises
+    ------
+    ValueError
+        If ``param_grid`` is empty, or if any value is not an instance of
+        :class:`~sklearn_genetic.space.Integer`,
+        :class:`~sklearn_genetic.space.Categorical` or
+        :class:`~sklearn_genetic.space.Continuous`. The message names the
+        offending key and the type that was passed instead.
     """
     if not param_grid:
-        raise ValueError(f"param_grid can not be empty")
+        raise ValueError("param_grid can not be empty")
 
     # Make sure that each of the param_grid values are defined using one of the available Space objects
     for key, value in param_grid.items():
         if not isinstance(value, BaseDimension):
             raise ValueError(
-                f"{key} must be a valid instance of Integer, Categorical or Continuous classes"
+                f"Invalid param_grid entry for '{key}': expected a space object "
+                f"(Continuous, Integer, or Categorical), got "
+                f"{type(value).__name__} instead.\n"
+                f"Example:\n"
+                f"    from sklearn_genetic.space import Categorical\n"
+                f'    param_grid = {{"{key}": Categorical([...])}}'
             )
 
 

--- a/sklearn_genetic/space/tests/test_space.py
+++ b/sklearn_genetic/space/tests/test_space.py
@@ -129,12 +129,29 @@ def test_check_space_fail():
         "max_depth": range(10, 20),
     }
 
-    with pytest.raises(Exception) as excinfo:
+    with pytest.raises(ValueError) as excinfo:
         my_space = Space(param_grid)
-    assert (
-        str(excinfo.value)
-        == "max_depth must be a valid instance of Integer, Categorical or Continuous classes"
-    )
+    message = str(excinfo.value)
+    # The improved message names the offending key, the type that was passed,
+    # and shows a corrective example.
+    assert "Invalid param_grid entry for 'max_depth'" in message
+    assert "got range instead" in message
+    assert "Categorical" in message
+
+
+def test_check_space_invalid_type_message():
+    """A non-space value yields a clear, actionable error (issue #210)."""
+    param_grid = {"kernel": ["rbf", "linear"]}  # should be Categorical([...])
+
+    with pytest.raises(ValueError, match=r"Invalid param_grid entry for 'kernel'"):
+        Space(param_grid)
+
+    with pytest.raises(ValueError) as excinfo:
+        Space(param_grid)
+    message = str(excinfo.value)
+    assert "expected a space object (Continuous, Integer, or Categorical)" in message
+    assert "got list instead" in message
+    assert 'param_grid = {"kernel": Categorical([...])}' in message
 
 
 @pytest.mark.parametrize(

--- a/sklearn_genetic/tests/test_genetic_search.py
+++ b/sklearn_genetic/tests/test_genetic_search.py
@@ -1076,6 +1076,24 @@ def test_no_param_grid():
     assert str(excinfo.value) == "param_grid can not be empty"
 
 
+def test_invalid_param_grid_type():
+    """An invalid param_grid value raises a clear, actionable error (issue #210)."""
+    clf = SGDClassifier(loss="modified_huber", fit_intercept=True)
+    with pytest.raises(ValueError, match=r"Invalid param_grid entry for 'alpha'"):
+        GASearchCV(
+            clf,
+            cv=3,
+            scoring="accuracy",
+            population_size=12,
+            generations=8,
+            tournament_size=3,
+            elitism=False,
+            verbose=False,
+            criteria="max",
+            param_grid={"alpha": [1e-4, 1]},  # should be Continuous(1e-4, 1)
+        )
+
+
 def test_expected_ga_multimetric():
     clf = SGDClassifier(loss="modified_huber", fit_intercept=True)
     scoring = {


### PR DESCRIPTION
## Summary

Improves the error raised when `param_grid` contains a non-space value (e.g. a plain list or `range` instead of `Categorical`/`Integer`/`Continuous`). The message now names the offending key, the type that was actually passed, and shows a corrective example.

## Related Issue

Closes #210

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] Other (describe):

## What changed

Before:
```
ValueError: max_depth must be a valid instance of Integer, Categorical or Continuous classes
```
After:
```
ValueError: Invalid param_grid entry for 'max_depth': expected a space object
(Continuous, Integer, or Categorical), got range instead.
Example:
    from sklearn_genetic.space import Categorical
    param_grid = {"max_depth": Categorical([...])}
```

### Implementation note (differs slightly from the issue's hint)

The issue suggested adding the check in `GASearchCV.fit()` and `GAFeatureSelectionCV.fit()`. Two things I found while reading the code:

1. Validation **already exists** centrally in `check_space()` (`sklearn_genetic/space/space.py`), which `GASearchCV` runs at construction via `Space(param_grid)`. So rather than duplicating a check into `fit()`, I improved the message at that single source — it's DRY and covers the existing path.
2. `GAFeatureSelectionCV` doesn't take a `param_grid`, so it has nothing to validate here.

If you'd prefer the validation duplicated at the `fit()` entry points anyway, happy to adjust.

Also: dropped a stray `f""` prefix on the empty-grid message and expanded the `check_space` docstring with a `Raises` section.

## Checklist

- [x] Tests pass locally (`pytest sklearn_genetic/`) — full `space` suite (29) green
- [x] Code is formatted with Black (`black sklearn_genetic/`)
- [x] New functionality is covered by tests — `test_check_space_invalid_type_message` (space) + `test_invalid_param_grid_type` (GASearchCV); updated the existing `test_check_space_fail` assertion
- [ ] Documentation updated if needed — none required; happy to add a CHANGELOG entry if you'd like one

— Contributed by **Mayoka Labs**