### PR TITLE
 Fix incorrect type annotation for Categorical.random_state

### DIFF
--- a/sklearn_genetic/space/space.py
+++ b/sklearn_genetic/space/space.py
@@ -144,7 +144,7 @@ class Categorical(BaseDimension):
         choices: Optional[List[Any]] = None,
         priors: Optional[List[float]] = None,
         distribution: str = "choice",
-        random_state: Optional[Union[int, np.random.Generator]] = None,
+        random_state: Optional[int] = None,
     ) -> None:
         """
         Parameters


### PR DESCRIPTION
Fixes a type annotation on `Categorical.random_state` that doesn't match what the code actually supports.

## Related Issue

No existing issue — found while reviewing the `Categorical` class implementation. 

## Type of Change

- [x] Bug fix

- [x] I checked the linked issue is open and not already covered by another PR
- [x] Tests pass locally (`pytest sklearn_genetic/`)
- [x] Code is formatted with Black (`black sklearn_genetic/`)
- [ ] New functionality is covered by tests
- [ ] Documentation updated if needed

## Details

`Categorical.__init__` declares `random_state: Optional[Union[int, np.random.Generator]]`, but the parameter is only ever used as an integer seed internally — passing an `np.random.Generator` instance is not actually supported by the implementation. This PR narrows the annotation to `Optional[int]` to match real behavior.

This is a type-annotation-only change. No runtime logic was modified. Existing test suite passes locally with no regressions.