### PR TITLE
fix: validate error_score during construction

### DIFF
--- a/sklearn_genetic/evaluation.py
+++ b/sklearn_genetic/evaluation.py
@@ -1,4 +1,18 @@
+from numbers import Real
+
 from joblib import Parallel, delayed, effective_n_jobs
+
+
+def validate_error_score(error_score):
+    if isinstance(error_score, str):
+        if error_score == "raise":
+            return
+        raise ValueError(f"error_score must be numeric or 'raise', got {error_score!r} instead")
+
+    if isinstance(error_score, Real):
+        return
+
+    raise ValueError(f"error_score must be numeric or 'raise', got {error_score!r} instead")
 
 
 def logbook_record(logbook, chapter_name, parameters):

--- a/sklearn_genetic/genetic_search.py
+++ b/sklearn_genetic/genetic_search.py
@@ -61,6 +61,7 @@ from .evaluation import (
     evaluate_population as _evaluate_population_batch,
     logbook_record as _logbook_record,
     record_fit_stats as _record_fit_stats,
+    validate_error_score as _validate_error_score,
     validate_parallel_backend as _validate_parallel_backend,
 )
 from .population import (
@@ -604,6 +605,7 @@ class GASearchCV(GeneticEstimatorMixin, BaseSearchCV):
         self.final_selection_cv = final_selection_cv
 
         _validate_parallel_backend(self.parallel_backend)
+        _validate_error_score(self.error_score)
         _validate_population_initializer(self.population_initializer)
         if self.final_selection_top_k < 1:
             raise ValueError("final_selection_top_k must be greater than or equal to 1")
@@ -1635,6 +1637,7 @@ class GAFeatureSelectionCV(GeneticEstimatorMixin, MetaEstimatorMixin, SelectorMi
         self.sharing_alpha = sharing_alpha
 
         _validate_parallel_backend(self.parallel_backend)
+        _validate_error_score(self.error_score)
         _validate_population_initializer(self.population_initializer)
         _validate_optimizer_control(
             self.local_search_top_k,

--- a/sklearn_genetic/tests/test_feature_selection.py
+++ b/sklearn_genetic/tests/test_feature_selection.py
@@ -115,6 +115,29 @@ def test_feature_selection_grouped_config_is_sklearn_clone_compatible():
     assert "runtime_config" in cloned.get_params()
 
 
+def test_feature_selection_rejects_invalid_error_score():
+    with pytest.raises(ValueError) as excinfo:
+        GAFeatureSelectionCV(
+            DecisionTreeClassifier(),
+            error_score="warn",
+        )
+
+    assert str(excinfo.value) == "error_score must be numeric or 'raise', got 'warn' instead"
+
+
+@pytest.mark.parametrize("error_score", ["raise", np.nan, 0.0])
+def test_feature_selection_accepts_valid_error_score(error_score):
+    estimator = GAFeatureSelectionCV(
+        DecisionTreeClassifier(),
+        error_score=error_score,
+    )
+
+    if isinstance(error_score, float) and np.isnan(error_score):
+        assert np.isnan(estimator.error_score)
+    else:
+        assert estimator.error_score == error_score
+
+
 def test_smart_population_initializer_creates_diverse_feature_masks():
     estimator = GAFeatureSelectionCV(
         DecisionTreeClassifier(random_state=42),

--- a/sklearn_genetic/tests/test_genetic_search.py
+++ b/sklearn_genetic/tests/test_genetic_search.py
@@ -154,6 +154,31 @@ def test_wrong_parallel_backend():
     )
 
 
+def test_gasearch_rejects_invalid_error_score():
+    with pytest.raises(ValueError) as excinfo:
+        GASearchCV(
+            DecisionTreeClassifier(),
+            param_grid={"max_depth": Integer(1, 3)},
+            error_score="warn",
+        )
+
+    assert str(excinfo.value) == "error_score must be numeric or 'raise', got 'warn' instead"
+
+
+@pytest.mark.parametrize("error_score", ["raise", np.nan, 0.0])
+def test_gasearch_accepts_valid_error_score(error_score):
+    estimator = GASearchCV(
+        DecisionTreeClassifier(),
+        param_grid={"max_depth": Integer(1, 3)},
+        error_score=error_score,
+    )
+
+    if isinstance(error_score, float) and np.isnan(error_score):
+        assert np.isnan(estimator.error_score)
+    else:
+        assert estimator.error_score == error_score
+
+
 def test_wrong_population_initializer():
     with pytest.raises(ValueError) as excinfo:
         GASearchCV(


### PR DESCRIPTION
## Summary

- Add a shared `validate_error_score` helper for runtime error-score validation.
- Validate `error_score` during `GASearchCV` and `GAFeatureSelectionCV` construction.
- Add focused tests for invalid string values and accepted `"raise"`, `np.nan`, and numeric values.

## Testing

- `pytest sklearn_genetic/tests/test_genetic_search.py sklearn_genetic/tests/test_feature_selection.py`
- `black --check sklearn_genetic/evaluation.py sklearn_genetic/genetic_search.py sklearn_genetic/tests/test_genetic_search.py sklearn_genetic/tests/test_feature_selection.py`

Closes #237