### PR TITLE
docs(presets): add Pipeline example for preset prefix usage

### DIFF
--- a/docs-vitepress/versions/latest/api/presets.md
+++ b/docs-vitepress/versions/latest/api/presets.md
@@ -85,6 +85,56 @@ param_grid = svc_space(prefix="model__")
 This returns parameter names such as `model__C`, `model__kernel`, and
 `model__gamma`.
 
+### Full example: tuning a preset inside a Pipeline
+
+The `prefix` must match the **step name** you gave the estimator in the pipeline.
+If the step is named `"model"`, pass `prefix="model__"` so every key becomes
+`model__n_estimators`, `model__max_depth`, and so on:
+
+```python
+from sklearn.datasets import load_breast_cancer
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.model_selection import train_test_split
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
+
+from sklearn_genetic import GASearchCV
+from sklearn_genetic.presets import random_forest_classifier_space
+
+X, y = load_breast_cancer(return_X_y=True)
+X_train, X_test, y_train, y_test = train_test_split(
+    X, y, test_size=0.2, stratify=y, random_state=0
+)
+
+pipe = Pipeline(
+    [
+        ("scale", StandardScaler()),
+        ("model", RandomForestClassifier(random_state=0, n_jobs=1)),
+    ]
+)
+
+# prefix="model__" matches the "model" step → model__n_estimators, model__max_depth, ...
+param_grid = random_forest_classifier_space(prefix="model__")
+
+search = GASearchCV(
+    estimator=pipe,
+    param_grid=param_grid,
+    scoring="roc_auc",
+    cv=3,
+    population_size=10,
+    generations=5,
+    random_state=0,
+)
+search.fit(X_train, y_train)
+print("Best ROC AUC:", round(search.best_score_, 4))
+```
+
+:::tip
+The prefix is the pipeline step name followed by `__`. If your step is called
+`"clf"`, use `prefix="clf__"`. See [Tuning scikit-learn Pipelines](../guide/pipeline-tuning)
+for the full pipeline tuning guide.
+:::
+
 ## XGBoost
 
 The XGBoost presets cover the common nine-parameter tree booster space used in

--- a/docs-vitepress/versions/latest/guide/pipeline-tuning.md
+++ b/docs-vitepress/versions/latest/guide/pipeline-tuning.md
@@ -90,6 +90,53 @@ print("Best parameters:", search.best_params_)
 y_pred = search.predict(X_test)
 ```
 
+## Using Preset Search Spaces
+
+Instead of writing every dimension by hand, you can start from a [preset](../api/presets)
+search space and pass `prefix` to match your pipeline step name:
+
+```python
+from sklearn.datasets import load_breast_cancer
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.model_selection import train_test_split
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
+
+from sklearn_genetic import GASearchCV
+from sklearn_genetic.presets import random_forest_classifier_space
+
+X, y = load_breast_cancer(return_X_y=True)
+X_train, X_test, y_train, y_test = train_test_split(
+    X, y, test_size=0.2, stratify=y, random_state=0
+)
+
+pipe = Pipeline(
+    [
+        ("scale", StandardScaler()),
+        ("model", RandomForestClassifier(random_state=0, n_jobs=1)),
+    ]
+)
+
+# prefix="model__" produces keys like model__n_estimators, model__max_depth
+param_grid = random_forest_classifier_space(prefix="model__")
+
+search = GASearchCV(
+    estimator=pipe,
+    param_grid=param_grid,
+    scoring="roc_auc",
+    cv=3,
+    population_size=10,
+    generations=5,
+    random_state=0,
+)
+search.fit(X_train, y_train)
+print("Best ROC AUC:", round(search.best_score_, 4))
+```
+
+The prefix must match the step name — `"model"` → `prefix="model__"`. See
+[Estimator Presets](../api/presets) for the full list of available presets and
+profiles (`"fast"`, `"balanced"`, `"wide"`).
+
 ## Tips & Gotchas
 
 - Always call `pipe.get_params().keys()` first — it is easy to misspell a step name.


### PR DESCRIPTION
## Summary

Adds documentation showing how to use preset search spaces inside scikit-learn `Pipeline` objects — how `prefix="model__"` maps to `model__n_estimators`-style keys and plugs into `GASearchCV(estimator=pipe)`.

The issue notes this is a medium documentation task because it touches **two** docs pages:

### Changes

**`docs-vitepress/versions/latest/api/presets.md`**
- Added a "Full example: tuning a preset inside a Pipeline" subsection after the existing "Pipeline prefixes" section
- Shows `random_forest_classifier_space(prefix="model__")` inside a `Pipeline` with `StandardScaler` + `RandomForestClassifier`
- Includes a tip explaining the prefix must match the pipeline step name, with a cross-link to the pipeline tuning guide

**`docs-vitepress/versions/latest/guide/pipeline-tuning.md`**
- Added a "Using Preset Search Spaces" section showing presets as an alternative to manually writing `param_grid` dimensions
- Cross-links back to the Estimator Presets API page so readers can discover all available presets and profiles

### Validation

- Python example verified — runs without errors, produces correctly prefixed keys (`model__n_estimators`, `model__max_depth`, etc.) and a valid best score
- VitePress build passes (`npx vitepress build .`)

## Related Issue

Closes #263

## Type of Change

- [x] Documentation update

## Checklist

- [x] Tests pass locally — n/a (docs only)
- [x] Code is formatted with Black — n/a (docs)
- [x] Documentation updated