### PR TITLE
Add CITATION.cff to make library citable in academic work

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,10 +7,10 @@ authors:
   - family-names: Arenas
     given-names: Rodrigo
 repository-code: "https://github.com/rodrigo-arenas/Sklearn-genetic-opt"
-url: "https://rodrigo-arenas.github.io/Sklearn-genetic-opt/"
+url: "https://sklearngeneticopt.rodrigo-arenas.com/"
 license: MIT
-version: "0.13.1"
-date-released: "2025-01-01"
+version: "0.13.2"
+date-released: "2026-06-28"
 keywords:
   - hyperparameter-tuning
   - feature-selection

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,19 @@
+cff-version: 1.2.0
+message: "If you use this software in your research, please cite it as below."
+type: software
+title: "sklearn-genetic-opt"
+abstract: "Hyperparameter tuning and feature selection using genetic algorithms, built on top of scikit-learn."
+authors:
+  - family-names: Arenas
+    given-names: Rodrigo
+repository-code: "https://github.com/rodrigo-arenas/Sklearn-genetic-opt"
+url: "https://rodrigo-arenas.github.io/Sklearn-genetic-opt/"
+license: MIT
+version: "0.13.1"
+date-released: "2025-01-01"
+keywords:
+  - hyperparameter-tuning
+  - feature-selection
+  - genetic-algorithm
+  - scikit-learn
+  - machine-learning


### PR DESCRIPTION
## Summary

Fixes #208

   Added a CITATION.cff file at the repo root following the structure 
   requested in the issue, so GitHub surfaces the "Cite this repository" 
   button for users citing sklearn-genetic-opt in academic work.

## Related Issue

Closes #208

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] Other (describe):

## Checklist

- [ ] Tests pass locally (`pytest sklearn_genetic/`)
- [ ] Code is formatted with Black (`black sklearn_genetic/`)
- [ ] New functionality is covered by tests
- [ ] Documentation updated if needed
