### PR TITLE
Fix/plot history show available fields

### DIFF
--- a/sklearn_genetic/plots.py
+++ b/sklearn_genetic/plots.py
@@ -73,7 +73,7 @@ def _history_frame(estimator, source="history", fields=None):
     if fields is not None:
         missing = [field for field in fields if field not in frame.columns]
         if missing:
-            raise ValueError(f"fields not found in {source}: {missing}")
+            raise ValueError(f"fields not found in {source}: {missing}. Available fields include: {list(frame.columns)}")
         frame = frame.loc[:, list(fields)]
 
     return frame
@@ -442,7 +442,7 @@ def plot_history(
 
     missing = [field for field in fields if field not in frame.columns]
     if missing:
-        raise ValueError(f"fields not found in {source}: {missing}")
+        raise ValueError(f"fields not found in {source}: {missing}. Available fields include: {list(frame.columns)}")
 
     plotted = frame.loc[:, fields].copy()
     if rolling is not None:

--- a/sklearn_genetic/plots.py
+++ b/sklearn_genetic/plots.py
@@ -73,7 +73,9 @@ def _history_frame(estimator, source="history", fields=None):
     if fields is not None:
         missing = [field for field in fields if field not in frame.columns]
         if missing:
-            raise ValueError(f"fields not found in {source}: {missing}. Available fields include: {list(frame.columns)}")
+            raise ValueError(
+                f"fields not found in {source}: {missing}. Available fields include: {list(frame.columns)}"
+            )
         frame = frame.loc[:, list(fields)]
 
     return frame
@@ -442,7 +444,9 @@ def plot_history(
 
     missing = [field for field in fields if field not in frame.columns]
     if missing:
-        raise ValueError(f"fields not found in {source}: {missing}. Available fields include: {list(frame.columns)}")
+        raise ValueError(
+            f"fields not found in {source}: {missing}. Available fields include: {list(frame.columns)}"
+        )
 
     plotted = frame.loc[:, fields].copy()
     if rolling is not None:

--- a/sklearn_genetic/tests/test_plots.py
+++ b/sklearn_genetic/tests/test_plots.py
@@ -111,7 +111,12 @@ def test_plot_history():
 
     with pytest.raises(ValueError, match="fields not found in history") as excinfo:
         plot_history(evolved_estimator, fields=["missing_field"])
-    assert "Available fields include" in str(excinfo.value)
+    message = str(excinfo.value)
+    assert "Available fields include" in message
+    assert "gen" in message
+
+
+
     with pytest.raises(ValueError, match="kind must be one of"):
         plot_history(evolved_estimator, kind="scatter")
 

--- a/sklearn_genetic/tests/test_plots.py
+++ b/sklearn_genetic/tests/test_plots.py
@@ -115,8 +115,6 @@ def test_plot_history():
     assert "Available fields include" in message
     assert "gen" in message
 
-
-
     with pytest.raises(ValueError, match="kind must be one of"):
         plot_history(evolved_estimator, kind="scatter")
 

--- a/sklearn_genetic/tests/test_plots.py
+++ b/sklearn_genetic/tests/test_plots.py
@@ -109,9 +109,9 @@ def test_plot_history():
     )
     assert logbook_plot.get_xlabel() == "record index"
 
-    with pytest.raises(ValueError, match="fields not found in history"):
+    with pytest.raises(ValueError, match="fields not found in history") as excinfo:
         plot_history(evolved_estimator, fields=["missing_field"])
-
+    assert "Available fields include" in str(excinfo.value)
     with pytest.raises(ValueError, match="kind must be one of"):
         plot_history(evolved_estimator, kind="scatter")
 


### PR DESCRIPTION
## Summary
Improved the error message in `plot_history` to show available fields when an unknown field is passed. Previously the error only showed the missing field name, making it hard for users to know what valid fields exist without inspecting internal data structures manually.

## Related Issue
Closes #253

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] Other (describe):

## Checklist
- [x] I checked the linked issue is open and not already covered by another PR
- [x] Tests pass locally (`pytest sklearn_genetic/`)
- [x] Code is formatted with Black (`black sklearn_genetic/`)
- [x] New functionality is covered by tests
- [ ] Documentation updated if needed