### PR TITLE
Validate top_k values in candidate plots

### DIFF
--- a/sklearn_genetic/plots.py
+++ b/sklearn_genetic/plots.py
@@ -215,7 +215,17 @@ def _score_values(estimator, metric=None):
     return frame, score_column, pd.to_numeric(frame[score_column], errors="coerce")
 
 
+def _validate_top_k(top_k):
+    if top_k is None:
+        return
+
+    if isinstance(top_k, bool) or not isinstance(top_k, (int, np.integer)) or top_k < 1:
+        raise ValueError("top_k must be a positive integer")
+
+
 def _candidate_frame(estimator, metric=None, top_k=None, sort=True):
+    _validate_top_k(top_k)
+
     frame, score_column, scores = _score_values(estimator, metric=metric)
     candidates = frame.copy()
     candidates[score_column] = scores
@@ -760,18 +770,12 @@ def plot_candidate_scores(
 
     _require_seaborn()
 
-    frame, score_column, scores = _score_values(estimator, metric=metric)
-    candidates = frame.copy()
-    candidates[score_column] = scores
-    candidates = candidates.dropna(subset=[score_column])
-
-    if candidates.empty:
-        raise ValueError("No candidate scores were found in estimator.cv_results_")
-
-    if sort:
-        candidates = candidates.sort_values(score_column, ascending=False)
-
-    candidates = candidates.head(top_k)
+    candidates, score_column = _candidate_frame(
+        estimator,
+        metric=metric,
+        top_k=top_k,
+        sort=sort,
+    )
     labels = _candidate_labels(
         candidates,
         label_params=label_params,

--- a/sklearn_genetic/tests/test_plots.py
+++ b/sklearn_genetic/tests/test_plots.py
@@ -192,6 +192,34 @@ def test_plot_candidate_scores():
     )
 
 
+@pytest.mark.parametrize(
+    "plot_function",
+    [
+        plot_candidate_scores,
+        plot_cv_scores,
+        plot_candidate_rankings,
+    ],
+)
+@pytest.mark.parametrize("top_k", [0, -1, 1.5])
+def test_candidate_plots_reject_invalid_top_k(plot_function, top_k):
+    with pytest.raises(ValueError, match="top_k must be a positive integer"):
+        plot_function(evolved_estimator, top_k=top_k)
+
+
+@pytest.mark.parametrize(
+    "plot_function",
+    [
+        plot_candidate_scores,
+        plot_cv_scores,
+        plot_candidate_rankings,
+    ],
+)
+@pytest.mark.parametrize("top_k", [1, None])
+def test_candidate_plots_accept_valid_top_k(plot_function, top_k):
+    plot = plot_function(evolved_estimator, top_k=top_k)
+    assert plot is not None
+
+
 def test_plot_convergence_and_diversity():
     convergence = plot_convergence(evolved_estimator)
     assert convergence.get_title() == "Convergence"


### PR DESCRIPTION
## Summary

Add shared validation for `top_k` in candidate plotting helpers.

Invalid values such as zero, negative integers, floats, and booleans now raise a clear `ValueError`. Positive integers and `None` remain supported.

## Related Issue

Closes #257

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [x] Refactor / cleanup
* [ ] Other (describe):

## Checklist

* [x] I checked the linked issue is open and not already covered by another PR
* [x] Tests pass locally (`pytest sklearn_genetic/`)
* [x] Code is formatted with Black (`black sklearn_genetic/`)
* [x] New functionality is covered by tests
* [ ] Documentation updated if needed
