### PR TITLE
[Good First Issue] Show expected/received counts in feature_names length error

### DIFF
--- a/sklearn_genetic/plots.py
+++ b/sklearn_genetic/plots.py
@@ -835,7 +835,10 @@ def plot_feature_selection(
     else:
         feature_names = _as_list(feature_names)
         if len(feature_names) != mask.size:
-            raise ValueError("feature_names must have the same length as estimator.best_features_")
+            raise ValueError(
+            f"feature_names must have the same length as estimator.best_features_: "
+            f"expected {mask.size}, got {len(feature_names)}"
+        )
 
     if ax is None:
         _, ax = plt.subplots(figsize=(10, max(4, 0.28 * mask.size)))


### PR DESCRIPTION
Fixes #239

## Summary

Improve the `plot_feature_selection` error message when `feature_names` length does not match `estimator.best_features_`.

**Before:**
```
feature_names must have the same length as estimator.best_features_
```

**After:**
```
feature_names must have the same length as estimator.best_features_: expected 30, got 29
```

## Why this helps

Users who pass the wrong list of column names now see exactly how many names they provided versus how many were expected, making the fix immediately obvious.

## Testing

Updated the existing length-mismatch test in `sklearn_genetic/tests/test_plots.py` to assert the message contains `feature_names`, `expected`, `got`, and the actual counts.