### PR TITLE
test(plots): add direct unit tests for the _as_list helper (#256)

### DIFF
--- a/sklearn_genetic/tests/test_plots.py
+++ b/sklearn_genetic/tests/test_plots.py
@@ -9,6 +9,7 @@ matplotlib.use("Agg")
 
 from .. import GASearchCV, GAFeatureSelectionCV
 from ..plots import (
+    _as_list,
     SearchPlotter,
     plot_candidate_rankings,
     plot_candidate_scores,
@@ -352,3 +353,23 @@ def test_plot_feature_selection_on_unfitted_estimator_names_the_plot():
     assert "plot_feature_selection requires" in message
     assert "estimator.fit(X, y)" in message
     assert "estimator.best_features_" in message
+
+
+def test_as_list_normalizes_plot_inputs():
+    """_as_list normalizes the field/parameter-name inputs used across the plots."""
+    # None means "nothing selected" -> empty list.
+    assert _as_list(None) == []
+
+    # A single string becomes a one-element list, not a list of characters.
+    assert _as_list("score") == ["score"]
+    assert _as_list("score") != ["s", "c", "o", "r", "e"]
+
+    # An iterable of strings is materialized into a list.
+    assert _as_list(("a", "b")) == ["a", "b"]
+    assert _as_list(["a", "b"]) == ["a", "b"]
+
+    # A lazy iterable (generator) is consumed into a concrete list.
+    assert _as_list(name for name in ("x", "y")) == ["x", "y"]
+
+    # A non-iterable scalar is wrapped as a single-element list.
+    assert _as_list(5) == [5]


### PR DESCRIPTION
## Summary

Add direct unit tests for the internal `_as_list` plotting helper. Test-only — no behavior change.

## Related Issue

Closes #256

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / cleanup
- [x] Other (describe): test coverage for an internal helper

## What changed

`_as_list` (in `sklearn_genetic/plots.py`) normalizes the field/parameter-name inputs accepted by several public plotting functions (`plot_history`, `plot_search_space`, `plot_parameter_evolution`, …), where a value may be a single string or an iterable of strings. It had no direct test. This pins its contract:

- `_as_list(None)` → `[]`
- `_as_list("score")` → `["score"]` (a single string is **not** split into characters)
- `_as_list(("a", "b"))` / `_as_list(["a", "b"])` → `["a", "b"]`
- a generator (lazy iterable) is consumed into a concrete list
- a non-iterable scalar is wrapped as `[value]`

## Tests

```
pytest sklearn_genetic/tests/test_plots.py -k as_list
# 1 passed
```

## Checklist

- [x] I checked the linked issue is open and not already covered by another PR
- [x] Tests pass locally (`pytest sklearn_genetic/`)
- [x] Code is formatted with Black (`black sklearn_genetic/`)
- [x] New functionality is covered by tests
- [ ] Documentation updated if needed (not needed — internal helper)
