### PR TITLE
fix: include feature name count mismatch details

### DIFF
--- a/sklearn_genetic/plots.py
+++ b/sklearn_genetic/plots.py
@@ -835,7 +835,10 @@ def plot_feature_selection(
     else:
         feature_names = _as_list(feature_names)
         if len(feature_names) != mask.size:
-            raise ValueError("feature_names must have the same length as estimator.best_features_")
+            raise ValueError(
+                "feature_names must have the same length as estimator.best_features_: "
+                f"expected {mask.size}, got {len(feature_names)}"
+            )
 
     if ax is None:
         _, ax = plt.subplots(figsize=(10, max(4, 0.28 * mask.size)))

--- a/sklearn_genetic/tests/test_plots.py
+++ b/sklearn_genetic/tests/test_plots.py
@@ -314,8 +314,17 @@ def test_feature_selection_plot():
     with pytest.raises(TypeError, match="supports GASearchCV only"):
         plot_score_landscape(estimator, x="feature_0", y="feature_1")
 
-    with pytest.raises(ValueError, match="same length"):
+    expected_count = len(estimator.best_features_)
+    received_count = 1
+    with pytest.raises(ValueError) as excinfo:
         plot_feature_selection(estimator, feature_names=["one"])
+
+    message = str(excinfo.value)
+    assert "feature_names" in message
+    assert "expected" in message
+    assert "got" in message
+    assert str(expected_count) in message
+    assert str(received_count) in message
 
 
 def test_plot_on_unfitted_estimator_gives_actionable_error():


### PR DESCRIPTION
## Summary
- Include the expected and received counts when `plot_feature_selection(..., feature_names=...)` gets a mismatched list.
- Update the existing plotting test to assert the improved message includes `feature_names`, `expected`, `got`, and both counts.

## Why
The previous error only said the lengths must match. Including both counts makes the mismatch immediately actionable for users passing pandas column names or custom feature labels.

## Test Plan
- [x] `pytest sklearn_genetic/tests/test_plots.py -q`
- [x] `pytest sklearn_genetic/tests/test_plots.py sklearn_genetic/tests/test_feature_selection.py -q`
- [x] `python -m black --check sklearn_genetic/plots.py sklearn_genetic/tests/test_plots.py`
- [x] `pytest -q`

Closes #239
