### PR TITLE
fix: show feature_names length counts in plot error

### DIFF
--- a/sklearn_genetic/plots.py
+++ b/sklearn_genetic/plots.py
@@ -835,7 +835,10 @@ def plot_feature_selection(
     else:
         feature_names = _as_list(feature_names)
         if len(feature_names) != mask.size:
-            raise ValueError("feature_names must have the same length as estimator.best_features_")
+            raise ValueError(
+                "feature_names must have the same length as estimator.best_features_: "
+                f"expected {mask.size}, got {len(feature_names)}"
+            )
 
     if ax is None:
         _, ax = plt.subplots(figsize=(10, max(4, 0.28 * mask.size)))

--- a/sklearn_genetic/tests/test_plots.py
+++ b/sklearn_genetic/tests/test_plots.py
@@ -314,8 +314,14 @@ def test_feature_selection_plot():
     with pytest.raises(TypeError, match="supports GASearchCV only"):
         plot_score_landscape(estimator, x="feature_0", y="feature_1")
 
-    with pytest.raises(ValueError, match="same length"):
+    with pytest.raises(ValueError) as excinfo:
         plot_feature_selection(estimator, feature_names=["one"])
+    message = str(excinfo.value)
+    assert "feature_names" in message
+    assert "expected" in message
+    assert "got" in message
+    assert f"expected {len(estimator.best_features_)}" in message
+    assert "got 1" in message
 
 
 def test_plot_on_unfitted_estimator_gives_actionable_error():


### PR DESCRIPTION
## Summary
- include expected and received counts when `plot_feature_selection` gets a mismatched `feature_names` list
- update the existing plotting test to assert `feature_names`, `expected`, `got`, and both counts are present

Closes #239.

## Validation
- `uv run --extra test --extra plot pytest sklearn_genetic/tests/test_plots.py`
- `git diff --check`