### PR TITLE
Show available fields in error when plot history receives an unknown field.

### DIFF
--- a/sklearn_genetic/plots.py
+++ b/sklearn_genetic/plots.py
@@ -73,7 +73,10 @@ def _history_frame(estimator, source="history", fields=None):
     if fields is not None:
         missing = [field for field in fields if field not in frame.columns]
         if missing:
-            raise ValueError(f"fields not found in {source}: {missing}")
+            available = sorted(frame.columns.tolist())
+            raise ValueError(
+                f"fields not found in {source}: {missing}. Available fields: {available}"
+            )
         frame = frame.loc[:, list(fields)]
 
     return frame
@@ -452,7 +455,10 @@ def plot_history(
 
     missing = [field for field in fields if field not in frame.columns]
     if missing:
-        raise ValueError(f"fields not found in {source}: {missing}")
+        available = sorted(frame.columns.tolist())
+        raise ValueError(
+            f"fields not found in {source}: {missing}. Available fields: {available}"
+        )
 
     plotted = frame.loc[:, fields].copy()
     if rolling is not None:

--- a/sklearn_genetic/tests/test_plots.py
+++ b/sklearn_genetic/tests/test_plots.py
@@ -109,8 +109,10 @@ def test_plot_history():
     )
     assert logbook_plot.get_xlabel() == "record index"
 
-    with pytest.raises(ValueError, match="fields not found in history"):
+    with pytest.raises(ValueError, match="fields not found in history") as exc_info:
         plot_history(evolved_estimator, fields=["missing_field"])
+    assert "Available fields" in str(exc_info.value)
+    assert "missing_field" in str(exc_info.value)
 
     with pytest.raises(ValueError, match="kind must be one of"):
         plot_history(evolved_estimator, kind="scatter")


### PR DESCRIPTION
When an unknown field is passed to plot history, the error now lists available fields, making it easier to correct the mistake.

Closes #253.