### PR TITLE
fix: raise clear error when mlflow is missing

### DIFF
--- a/sklearn_genetic/mlflow_log.py
+++ b/sklearn_genetic/mlflow_log.py
@@ -4,8 +4,19 @@ import logging
 try:
     import mlflow
 except ModuleNotFoundError:  # noqa
+    mlflow = None
     logger = logging.getLogger(__name__)  # noqa
     logger.error("MLflow not found, pip install mlflow to use MLflowConfig")  # noqa
+
+
+_MLFLOW_INSTALL_MESSAGE = (
+    'MLflowConfig requires mlflow. Install it with: pip install "sklearn-genetic-opt[mlflow]"'
+)
+
+
+def _require_mlflow():
+    if mlflow is None:
+        raise ImportError(_MLFLOW_INSTALL_MESSAGE)
 
 
 class MLflowConfig:
@@ -40,6 +51,8 @@ class MLflowConfig:
             Dictionary of tag_name: String -> value.
 
         """
+        _require_mlflow()
+
         self.client = mlflow.tracking.MlflowClient()
         self.tracking_uri = tracking_uri
         self.experiment = experiment

--- a/sklearn_genetic/tests/test_mlflow.py
+++ b/sklearn_genetic/tests/test_mlflow.py
@@ -79,6 +79,25 @@ def test_mlflow_config(mlflow_resources):
     assert isinstance(mlflow_config, MLflowConfig)
 
 
+def test_mlflow_config_requires_mlflow(monkeypatch):
+    """
+    Check MLflowConfig raises a clear error when mlflow is not installed.
+    """
+    import sklearn_genetic.mlflow_log as mlflow_log
+
+    monkeypatch.setattr(mlflow_log, "mlflow", None)
+
+    with pytest.raises(ImportError, match="MLflowConfig requires mlflow") as error_info:
+        MLflowConfig(
+            tracking_uri="sqlite:///mlflow.db",
+            experiment=EXPERIMENT_NAME,
+            run_name="Decision Tree",
+        )
+
+    assert "mlflow" in str(error_info.value)
+    assert 'pip install "sklearn-genetic-opt[mlflow]"' in str(error_info.value)
+
+
 def test_runs(mlflow_resources, mlflow_run):
     """
     Check if runs are captured and parameters are true.


### PR DESCRIPTION
## Summary

- Set the optional `mlflow` module reference to `None` when the dependency is missing.
- Add a small guard so `MLflowConfig` raises a clear `ImportError` with the install extra.
- Add a focused monkeypatch test for the missing-mlflow path.

## Testing

- `pytest sklearn_genetic/tests/test_mlflow.py`
- `black --check sklearn_genetic/mlflow_log.py sklearn_genetic/tests/test_mlflow.py`

Closes #238