### PR TITLE
feat(schedules): include received type in check_adapter error (#254)

### DIFF
--- a/sklearn_genetic/schedules/tests/test_schedules.py
+++ b/sklearn_genetic/schedules/tests/test_schedules.py
@@ -45,13 +45,40 @@ def test_check_adapter():
     for _ in range(10):
         assert constant_adapter.step() == 0.6
 
-    with pytest.raises(Exception) as excinfo:
+    with pytest.raises(ValueError) as excinfo:
         check_adapter(True)
-    assert (
-        str(excinfo.value)
-        == "adapter should be either a class with inheritance from schedulers.base.BaseAdapter "
-        "or a real number."
-    )
+
+    message = str(excinfo.value)
+    # The received type is reported so misconfigurations are easy to debug ...
+    assert "bool" in message
+    # ... and the expected adapter base class is still mentioned.
+    assert "schedulers.base.BaseAdapter" in message
+
+
+class _NotAnAdapter:
+    """A plain object that does not inherit from ``BaseAdapter``."""
+
+
+@pytest.mark.parametrize(
+    "invalid_adapter, expected_type_name",
+    [
+        (True, "bool"),
+        ("constant", "str"),
+        ([0.5], "list"),
+        (None, "NoneType"),
+        (_NotAnAdapter(), "_NotAnAdapter"),
+    ],
+)
+def test_check_adapter_invalid_object_error_message(invalid_adapter, expected_type_name):
+    # 1. Invalid objects raise a ValueError.
+    with pytest.raises(ValueError) as excinfo:
+        check_adapter(invalid_adapter)
+
+    message = str(excinfo.value)
+    # 2. The message names the received type so the mistake is obvious.
+    assert expected_type_name in message
+    # 3. The message still points users to the expected adapter base class.
+    assert "schedulers.base.BaseAdapter" in message
 
 
 def test_scheduler_reset():

--- a/sklearn_genetic/schedules/validations.py
+++ b/sklearn_genetic/schedules/validations.py
@@ -4,7 +4,7 @@ from .schedulers import ConstantAdapter
 
 def check_adapter(adapter):
     """
-    Check if the adapter is a number of a class, if it's a number it will create a ConstantAdapter
+    Check if the adapter is a number or a class, if it's a number it will create a ConstantAdapter
     """
     if isinstance(adapter, BaseAdapter):
         return adapter
@@ -12,6 +12,8 @@ def check_adapter(adapter):
         return ConstantAdapter(initial_value=adapter, end_value=adapter, adaptive_rate=0)
     else:
         raise ValueError(
-            "adapter should be either a class with inheritance from schedulers.base.BaseAdapter "
-            "or a real number."
+            "adapter should be either a class with inheritance from "
+            "schedulers.base.BaseAdapter (for example ConstantAdapter, "
+            "ExponentialAdapter, InverseAdapter, or PotentialAdapter) or a real "
+            f"number, but got {type(adapter).__name__!r}."
         )


### PR DESCRIPTION
## Summary

Improve the `check_adapter` validation error so it names the **type that was actually received** (e.g. `'bool'`) in addition to the expected base class. The valid number/adapter behavior is unchanged — this only makes misconfigured scheduler adapters faster to debug.

## Related Issue

Closes #254

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] Other (describe):

## What changed

`sklearn_genetic/schedules/validations.py` — when an invalid object is passed as a scheduler adapter (for example as a `crossover_probability` or `mutation_probability`), the raised `ValueError` previously named only the expected base class:

```
adapter should be either a class with inheritance from schedulers.base.BaseAdapter or a real number.
```

It now also reports the received type and lists concrete valid adapters:

```
adapter should be either a class with inheritance from schedulers.base.BaseAdapter
(for example ConstantAdapter, ExponentialAdapter, InverseAdapter, or PotentialAdapter)
or a real number, but got 'bool'.
```

## Tests

- Updated `test_check_adapter` to assert on the new message (received type + expected base class) instead of an exact-string match.
- Added `test_check_adapter_invalid_object_error_message`, parametrized over `bool`, `str`, `list`, `None`, and a non-adapter object — each must raise `ValueError`, name the received type, and still mention `schedulers.base.BaseAdapter`.

```
pytest sklearn_genetic/schedules/tests/test_schedules.py
# 21 passed
```

## Checklist

- [x] I checked the linked issue is open and not already covered by another PR
- [x] Tests pass locally (`pytest sklearn_genetic/`)
- [x] Code is formatted with Black (`black sklearn_genetic/`)
- [x] New functionality is covered by tests
- [ ] Documentation updated if needed (not needed — internal validation message only)
