### PR TITLE
docs(callbacks): add a runnable TimerStopping example (#255)

### DIFF
--- a/docs-vitepress/versions/latest/guide/callbacks.md
+++ b/docs-vitepress/versions/latest/guide/callbacks.md
@@ -122,6 +122,18 @@ callback = TimerStopping(total_seconds=300)  # stop after 5 minutes
 |-----------|------|-------------|
 | `total_seconds` | float | Maximum elapsed seconds. Checked after each generation, so the current generation completes before stopping |
 
+Pass it to `fit` to cap a long search by wall-clock time — handy for notebook and local experiments where the search space may be larger than expected:
+
+```python
+from sklearn_genetic.callbacks import TimerStopping
+
+callbacks = [TimerStopping(total_seconds=60)]
+
+search.fit(X_train, y_train, callbacks=callbacks)
+```
+
+The optimization stops after the time budget is reached, once the current generation finishes.
+
 ---
 
 ### LogbookSaver


### PR DESCRIPTION
## Summary

Add a short, copy-pasteable `TimerStopping` example to the callbacks guide showing how to cap a long search by wall-clock time.

## Related Issue

Closes #255

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactor / cleanup
- [ ] Other (describe):

## What changed

`docs-vitepress/versions/latest/guide/callbacks.md` already documented `TimerStopping` and its `total_seconds` parameter, but did not show it wired into `fit`. Added an example mirroring the issue's suggestion (and this page's existing `search.fit(X_train, y_train, ...)` style):

```python
from sklearn_genetic.callbacks import TimerStopping

callbacks = [TimerStopping(total_seconds=60)]

search.fit(X_train, y_train, callbacks=callbacks)
```

plus one sentence noting the run stops after the current generation once the time budget is reached.

## Validation

```
npm run docs:build   # vitepress build . -> build complete, exit 0
```

## Checklist

- [x] I checked the linked issue is open and not already covered by another PR
- [ ] Tests pass locally (`pytest sklearn_genetic/`) — docs-only change, no Python tests
- [ ] Code is formatted with Black — docs-only change
- [ ] New functionality is covered by tests — docs-only change
- [x] Documentation updated and builds locally (`npm run docs:build`)
