### PR TITLE
fix(presets): validate prefix argument type

### DIFF
--- a/sklearn_genetic/presets.py
+++ b/sklearn_genetic/presets.py
@@ -192,6 +192,8 @@ def xgboost_regressor_space(profile="balanced", prefix=""):
 
 
 def _with_prefix(space, prefix):
+    if not isinstance(prefix, str):
+        raise TypeError(f"prefix must be a string, got {type(prefix).__name__} instead")
     if not prefix:
         return space
     return {f"{prefix}{name}": dimension for name, dimension in space.items()}

--- a/sklearn_genetic/tests/test_presets.py
+++ b/sklearn_genetic/tests/test_presets.py
@@ -90,6 +90,22 @@ def test_all_presets_treat_empty_prefix_as_unprefixed(preset):
     assert set(preset(prefix="")) == set(preset())
 
 
+@pytest.mark.parametrize(
+    ("prefix", "type_name"),
+    [
+        pytest.param(None, "NoneType", id="none"),
+        pytest.param(["model__"], "list", id="list"),
+    ],
+)
+def test_presets_reject_non_string_prefixes(prefix, type_name):
+    with pytest.raises(TypeError) as excinfo:
+        random_forest_classifier_space(prefix=prefix)
+
+    message = str(excinfo.value)
+    assert "prefix" in message
+    assert type_name in message
+
+
 def test_xgboost_classifier_preset_matches_interacting_tree_space():
     space = xgboost_classifier_space(profile="balanced")
 


### PR DESCRIPTION
## Summary

- Reject non-string preset prefixes with a clear `TypeError`.
- Preserve valid string and empty-prefix behavior.
- Add focused tests for `None` and list inputs.

## Why

The shared prefix helper previously accepted falsy non-string values and stringified truthy non-string values. Validating the argument at the shared boundary gives every preset consistent behavior and a clear error.

## Testing

- 53 preset tests passed.
- Full suite: 311 passed, 4 skipped.
- Coverage: 95.43%.
- Black passed.

Closes #236
