### PR TITLE
feat(converters): suggest list/Categorical for unsupported scipy distributions (#260)

### DIFF
--- a/sklearn_genetic/space/converters.py
+++ b/sklearn_genetic/space/converters.py
@@ -80,8 +80,9 @@ def _convert_scipy_distribution(parameter, distribution):
     raise ValueError(
         f"{parameter} uses scipy.stats.{name}, which cannot be converted automatically. "
         "Supported scipy distributions are randint, uniform, loguniform, and reciprocal. "
-        "For other distributions, define the search space manually, for example "
-        "Continuous(lower, upper)."
+        "For other distributions, define the search space manually: use "
+        "Continuous(lower, upper) or Integer(lower, upper) for numeric ranges, or a "
+        "plain list / Categorical([...]) for a small set of choices."
     )
 
 

--- a/sklearn_genetic/space/tests/test_space.py
+++ b/sklearn_genetic/space/tests/test_space.py
@@ -328,6 +328,9 @@ def test_from_sklearn_space_rejects_unsupported_distributions():
     )
     assert "define the search space manually" in message
     assert "Continuous(lower, upper)" in message
+    # Guidance for users who actually wanted a small set of choices (#260).
+    assert "Categorical([...])" in message
+    assert "choices" in message
 
 
 def test_from_sklearn_space_rejects_empty_or_ambiguous_values():


### PR DESCRIPTION
## Summary

Makes `from_sklearn_space`'s unsupported-distribution error more actionable for users who actually wanted a small set of choices — it now points them to a plain list or `Categorical([...])` (and `Integer` for numeric ranges), alongside the existing `Continuous` guidance.

## Related Issue

Closes #260

## Type of Change

- [x] Bug fix / UX improvement

## What changed

```
alpha uses scipy.stats.expon, which cannot be converted automatically.
Supported scipy distributions are randint, uniform, loguniform, and reciprocal.
For other distributions, define the search space manually: use Continuous(lower, upper)
or Integer(lower, upper) for numeric ranges, or a plain list / Categorical([...]) for a
small set of choices.
```

Supported conversions are unchanged, and the parameter name + scipy distribution name are still kept in the message.

## Checklist

- [x] Tests pass locally (`pytest sklearn_genetic/`) — strengthened `test_from_sklearn_space_rejects_unsupported_distributions`
- [x] Code is formatted with Black
- [x] New functionality is covered by tests
- [ ] Documentation updated if needed — n/a

— Contributed by **Mayoka Labs**