### PR TITLE
docs(presets): add full Pipeline example for preset prefix (#263)

### DIFF
--- a/docs-vitepress/versions/latest/api/presets.md
+++ b/docs-vitepress/versions/latest/api/presets.md
@@ -85,6 +85,55 @@ param_grid = svc_space(prefix="model__")
 This returns parameter names such as `model__C`, `model__kernel`, and
 `model__gamma`.
 
+### Full example: tuning a preset inside a `Pipeline`
+
+The `prefix` must match the **step name** of the estimator in the pipeline. If
+the step is named `"model"`, use `prefix="model__"` so the keys become
+`model__n_estimators`, `model__max_depth`, and so on:
+
+```python
+from sklearn.datasets import load_breast_cancer
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.model_selection import train_test_split
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
+
+from sklearn_genetic import GASearchCV
+from sklearn_genetic.presets import random_forest_classifier_space
+
+X, y = load_breast_cancer(return_X_y=True)
+X_train, X_test, y_train, y_test = train_test_split(
+    X, y, test_size=0.2, stratify=y, random_state=0
+)
+
+pipe = Pipeline(
+    [
+        ("scale", StandardScaler()),
+        ("model", RandomForestClassifier(random_state=0, n_jobs=1)),
+    ]
+)
+
+# prefix="model__" matches the "model" step, e.g. model__n_estimators
+param_grid = random_forest_classifier_space(prefix="model__")
+
+search = GASearchCV(
+    estimator=pipe,
+    param_grid=param_grid,
+    scoring="roc_auc",
+    cv=3,
+    population_size=10,
+    generations=5,
+    random_state=0,
+)
+search.fit(X_train, y_train)
+print("Best ROC AUC:", round(search.best_score_, 4))
+```
+
+:::tip
+The prefix is just the pipeline step name followed by `__`. If your step is
+called `"clf"`, use `prefix="clf__"`. See [Tuning scikit-learn Pipelines](../guide/pipeline-tuning) for more.
+:::
+
 ## XGBoost
 
 The XGBoost presets cover the common nine-parameter tree booster space used in


### PR DESCRIPTION
## Summary

Adds a compact, runnable example to `api/presets.md` showing how to use a preset search space inside a scikit-learn `Pipeline` — how `prefix="model__"` maps to `model__n_estimators`-style keys and plugs into `GASearchCV(estimator=pipe)`.

## Related Issue

Closes #263

## Type of Change

- [x] Documentation update

## Notes

- Built on the existing "Pipeline prefixes" section (extended, not duplicated).
- Example uses a built-in sklearn dataset (`load_breast_cancer`) and small `population_size`/`generations`, per the docs example standards — verified it constructs and the prefix produces `model__` keys.
- Links to the existing `guide/pipeline-tuning` page (target verified).
- Edited `versions/latest/` only.

## Checklist

- [x] Tests pass locally — n/a (docs)
- [x] Code is formatted with Black — n/a (docs)
- [x] Documentation updated

— Contributed by **Mayoka Labs**