### PR TITLE
feat(plots): list available metric names in metric-column errors (#259)

### DIFF
--- a/sklearn_genetic/plots.py
+++ b/sklearn_genetic/plots.py
@@ -122,8 +122,15 @@ def _cv_results_frame(estimator):
 def _metric_column(estimator, metric=None, prefix="mean_test"):
     metric = metric or getattr(estimator, "refit_metric", "score")
     column = f"{prefix}_{metric}"
-    if column not in getattr(estimator, "cv_results_", {}):
-        raise ValueError(f"metric column not found in estimator.cv_results_: {column}")
+    cv_results = getattr(estimator, "cv_results_", {})
+    if column not in cv_results:
+        available = sorted(
+            key[len(prefix) + 1 :] for key in cv_results if key.startswith(f"{prefix}_")
+        )
+        raise ValueError(
+            f"metric column not found in estimator.cv_results_: {column}. "
+            f"Available metrics: {available}"
+        )
     return column
 
 

--- a/sklearn_genetic/tests/test_plots.py
+++ b/sklearn_genetic/tests/test_plots.py
@@ -401,3 +401,29 @@ def test_as_list_normalizes_plot_inputs():
 
     # A non-iterable scalar is wrapped as a single-element list.
     assert _as_list(5) == [5]
+
+
+def test_metric_column_lists_available_metrics_on_unknown():
+    """An unknown metric error lists the available metric names (#259)."""
+    from types import SimpleNamespace
+    from ..plots import _metric_column
+
+    estimator = SimpleNamespace(
+        cv_results_={
+            "mean_test_accuracy": [0.9],
+            "mean_test_f1": [0.8],
+            "std_test_accuracy": [0.0],  # different prefix, must be ignored
+        },
+        refit_metric="accuracy",
+    )
+
+    # A valid metric still resolves to its column.
+    assert _metric_column(estimator, metric="accuracy") == "mean_test_accuracy"
+
+    # An unknown metric names the missing column and the available metrics.
+    with pytest.raises(ValueError) as excinfo:
+        _metric_column(estimator, metric="roc_auc")
+    message = str(excinfo.value)
+    assert "mean_test_roc_auc" in message
+    assert "Available metrics" in message
+    assert "accuracy" in message and "f1" in message


### PR DESCRIPTION
## Summary

When a plotting helper receives a metric that isn't in `estimator.cv_results_`, the error now also lists the **available** metrics, so the fix is obvious for multi-metric searches.

## Related Issue

Closes #259

## Type of Change

- [x] Bug fix / UX improvement

## What changed

`_metric_column` collects the metric names from the `mean_test_*` columns and includes them in the `ValueError`:

Before:
```
metric column not found in estimator.cv_results_: mean_test_roc_auc
```
After:
```
metric column not found in estimator.cv_results_: mean_test_roc_auc. Available metrics: ['accuracy', 'f1']
```

Existing missing-column detail is kept; only `mean_test_*` columns are considered (e.g. `std_test_*` is ignored).

## Checklist

- [x] Tests pass locally (`pytest sklearn_genetic/`) — added a focused `_metric_column` unit test
- [x] Code is formatted with Black
- [x] New functionality is covered by tests
- [ ] Documentation updated if needed — n/a

— Contributed by **Mayoka Labs**