### PR TITLE
Make unsupported sklearn-space distribution errors actionable

### DIFF
--- a/docs-vitepress/versions/latest/api/space.md
+++ b/docs-vitepress/versions/latest/api/space.md
@@ -122,9 +122,9 @@ Conversion rules:
 | `scipy.stats.loguniform(a, b)` / `reciprocal(a, b)` | `Continuous(a, b, distribution="log-uniform")` |
 | Existing `Integer`, `Continuous`, `Categorical` | returned unchanged |
 
-Unsupported scipy distributions raise `ValueError` so you can choose an explicit
-`Integer`, `Continuous`, or `Categorical` dimension instead of getting a silent
-misconfiguration.
+Unsupported scipy distributions raise an actionable `ValueError` that names the
+distribution and suggests defining the corresponding `Integer`, `Continuous`, or
+`Categorical` dimension manually.
 
 ## See Also
 

--- a/sklearn_genetic/space/converters.py
+++ b/sklearn_genetic/space/converters.py
@@ -78,7 +78,7 @@ def _convert_scipy_distribution(parameter, distribution):
         return Continuous(float(lower), float(upper), distribution="log-uniform")
 
     raise ValueError(
-        f"{parameter} uses scipy.stats.{name}, which can not be converted automatically. "
+        f"{parameter} uses scipy.stats.{name}, which cannot be converted automatically. "
         "Supported scipy distributions are randint, uniform, loguniform, and reciprocal. "
         "For other distributions, define the search space manually, for example "
         "Continuous(lower, upper)."

--- a/sklearn_genetic/space/converters.py
+++ b/sklearn_genetic/space/converters.py
@@ -78,7 +78,10 @@ def _convert_scipy_distribution(parameter, distribution):
         return Continuous(float(lower), float(upper), distribution="log-uniform")
 
     raise ValueError(
-        f"{parameter} uses scipy.stats.{name}, which can not be converted automatically"
+        f"{parameter} uses scipy.stats.{name}, which can not be converted automatically. "
+        "Supported scipy distributions are randint, uniform, loguniform, and reciprocal. "
+        "For other distributions, define the search space manually, for example "
+        "Continuous(lower, upper)."
     )
 
 

--- a/sklearn_genetic/space/tests/test_space.py
+++ b/sklearn_genetic/space/tests/test_space.py
@@ -247,7 +247,11 @@ def test_from_sklearn_space_rejects_unsupported_distributions():
     with pytest.raises(ValueError) as excinfo:
         from_sklearn_space({"alpha": stats.expon()})
 
-    assert "scipy.stats.expon" in str(excinfo.value)
+    message = str(excinfo.value)
+    assert "alpha uses scipy.stats.expon" in message
+    assert "Supported scipy distributions are randint, uniform, loguniform, and reciprocal" in message
+    assert "define the search space manually" in message
+    assert "Continuous(lower, upper)" in message
 
 
 def test_from_sklearn_space_rejects_empty_or_ambiguous_values():

--- a/sklearn_genetic/space/tests/test_space.py
+++ b/sklearn_genetic/space/tests/test_space.py
@@ -249,7 +249,9 @@ def test_from_sklearn_space_rejects_unsupported_distributions():
 
     message = str(excinfo.value)
     assert "alpha uses scipy.stats.expon" in message
-    assert "Supported scipy distributions are randint, uniform, loguniform, and reciprocal" in message
+    assert (
+        "Supported scipy distributions are randint, uniform, loguniform, and reciprocal" in message
+    )
     assert "define the search space manually" in message
     assert "Continuous(lower, upper)" in message
 


### PR DESCRIPTION
Fixes #221.

This updates the unsupported scipy distribution error from from_sklearn_space() so it tells users which scipy distributions are supported and suggests defining the search space manually when conversion is not available.

The updated test now checks that the expon() error mentions the parameter, supported scipy distributions, and a Continuous(lower, upper) manual-space example.

Validation:
- .venv/bin/python -m pytest sklearn_genetic/space/tests/test_space.py::test_from_sklearn_space_rejects_unsupported_distributions -q
- .venv/bin/python -m pytest sklearn_genetic/space/tests/test_space.py -q
- git diff --check