### PR TITLE
docs(community): add community article comparing GASearchCV vs RandomizedSearchCV

### DIFF
--- a/docs-vitepress/versions/latest/community/articles.md
+++ b/docs-vitepress/versions/latest/community/articles.md
@@ -37,6 +37,4 @@ promotional.
    evolution of the project over several years.
 
 4. [GASearchCV vs RandomizedSearchCV: When Evolutionary Search Pays Off](https://github.com/andrianbalanesq/sklearn-genetic-opt-tutorials/tree/main/tutorials/01-ga-vs-random-search)  
-   Andrian Balanescu (@andrianbalanesq) on GitHub. Compares `GASearchCV`
-   against `RandomizedSearchCV` on a noisy XGBoost task at a fixed
-   evaluation budget, with a runnable notebook and reproducible numbers.
+   Andrian Balanescu (@andrianbalanesq) on GitHub. Compares `GASearchCV` against `RandomizedSearchCV` on a noisy XGBoost task with a runnable notebook.

--- a/docs-vitepress/versions/latest/community/articles.md
+++ b/docs-vitepress/versions/latest/community/articles.md
@@ -38,7 +38,5 @@ promotional.
 
 4. [GASearchCV vs RandomizedSearchCV: When Evolutionary Search Pays Off](https://github.com/andrianbalanesq/sklearn-genetic-opt-tutorials/tree/main/tutorials/01-ga-vs-random-search)  
    Andrian Balanescu (@andrianbalanesq) on GitHub. Compares `GASearchCV`
-   against scikit-learn's `RandomizedSearchCV` on a noisy XGBoost
-   classification task at the same evaluation budget, and explains
-   when the extra wall-clock cost of the genetic search is worth it.
-   Includes a runnable notebook and reproducible numbers.
+   against `RandomizedSearchCV` on a noisy XGBoost task at a fixed
+   evaluation budget, with a runnable notebook and reproducible numbers.

--- a/docs-vitepress/versions/latest/community/articles.md
+++ b/docs-vitepress/versions/latest/community/articles.md
@@ -35,3 +35,10 @@ promotional.
 3. [sklearn-genetic-opt 0.13: What Five Years of Genetic Search Taught Me](https://rodrigo-arenas.medium.com/sklearn-genetic-opt-0-13-what-five-years-of-genetic-search-taught-me-3f842fc105b2)  
    Rodrigo Arenas on Medium. Shares lessons from the 0.13 release and the
    evolution of the project over several years.
+
+4. [GASearchCV vs RandomizedSearchCV: When Evolutionary Search Pays Off](https://github.com/andrianbalanesq/sklearn-genetic-opt-tutorials/tree/main/tutorials/01-ga-vs-random-search)  
+   Andrian Balanescu (@andrianbalanesq) on GitHub. Compares `GASearchCV`
+   against scikit-learn's `RandomizedSearchCV` on a noisy XGBoost
+   classification task at the same evaluation budget, and explains
+   when the extra wall-clock cost of the genetic search is worth it.
+   Includes a runnable notebook and reproducible numbers.


### PR DESCRIPTION
## Summary

Adds a new entry to the Community Articles page referencing a community-written tutorial.

The tutorial — published at [andrianbalanesq/sklearn-genetic-opt-tutorials/tree/main/tutorials/01-ga-vs-random-search](https://github.com/andrianbalanesq/sklearn-genetic-opt-tutorials/tree/main/tutorials/01-ga-vs-random-search) — compares `GASearchCV` against scikit-learn's `RandomizedSearchCV` on a noisy XGBoost problem at the same evaluation budget, and includes a runnable notebook plus reproducible numbers from `run_experiment.py`.

## Why this is useful

The page currently lists three articles, all by the project maintainer. This entry adds a community-authored comparison piece that complements the existing list by addressing a topic not yet covered: a head-to-head benchmark of `GASearchCV` against another scikit-learn search algorithm.

## Details

- **Author:** Andrian Balanescu (@andrianbalanesq) — first-time contributor.
- **Platform:** GitHub (self-contained repo with README and runnable Jupyter notebook).
- **Topic:** Comparison, XGBoost on noisy data, with reproducible numbers and a fixed evaluation budget for both methods.
- **Format:** Follows the existing numbered-list convention with title, author, platform, and a short description.

Closes part of #267 (the docs-only aspect of the 'share community articles' issue).