### PR TITLE
docs: add CITATION.cff (#208)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -6,6 +6,7 @@ abstract: "Hyperparameter tuning and feature selection using genetic algorithms,
 authors:
   - family-names: Arenas
     given-names: Rodrigo
+    orcid: "https://orcid.org/0009-0005-0910-3705"
 repository-code: "https://github.com/rodrigo-arenas/Sklearn-genetic-opt"
 url: "https://sklearngeneticopt.rodrigo-arenas.com/"
 license: MIT

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,19 @@
+cff-version: 1.2.0
+message: "If you use this software in your research, please cite it as below."
+type: software
+title: "sklearn-genetic-opt"
+abstract: "Hyperparameter tuning and feature selection using genetic algorithms, built on top of scikit-learn."
+authors:
+  - family-names: Arenas
+    given-names: Rodrigo
+repository-code: "https://github.com/rodrigo-arenas/Sklearn-genetic-opt"
+url: "https://sklearngeneticopt.rodrigo-arenas.com/"
+license: MIT
+version: "0.13.2"
+date-released: "2026-06-27"
+keywords:
+  - hyperparameter-tuning
+  - feature-selection
+  - genetic-algorithm
+  - scikit-learn
+  - machine-learning


### PR DESCRIPTION
## Summary

Adds a `CITATION.cff` at the repo root so GitHub surfaces a "Cite this repository" button and researchers can cite the library properly.

## Related Issue

Closes #208

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation update

## Notes

- Metadata matches `pyproject.toml` / `LICENSE`: MIT, author Rodrigo Arenas, docs URL `https://sklearngeneticopt.rodrigo-arenas.com/`.
- `version`/`date-released` point at the latest release (0.13.2, 2026-06-27) — easy to bump on each release.
- Validated with `cffconvert --validate`: *"Citation metadata are valid according to schema version 1.2.0."*
- ORCID left out (optional) — happy to add yours if you'd like.

## Checklist

- [x] Tests pass locally — n/a (metadata file); validated against the CFF 1.2.0 schema
- [x] Code is formatted with Black — n/a
- [ ] New functionality is covered by tests — n/a
- [x] Documentation updated

— Contributed by **Mayoka Labs**