### PR TITLE
docs: help contributors avoid duplicating work on resolved issues

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,10 @@
 
 Closes #<!-- issue number -->
 
+<!-- Please confirm the issue above is still OPEN and isn't already covered by
+     another PR. Check the issue's linked PRs (Development section) and comments
+     before submitting, so we avoid duplicated effort. -->
+
 ## Type of Change
 
 - [ ] Bug fix
@@ -16,6 +20,7 @@ Closes #<!-- issue number -->
 
 ## Checklist
 
+- [ ] I checked the linked issue is open and not already covered by another PR
 - [ ] Tests pass locally (`pytest sklearn_genetic/`)
 - [ ] Code is formatted with Black (`black sklearn_genetic/`)
 - [ ] New functionality is covered by tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,24 @@ Code contributions are always welcome, from simple bug fixes to new features.
 Also, consider contributing to the documentation, 
 and reviewing open issues, it is the easiest way to get started.
 
+## Before you start working on an issue
+
+To avoid duplicated effort, please check these things **before** you start coding:
+
+1. **The issue is still open.** Closed issues are usually already resolved — this
+   is especially common for `good first issue` tickets. Check the status shown at
+   the top of the issue before picking it up.
+2. **No one is already working on it.** Look at the issue's **Development** section
+   in the right sidebar for linked pull requests, and skim the comments. You can
+   also filter the open [pull requests](https://github.com/rodrigo-arenas/Sklearn-genetic-opt/pulls)
+   by the issue number.
+3. **Claim it.** Leave a short comment saying you'd like to work on it, so others
+   know it's taken and don't duplicate your work.
+
+If an issue is already closed, or already has an open or recently merged PR, please
+pick a different one — and feel free to ask in the comments if you'd like a
+suggestion for a good next issue to tackle.
+
 ## Local development setup
 
 sklearn-genetic-opt supports Python 3.12 and newer. Python 3.13 is a good
@@ -116,8 +134,11 @@ If you have questions, you can open an issue (tag it as a question).
 We encourage you to follow these guidelines:
 
 * Fork this project, make the changes you expect to merge and make a pull request 
-* If the work you are making is related to some issue, please mention in the comments 
-  that you are working on it, so other people know and no duplicate your work.
+* If the work you are making is related to some issue, please first check that the
+  issue is still open and not already covered by another PR (see
+  [Before you start working on an issue](#before-you-start-working-on-an-issue)),
+  then mention in the comments that you are working on it, so other people know and
+  don't duplicate your work.
 * If you are working on a new feature, or have an idea, consider first opening an issue
   so people know what you are working on and possibly give some guidelines
 * Commit all changes by pull request (PR)


### PR DESCRIPTION
## Summary

Adds guidance so contributors check an issue's status **before** starting, to avoid duplicating effort on issues that are already closed or already have an open PR.

Motivated by a recent case where issue #239 received three separate PRs (#241, #244, #245) for the same one-line fix — two of them after the issue was effectively resolved.

## What changed

- **`CONTRIBUTING.md`**: new, prominent **"Before you start working on an issue"** section (check the issue is open, look for linked PRs in the Development section / open PRs, then claim it by commenting). Also links the existing guideline bullet to it and fixes a small typo (`no duplicate` → `don't duplicate`).
- **`.github/pull_request_template.md`**: a short comment under *Related Issue* prompting authors to confirm the issue is open and unclaimed, plus a checklist item: *"I checked the linked issue is open and not already covered by another PR."*

Docs/templates only — no code changes.

## Type of Change

- [x] Documentation update

## Checklist

- [x] I checked the linked issue is open and not already covered by another PR (n/a — process improvement, no linked issue)
- [x] Tests pass locally (`pytest sklearn_genetic/`) — n/a (docs/templates only)
- [x] Code is formatted with Black — n/a
- [x] New functionality is covered by tests — n/a
- [x] Documentation updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012o93RxHyzWbpUwV6iME9pQ

---
_Generated by [Claude Code](https://claude.ai/code/session_012o93RxHyzWbpUwV6iME9pQ)_