### PR TITLE
fix(plots): list available metrics when metric column not found

### DIFF
--- a/sklearn_genetic/plots.py
+++ b/sklearn_genetic/plots.py
@@ -123,7 +123,19 @@ def _metric_column(estimator, metric=None, prefix="mean_test"):
     metric = metric or getattr(estimator, "refit_metric", "score")
     column = f"{prefix}_{metric}"
     if column not in getattr(estimator, "cv_results_", {}):
-        raise ValueError(f"metric column not found in estimator.cv_results_: {column}")
+        cv_results = getattr(estimator, "cv_results_", {}) or {}
+        prefix_with_sep = f"{prefix}_"
+        available_metrics = sorted(
+            {
+                col[len(prefix_with_sep):]
+                for col in cv_results
+                if col.startswith(prefix_with_sep)
+            }
+        )
+        raise ValueError(
+            f"metric column not found in estimator.cv_results_: {column}. "
+            f"Available metrics: {available_metrics}"
+        )
     return column
 
 

--- a/sklearn_genetic/tests/test_plots.py
+++ b/sklearn_genetic/tests/test_plots.py
@@ -10,6 +10,7 @@ matplotlib.use("Agg")
 from .. import GASearchCV, GAFeatureSelectionCV
 from ..plots import (
     _as_list,
+    _metric_column,
     SearchPlotter,
     plot_candidate_rankings,
     plot_candidate_scores,
@@ -401,3 +402,50 @@ def test_as_list_normalizes_plot_inputs():
 
     # A non-iterable scalar is wrapped as a single-element list.
     assert _as_list(5) == [5]
+
+
+def test_metric_column_lists_available_metrics_for_invalid_metric():
+    """Invalid metrics should raise ValueError that names available metrics (#259)."""
+    with pytest.raises(ValueError) as excinfo:
+        _metric_column(evolved_estimator, metric="auc")
+
+    message = str(excinfo.value)
+    assert "metric column not found in estimator.cv_results_:" in message
+    assert "mean_test_auc" in message
+    assert "Available metrics:" in message
+
+
+def test_metric_column_lists_actual_available_metrics():
+    """The error should list the metrics present in cv_results_ (#259)."""
+    with pytest.raises(ValueError) as excinfo:
+        _metric_column(evolved_estimator, metric="auc")
+
+    message = str(excinfo.value)
+    assert "score" in message
+    assert "fit_time" not in message  # fit_time does not start with mean_test_
+
+
+def test_metric_column_custom_prefix_includes_available_metrics():
+    """For custom prefixes, the error should list metrics for that prefix (#259)."""
+    with pytest.raises(ValueError) as excinfo:
+        _metric_column(evolved_estimator, metric="roc_auc", prefix="std_test")
+
+    message = str(excinfo.value)
+    assert "std_test_roc_auc" in message
+    assert "Available metrics:" in message
+
+
+def test_metric_column_valid_metric_returns_column():
+    """A valid metric should still resolve to its column name (#259)."""
+    assert _metric_column(evolved_estimator) == "mean_test_score"
+    assert _metric_column(evolved_estimator, metric="score") == "mean_test_score"
+
+
+def test_invalid_metric_error_caught_via_public_plot():
+    """The improved error should propagate through public plotting entry points (#259)."""
+    with pytest.raises(ValueError) as excinfo:
+        plot_candidate_scores(evolved_estimator, metric="nonexistent_metric")
+
+    message = str(excinfo.value)
+    assert "Available metrics:" in message
+    assert "mean_test_nonexistent_metric" in message


### PR DESCRIPTION
## Summary
When a user passes a metric that is not present in `estimator.cv_results_`, the plotting error now lists the available metrics alongside the missing column name. This makes the fix obvious for multi-metric searches where columns may use names like `mean_test_accuracy`, `mean_test_f1`, or `mean_test_roc_auc`.

### Example error message
```
metric column not found in estimator.cv_results_: mean_test_auc. Available metrics: ['accuracy', 'f1']
```

## Changes
- `sklearn_genetic/plots.py` — when `_metric_column` cannot find `{prefix}_{metric}`, it inspects `estimator.cv_results_` and lists the columns starting with `{prefix}_` (with the prefix removed) in the raised `ValueError`.
- `sklearn_genetic/tests/test_plots.py` — five new tests cover: the new error message for the default `mean_test` prefix, the actual available metric list being included, custom-prefix support, that valid metrics still resolve correctly, and that the improved error propagates through public plot entry points like `plot_candidate_scores`.

## Validation
- 40/40 tests pass in `sklearn_genetic/tests/test_plots.py` (35 pre-existing + 5 new)
- Full suite: 273 tests pass (excluding `test_mlflow.py` which requires an optional dependency not installed locally)

Closes #259