### PR TITLE
fix(presets): validate prefix is a string in _with_prefix

### DIFF
--- a/sklearn_genetic/presets.py
+++ b/sklearn_genetic/presets.py
@@ -192,6 +192,8 @@ def xgboost_regressor_space(profile="balanced", prefix=""):
 
 
 def _with_prefix(space, prefix):
+    if not isinstance(prefix, str):
+        raise TypeError(f"prefix must be a string, got {type(prefix).__name__} instead")
     if not prefix:
         return space
     return {f"{prefix}{name}": dimension for name, dimension in space.items()}

--- a/sklearn_genetic/tests/test_presets.py
+++ b/sklearn_genetic/tests/test_presets.py
@@ -66,6 +66,14 @@ def test_presets_support_pipeline_prefixes():
     assert isinstance(space["model__degree"], Integer)
 
 
+@pytest.mark.parametrize("prefix", [None, True, ["model__"], 1])
+def test_presets_reject_non_string_prefix(prefix):
+    with pytest.raises(
+        TypeError, match=f"prefix must be a string, got {type(prefix).__name__} instead"
+    ):
+        svc_space(prefix=prefix)
+
+
 @pytest.mark.parametrize("preset", PRESET_FUNCTIONS)
 @pytest.mark.parametrize("profile", ["fast", "balanced", "wide"])
 def test_all_presets_return_native_dimensions_for_each_profile(preset, profile):


### PR DESCRIPTION
This PR was written primarily by Claude Code; I reviewed the change and ran the test suite before submitting.

## Problem

Preset helpers (e.g. `svc_space(prefix="model__")`) accept a `prefix` argument that is only truthiness-checked in `_with_prefix`. A non-string value (`None`, `True`, `["model__"]`, etc.) slips through and produces malformed parameter names instead of failing early.

## Fix

Added a type check at the top of `_with_prefix` in `sklearn_genetic/presets.py`:

```python
if not isinstance(prefix, str):
    raise TypeError(f"prefix must be a string, got {type(prefix).__name__} instead")
```

This is the single helper used by every preset function, so all of them get consistent validation.

## Testing

Added `test_presets_reject_non_string_prefix`, parametrized over `None`, `True`, `["model__"]`, and `1`, asserting the `TypeError` and its message.

Ran `pytest sklearn_genetic/tests/test_presets.py -v`: 55 passed (51 existing + 4 new parametrized cases). Also ran `black --check` on both changed files.

Fixes #236