### PR TITLE
fix(plots): actionable unfitted-estimator errors in plotting helpers (#222)

### DIFF
--- a/sklearn_genetic/plots.py
+++ b/sklearn_genetic/plots.py
@@ -96,9 +96,25 @@ def _available_fields(estimator, fields):
     return [field for field in fields if field in getattr(estimator, "history", {})]
 
 
+def _require_fitted(estimator, attribute, plot_name=None):
+    """Raise an actionable error if ``estimator`` lacks a fit-time ``attribute``.
+
+    Plotting is often the first thing new users try after creating an
+    estimator, so the message tells them to call ``estimator.fit(X, y)`` first
+    and names the attribute the plot relies on (and, when known, the plotting
+    function).
+    """
+    if not hasattr(estimator, attribute):
+        who = f"{plot_name} requires" if plot_name else "This plot requires"
+        raise ValueError(
+            f"{who} a fitted {type(estimator).__name__} estimator. "
+            f"Call estimator.fit(X, y) before plotting because this plot reads "
+            f"estimator.{attribute}."
+        )
+
+
 def _cv_results_frame(estimator):
-    if not hasattr(estimator, "cv_results_"):
-        raise ValueError("estimator must be fitted before plotting cv_results_ data")
+    _require_fitted(estimator, "cv_results_")
 
     return pd.DataFrame(estimator.cv_results_)
 
@@ -811,8 +827,7 @@ def plot_feature_selection(
     if not isinstance(estimator, GAFeatureSelectionCV):
         raise TypeError("plot_feature_selection requires a GAFeatureSelectionCV estimator")
 
-    if not hasattr(estimator, "best_features_"):
-        raise ValueError("estimator must be fitted before plotting selected features")
+    _require_fitted(estimator, "best_features_", plot_name="plot_feature_selection")
 
     mask = np.asarray(estimator.best_features_, dtype=bool)
     if feature_names is None:

--- a/sklearn_genetic/tests/test_plots.py
+++ b/sklearn_genetic/tests/test_plots.py
@@ -316,3 +316,30 @@ def test_feature_selection_plot():
 
     with pytest.raises(ValueError, match="same length"):
         plot_feature_selection(estimator, feature_names=["one"])
+
+
+def test_plot_on_unfitted_estimator_gives_actionable_error():
+    """Plotting before fit should tell the user to call .fit(X, y) (issue #222)."""
+    unfitted = GASearchCV(
+        DecisionTreeRegressor(),
+        cv=2,
+        scoring="r2",
+        param_grid={"max_depth": Integer(2, 8)},
+    )
+    with pytest.raises(ValueError) as excinfo:
+        plot_candidate_scores(unfitted)
+    message = str(excinfo.value)
+    assert "fitted GASearchCV" in message
+    assert "estimator.fit(X, y)" in message
+    assert "estimator.cv_results_" in message
+
+
+def test_plot_feature_selection_on_unfitted_estimator_names_the_plot():
+    """plot_feature_selection should name itself and best_features_ (issue #222)."""
+    unfitted = GAFeatureSelectionCV(DecisionTreeRegressor(), cv=2, scoring="r2")
+    with pytest.raises(ValueError) as excinfo:
+        plot_feature_selection(unfitted)
+    message = str(excinfo.value)
+    assert "plot_feature_selection requires" in message
+    assert "estimator.fit(X, y)" in message
+    assert "estimator.best_features_" in message


### PR DESCRIPTION
## Summary

Makes the "estimator not fitted" errors in plotting helpers beginner-friendly: they now tell the user to call `estimator.fit(X, y)` and name the attribute (and plotting function) involved.

## Related Issue

Closes #222

## Type of Change

- [x] Bug fix

## What changed

Added a small `_require_fitted(estimator, attribute, plot_name=None)` helper and wired it into:
- `_cv_results_frame(...)` — covers every plot that reads `cv_results_`
- `plot_feature_selection(...)` — for `best_features_`

Before:
```
estimator must be fitted before plotting cv_results_ data
```
After:
```
This plot requires a fitted GASearchCV estimator. Call estimator.fit(X, y)
before plotting because this plot reads estimator.cv_results_.
```
and, with the plot name known:
```
plot_feature_selection requires a fitted GAFeatureSelectionCV estimator.
Call estimator.fit(X, y) before plotting because this plot reads
estimator.best_features_.
```

## Checklist

- [x] Tests pass locally (`pytest sklearn_genetic/`) — new tests + fitted-path regression green
- [x] Code is formatted with Black
- [x] New functionality is covered by tests (two new tests for the cv_results_ and best_features_ paths)
- [ ] Documentation updated if needed — n/a

— Contributed by **Mayoka Labs**