### PR TITLE
fix(converters): actionable error for unsupported scipy distributions (#221)

### DIFF
--- a/sklearn_genetic/space/converters.py
+++ b/sklearn_genetic/space/converters.py
@@ -78,7 +78,11 @@ def _convert_scipy_distribution(parameter, distribution):
         return Continuous(float(lower), float(upper), distribution="log-uniform")
 
     raise ValueError(
-        f"{parameter} uses scipy.stats.{name}, which can not be converted automatically"
+        f"{parameter} uses scipy.stats.{name}, which can not be converted "
+        f"automatically. Supported scipy distributions are randint, uniform, "
+        f"loguniform, and reciprocal. For anything else, define the dimension "
+        f"manually, e.g. Continuous(low, high) or "
+        f"Continuous(low, high, distribution='log-uniform') for '{parameter}'."
     )
 
 

--- a/sklearn_genetic/space/tests/test_space.py
+++ b/sklearn_genetic/space/tests/test_space.py
@@ -247,7 +247,13 @@ def test_from_sklearn_space_rejects_unsupported_distributions():
     with pytest.raises(ValueError) as excinfo:
         from_sklearn_space({"alpha": stats.expon()})
 
-    assert "scipy.stats.expon" in str(excinfo.value)
+    message = str(excinfo.value)
+    assert "scipy.stats.expon" in message
+    # The message should name the supported distributions and suggest a manual
+    # alternative for the offending parameter (issue #221).
+    assert "randint, uniform, loguniform, and reciprocal" in message
+    assert "Continuous(" in message
+    assert "'alpha'" in message
 
 
 def test_from_sklearn_space_rejects_empty_or_ambiguous_values():


### PR DESCRIPTION
## Summary

Improves the error from `from_sklearn_space()` when a scipy distribution can't be auto-converted: it now lists the supported distributions and suggests a manual alternative.

## Related Issue

Closes #221

## Type of Change

- [x] Bug fix

## What changed

Before:
```
alpha uses scipy.stats.expon, which can not be converted automatically
```
After:
```
alpha uses scipy.stats.expon, which can not be converted automatically.
Supported scipy distributions are randint, uniform, loguniform, and reciprocal.
For anything else, define the dimension manually, e.g. Continuous(low, high) or
Continuous(low, high, distribution='log-uniform') for 'alpha'.
```

## Checklist

- [x] Tests pass locally (`pytest sklearn_genetic/`) — full `space` suite (29) green
- [x] Code is formatted with Black
- [x] New functionality is covered by tests (strengthened `test_from_sklearn_space_rejects_unsupported_distributions`)
- [ ] Documentation updated if needed — n/a

— Contributed by **Mayoka Labs**