### PR TITLE
Fix #262: Add lightweight smoke tests for generated docs example scripts

### DIFF
--- a/docs-vitepress/scripts/smoke_test_examples.py
+++ b/docs-vitepress/scripts/smoke_test_examples.py
@@ -1,0 +1,58 @@
+import os
+import sys
+from pathlib import Path
+import runpy
+
+ROOT = Path(__file__).resolve().parents[2]
+EXAMPLES_SRC = ROOT / "docs-vitepress" / "examples-src"
+
+
+def patch_evolution_config():
+    from sklearn_genetic import EvolutionConfig
+
+    original_init = EvolutionConfig.__init__
+
+    def mocked_init(self, *args, **kwargs):
+        kwargs["population_size"] = min(kwargs.get("population_size", 2), 2)
+        kwargs["generations"] = min(kwargs.get("generations", 1), 1)
+        if "keep_top_k" in kwargs:
+            kwargs["keep_top_k"] = min(kwargs.get("keep_top_k", 1), 1)
+        original_init(self, *args, **kwargs)
+
+    EvolutionConfig.__init__ = mocked_init
+
+
+def run_smoke_tests(target_examples, base_dir=EXAMPLES_SRC):
+    patch_evolution_config()
+    sys.path.insert(0, str(ROOT))
+    sys.path.insert(0, str(base_dir))
+    os.environ["MPLBACKEND"] = "Agg"
+
+    failures = []
+    for filename in target_examples:
+        path = base_dir / filename
+        print(f"-> smoke testing {filename}")
+        try:
+            runpy.run_path(str(path), run_name="__docs_build__")
+        except Exception as exc:
+            print(f"   FAILED: {filename} - {type(exc).__name__}: {exc}")
+            failures.append((filename, exc))
+    return failures
+
+
+def main():
+    target_examples = [
+        "page_basic_usage.py",
+        "page_tutorial_feature_selection.py",
+        "page_plotting_gallery.py",
+    ]
+    failures = run_smoke_tests(target_examples)
+    if failures:
+        print(f"\n{len(failures)} example(s) failed smoke test.")
+        sys.exit(1)
+    print(f"\nAll {len(target_examples)} example(s) passed smoke test successfully.")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs-vitepress/scripts/test_smoke_test_examples.py
+++ b/docs-vitepress/scripts/test_smoke_test_examples.py
@@ -1,0 +1,48 @@
+import pytest
+from pathlib import Path
+import smoke_test_examples
+from smoke_test_examples import run_smoke_tests, EXAMPLES_SRC
+
+
+def test_smoke_test_success():
+    """Verify that the smoke test runs successfully on a known fast example."""
+    failures = run_smoke_tests(["page_plotting_gallery.py"], base_dir=EXAMPLES_SRC)
+    assert not failures, f"Expected 0 failures, got {len(failures)}"
+
+
+def test_smoke_test_failure_reporting(tmp_path):
+    """Verify that a failing example correctly reports its failure."""
+    failing_script = tmp_path / "page_failing.py"
+    failing_script.write_text("raise ValueError('Intentional failure for testing')")
+
+    failures = run_smoke_tests(["page_failing.py"], base_dir=tmp_path)
+    assert len(failures) == 1
+    filename, exc = failures[0]
+    assert filename == "page_failing.py"
+    assert isinstance(exc, ValueError)
+    assert "Intentional failure for testing" in str(exc)
+
+
+def test_optional_heavy_dependencies_are_excluded():
+    """Verify we don't accidentally add slow XGBoost/LightGBM examples to the defaults."""
+    from smoke_test_examples import main
+    import ast
+
+    # Read the smoke_test_examples.py source to see what main() uses
+    source = Path(__file__).parent / "smoke_test_examples.py"
+    tree = ast.parse(source.read_text())
+
+    examples = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "target_examples":
+                    if isinstance(node.value, ast.List):
+                        examples = [
+                            elt.s for elt in node.value.elts if isinstance(elt, ast.Constant)
+                        ]
+
+    assert len(examples) > 0
+    assert "page_tune_xgboost.py" not in examples
+    assert "page_tune_lightgbm.py" not in examples
+    assert "page_tune_catboost.py" not in examples


### PR DESCRIPTION
Resolves #262 by introducing a lightweight smoke test for documentation examples that caps generations and population size using a monkeypatch, and includes pytest validation for this runner.