### PR TITLE
Add community articles page

### DIFF
--- a/docs-vitepress/.vitepress/config.ts
+++ b/docs-vitepress/.vitepress/config.ts
@@ -185,6 +185,9 @@ function versionSidebar(versionPrefix: string) {
         relativePath: 'comparisons/optuna-vs-sklearn-genetic-opt',
       },
     ]),
+    ...pageSection(versionPrefix, 'Community', 'community/articles', [
+      { text: 'Articles', relativePath: 'community/articles' },
+    ]),
     {
       text: 'Release Notes',
       collapsed: false,

--- a/docs-vitepress/versions/latest/community/articles.md
+++ b/docs-vitepress/versions/latest/community/articles.md
@@ -1,0 +1,37 @@
+---
+title: Community Articles
+description: Community-written articles, tutorials, and external walkthroughs about sklearn-genetic-opt.
+---
+
+# Community Articles
+
+These articles, tutorials, and walkthroughs are written outside the official project
+documentation by people using or contributing to `sklearn-genetic-opt`.
+
+If you publish an article about the project, open a pull request adding it to the
+bottom of this list. Entries are kept in submission order so the page recognizes
+contributors fairly without ranking articles.
+
+Please include:
+
+- the article title
+- the author name or GitHub handle
+- the publication platform
+- a short description of what the article teaches
+
+Links should be relevant to `sklearn-genetic-opt`, respectful, and not primarily
+promotional.
+
+## Articles
+
+1. [Hyperparameters Tuning: From Grid Search to Optimization](https://medium.com/data-science/hyperparameters-tuning-from-grid-search-to-optimization-a09853e4e9b8)  
+   Rodrigo Arenas on Medium. Introduces hyperparameter tuning workflows and the
+   motivation for moving beyond exhaustive grid search.
+
+2. [Evolutionary Feature Selection for Machine Learning](https://medium.com/data-science/evolutionary-feature-selection-for-machine-learning-7f61af2a8c12)  
+   Rodrigo Arenas on Medium. Explains how evolutionary search can be used for
+   wrapper-based feature selection in machine learning projects.
+
+3. [sklearn-genetic-opt 0.13: What Five Years of Genetic Search Taught Me](https://rodrigo-arenas.medium.com/sklearn-genetic-opt-0-13-what-five-years-of-genetic-search-taught-me-3f842fc105b2)  
+   Rodrigo Arenas on Medium. Shares lessons from the 0.13 release and the
+   evolution of the project over several years.


### PR DESCRIPTION
## Summary

- Adds a new Community Articles page under the latest docs.
- Seeds the page with some of my existing Medium articles.
- Adds a Community section to the versioned sidebar when the page exists.
- Documents that new external articles should be appended below the current entries to preserve submission order.

## Validation

- `node node_modules\vitepress\bin\vitepress.js build .` from `docs-vitepress`
