### PR TITLE
Add Citation section to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -286,6 +286,18 @@ Common use cases
 `Browse all Tutorials →
 <https://sklearngeneticopt.rodrigo-arenas.com/versions/latest/tutorials/>`_
 
+Citation
+########
+
+If ``sklearn-genetic-opt`` is useful in your research, please cite it. You can use the
+"Cite this repository" button on the GitHub page (powered by ``CITATION.cff``), or cite
+it directly:
+
+.. code-block:: text
+
+    Arenas, R. sklearn-genetic-opt: Hyperparameter tuning and feature selection using
+    genetic algorithms, built on top of scikit-learn.
+    https://github.com/rodrigo-arenas/Sklearn-genetic-opt
 
 Learning paths
 ###############


### PR DESCRIPTION
Added citation section for sklearn-genetic-opt.

## Summary

Added a Citation section to README.rst (between Contributing and Links) so users know how to cite sklearn-genetic-opt in academic work. This follows up on the suggestion from @rodrigo-arenas in #248.

## Related Issue

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactor / cleanup
