### PR TITLE
feat(presets): add preset discovery helpers (#223)

### DIFF
--- a/docs-vitepress/versions/latest/api/presets.md
+++ b/docs-vitepress/versions/latest/api/presets.md
@@ -54,6 +54,24 @@ param_grid = random_forest_classifier_space(profile="fast")
 | `balanced` | You want a practical default for real tuning |
 | `wide` | You have more budget and want broader exploration |
 
+## Discovering presets
+
+Two helpers let you list the available presets and profiles from Python — handy
+in a notebook or for building a UI:
+
+```python
+from sklearn_genetic import list_preset_profiles, list_preset_spaces
+
+list_preset_profiles()
+# ['balanced', 'fast', 'wide']
+
+list_preset_spaces()
+# ['hist_gradient_boosting_classifier_space', ..., 'xgboost_regressor_space']
+```
+
+Both return sorted lists, and every name from `list_preset_spaces()` is
+importable from `sklearn_genetic`.
+
 ## Pipeline prefixes
 
 Use `prefix` when tuning an estimator inside a scikit-learn `Pipeline`:

--- a/sklearn_genetic/__init__.py
+++ b/sklearn_genetic/__init__.py
@@ -9,6 +9,8 @@ from .presets import (
     svc_space,
     xgboost_classifier_space,
     xgboost_regressor_space,
+    list_preset_profiles,
+    list_preset_spaces,
 )
 
 from .callbacks import (
@@ -42,6 +44,8 @@ __all__ = [
     "svc_space",
     "xgboost_classifier_space",
     "xgboost_regressor_space",
+    "list_preset_profiles",
+    "list_preset_spaces",
     "ThresholdStopping",
     "ConsecutiveStopping",
     "DeltaThreshold",

--- a/sklearn_genetic/presets.py
+++ b/sklearn_genetic/presets.py
@@ -15,18 +15,11 @@ __all__ = [
 
 _PROFILES = {"fast", "balanced", "wide"}
 
-# Names of the preset search-space factory functions, captured so the discovery
-# helpers below stay in sync with what is actually exported.
-_PRESET_SPACES = (
-    "hist_gradient_boosting_classifier_space",
-    "hist_gradient_boosting_regressor_space",
-    "logistic_regression_space",
-    "random_forest_classifier_space",
-    "random_forest_regressor_space",
-    "svc_space",
-    "xgboost_classifier_space",
-    "xgboost_regressor_space",
-)
+# Names of the preset search-space factory functions, derived from __all__ so
+# the discovery helpers stay in sync with what is exported: the presets are
+# everything in __all__ except the discovery helpers themselves.
+_DISCOVERY_HELPERS = {"list_preset_profiles", "list_preset_spaces"}
+_PRESET_SPACES = tuple(name for name in __all__ if name not in _DISCOVERY_HELPERS)
 
 
 def list_preset_profiles():

--- a/sklearn_genetic/presets.py
+++ b/sklearn_genetic/presets.py
@@ -9,9 +9,63 @@ __all__ = [
     "svc_space",
     "xgboost_classifier_space",
     "xgboost_regressor_space",
+    "list_preset_profiles",
+    "list_preset_spaces",
 ]
 
 _PROFILES = {"fast", "balanced", "wide"}
+
+# Names of the preset search-space factory functions, captured so the discovery
+# helpers below stay in sync with what is actually exported.
+_PRESET_SPACES = (
+    "hist_gradient_boosting_classifier_space",
+    "hist_gradient_boosting_regressor_space",
+    "logistic_regression_space",
+    "random_forest_classifier_space",
+    "random_forest_regressor_space",
+    "svc_space",
+    "xgboost_classifier_space",
+    "xgboost_regressor_space",
+)
+
+
+def list_preset_profiles():
+    """Return the profile names accepted by every preset space function.
+
+    Returns
+    -------
+    list of str
+        The valid ``profile`` arguments, sorted alphabetically
+        (``["balanced", "fast", "wide"]``).
+
+    Examples
+    --------
+    >>> from sklearn_genetic import list_preset_profiles
+    >>> list_preset_profiles()
+    ['balanced', 'fast', 'wide']
+    """
+    return sorted(_PROFILES)
+
+
+def list_preset_spaces():
+    """Return the names of the available preset search-space functions.
+
+    Each name is importable from :mod:`sklearn_genetic` and is a callable that
+    accepts a ``profile`` (see :func:`list_preset_profiles`) and an optional
+    ``prefix``.
+
+    Returns
+    -------
+    list of str
+        The preset function names, sorted alphabetically.
+
+    Examples
+    --------
+    >>> from sklearn_genetic import list_preset_spaces
+    >>> "random_forest_classifier_space" in list_preset_spaces()
+    True
+    """
+    return sorted(_PRESET_SPACES)
 
 
 def random_forest_classifier_space(profile="balanced", prefix=""):

--- a/sklearn_genetic/tests/test_presets.py
+++ b/sklearn_genetic/tests/test_presets.py
@@ -125,3 +125,25 @@ def test_presets_reject_unknown_profiles():
     for preset in PRESET_FUNCTIONS:
         with pytest.raises(ValueError, match="profile must be one of"):
             preset(profile="tiny")
+
+
+def test_list_preset_profiles_returns_valid_profiles():
+    from sklearn_genetic import list_preset_profiles
+
+    assert list_preset_profiles() == ["balanced", "fast", "wide"]
+    # Every reported profile is actually accepted by a preset.
+    for profile in list_preset_profiles():
+        random_forest_classifier_space(profile=profile)
+
+
+def test_list_preset_spaces_matches_exported_presets():
+    import sklearn_genetic
+    from sklearn_genetic import list_preset_spaces
+
+    names = list_preset_spaces()
+    assert names == sorted(names)  # stable, alphabetical
+    assert len(names) == len(PRESET_FUNCTIONS)
+    assert "random_forest_classifier_space" in names
+    # Every reported name is importable from the package and callable.
+    for name in names:
+        assert callable(getattr(sklearn_genetic, name))

--- a/sklearn_genetic/tests/test_presets.py
+++ b/sklearn_genetic/tests/test_presets.py
@@ -147,3 +147,16 @@ def test_list_preset_spaces_matches_exported_presets():
     # Every reported name is importable from the package and callable.
     for name in names:
         assert callable(getattr(sklearn_genetic, name))
+
+
+def test_discovery_helpers_return_fresh_lists():
+    """Mutating a returned list must not affect internal state or later calls."""
+    from sklearn_genetic import list_preset_profiles, list_preset_spaces
+
+    for helper in (list_preset_profiles, list_preset_spaces):
+        first = helper()
+        first.append("__mutated__")
+        first.clear()
+        second = helper()
+        assert "__mutated__" not in second
+        assert second == sorted(second) and len(second) > 0


### PR DESCRIPTION
## Summary

Adds two small public discovery helpers so users can list the available presets and profiles from Python.

## Related Issue

Closes #223

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / cleanup

## What changed

```python
from sklearn_genetic import list_preset_profiles, list_preset_spaces

list_preset_profiles()  # ['balanced', 'fast', 'wide']
list_preset_spaces()    # ['hist_gradient_boosting_classifier_space', ..., 'xgboost_regressor_space']
```

- `list_preset_profiles()` returns the sorted profile names accepted by every preset.
- `list_preset_spaces()` returns the sorted preset function names; each is importable from `sklearn_genetic` and callable.
- Both are exported via `sklearn_genetic.__all__` and `presets.__all__`. Existing preset behavior is untouched.

## Checklist

- [x] Tests pass locally (`pytest sklearn_genetic/`) — full preset suite (50) green
- [x] Code is formatted with Black
- [x] New functionality is covered by tests (`test_list_preset_profiles_returns_valid_profiles`, `test_list_preset_spaces_matches_exported_presets`)
- [ ] Documentation updated if needed — happy to add a note to `api/presets.md` if you'd like

— Contributed by **Mayoka Labs**