### PR TITLE
feat(space): complete type annotations for space parameter classes (#209)

### DIFF
--- a/sklearn_genetic/space/base.py
+++ b/sklearn_genetic/space/base.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from typing import Any
 
 
 class BaseDimension(ABC):
@@ -7,7 +8,7 @@ class BaseDimension(ABC):
     """
 
     @abstractmethod
-    def sample(self):
+    def sample(self) -> Any:
         """
         Sample a random value from the assigned distribution
         """

--- a/sklearn_genetic/space/space.py
+++ b/sklearn_genetic/space/space.py
@@ -60,7 +60,7 @@ class Integer(BaseDimension):
         if self.distribution == IntegerDistributions.uniform.value:
             self.rvs = stats.randint.rvs
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             f"{self.__class__.__name__}(lower={self.lower}, upper={self.upper}, "
             f"distribution={self.distribution!r})"
@@ -124,7 +124,7 @@ class Continuous(BaseDimension):
         elif self.distribution == ContinuousDistributions.log_uniform.value:
             self.rvs = stats.loguniform.rvs
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             f"{self.__class__.__name__}(lower={self.lower}, upper={self.upper}, "
             f"distribution={self.distribution!r})"
@@ -189,7 +189,7 @@ class Categorical(BaseDimension):
         if self.distribution == CategoricalDistributions.choice.value:
             self.rvs = self.rng.choice if self.rng else random.choice
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         if self.priors is None:
             return f"{self.__class__.__name__}(choices={self.choices!r})"
 

--- a/sklearn_genetic/space/space.py
+++ b/sklearn_genetic/space/space.py
@@ -1,6 +1,8 @@
+import random
+from typing import Any, List, Optional, Union
+
 import numpy as np
 from scipy import stats
-import random
 
 from .space_parameters import (
     IntegerDistributions,
@@ -15,11 +17,11 @@ class Integer(BaseDimension):
 
     def __init__(
         self,
-        lower: int = None,
-        upper: int = None,
+        lower: Optional[int] = None,
+        upper: Optional[int] = None,
         distribution: str = "uniform",
-        random_state=None,
-    ):
+        random_state: Optional[Union[int, np.random.Generator]] = None,
+    ) -> None:
         """
         Parameters
         ----------
@@ -64,7 +66,7 @@ class Integer(BaseDimension):
             f"distribution={self.distribution!r})"
         )
 
-    def sample(self):
+    def sample(self) -> int:
         """Sample a random value from the assigned distribution"""
 
         return self.rvs(self.lower, self.upper + 1, random_state=self.rng)
@@ -75,11 +77,11 @@ class Continuous(BaseDimension):
 
     def __init__(
         self,
-        lower: float = None,
-        upper: float = None,
+        lower: Optional[float] = None,
+        upper: Optional[float] = None,
         distribution: str = "uniform",
-        random_state=None,
-    ):
+        random_state: Optional[Union[int, np.random.Generator]] = None,
+    ) -> None:
         """
         Parameters
         ----------
@@ -128,7 +130,7 @@ class Continuous(BaseDimension):
             f"distribution={self.distribution!r})"
         )
 
-    def sample(self):
+    def sample(self) -> float:
         """Sample a random value from the assigned distribution"""
 
         return self.rvs(self.lower, self.shifted_upper, random_state=self.rng)
@@ -139,11 +141,11 @@ class Categorical(BaseDimension):
 
     def __init__(
         self,
-        choices: list = None,
-        priors: list = None,
+        choices: Optional[List[Any]] = None,
+        priors: Optional[List[float]] = None,
         distribution: str = "choice",
-        random_state=None,
-    ):
+        random_state: Optional[Union[int, np.random.Generator]] = None,
+    ) -> None:
         """
         Parameters
         ----------
@@ -193,7 +195,7 @@ class Categorical(BaseDimension):
 
         return f"{self.__class__.__name__}(choices={self.choices!r}, priors={self.priors!r})"
 
-    def sample(self):
+    def sample(self) -> Any:
         """Sample a random value from the assigned distribution"""
 
         return self.rvs(self.choices)

--- a/sklearn_genetic/space/tests/test_space.py
+++ b/sklearn_genetic/space/tests/test_space.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 import numpy as np
 from scipy import stats
@@ -115,6 +117,20 @@ def test_categorical_bad_parameters(data_object, parameters, message):
     with pytest.raises(Exception) as excinfo:
         data_object(**parameters)
     assert str(excinfo.value) == message
+
+
+def test_space_classes_have_complete_type_annotations():
+    """random_state and sample() carry annotations on every space class (#209)."""
+    import inspect
+
+    for cls, sample_return in [(Integer, int), (Continuous, float), (Categorical, Any)]:
+        init_params = inspect.signature(cls.__init__).parameters
+        assert init_params["random_state"].annotation is not inspect.Parameter.empty
+        sample_sig = inspect.signature(cls.sample)
+        assert sample_sig.return_annotation is sample_return
+
+    # The abstract base also annotates its sample() return type.
+    assert inspect.signature(BaseDimension.sample).return_annotation is Any
 
 
 def test_check_space_fail():


### PR DESCRIPTION
## Summary

Completes the type annotations on the `Integer`, `Continuous`, and `Categorical` space classes (and `BaseDimension`).

## Related Issue

Closes #209

## Type of Change

- [ ] Bug fix
- [x] New feature (typing)
- [ ] Documentation update
- [ ] Refactor / cleanup

## What changed

- `random_state: Optional[Union[int, np.random.Generator]] = None` on all three `__init__`s
- `__init__(...) -> None`
- Return types on `sample()`: `Integer -> int`, `Continuous -> float`, `Categorical -> Any`
- `lower`/`upper`/`choices`/`priors` are now `Optional[...]` to match their `None` defaults
- `BaseDimension.sample(self) -> Any`

Annotations only — no runtime behavior change.

## Checklist

- [x] Tests pass locally (`pytest sklearn_genetic/`) — full `space` suite (30) green
- [x] Code is formatted with Black
- [x] New functionality is covered by tests (`test_space_classes_have_complete_type_annotations`)
- [ ] Documentation updated if needed — n/a

— Contributed by **Mayoka Labs**