### PR TITLE
test(plots): add a few edge cases for _as_list not in #270 empty stri…

### DIFF
--- a/sklearn_genetic/tests/test_plots.py
+++ b/sklearn_genetic/tests/test_plots.py
@@ -1,5 +1,6 @@
 import matplotlib
 import pytest
+import numpy as np
 import re
 from sklearn.datasets import load_diabetes
 from sklearn.model_selection import train_test_split
@@ -430,3 +431,29 @@ def test_metric_column_lists_available_metrics_on_unknown():
     assert "mean_test_roc_auc" in message
     assert "Available metrics" in message
     assert "accuracy" in message and "f1" in message
+
+
+# _as_list – extra edge cases not covered by #270
+
+
+def test_as_list_with_numpy_array():
+    # sklearn pipelines pass arrays here, worth making sure it doesn't blow up
+    arr = np.array(["feature_0", "feature_1"])
+    assert _as_list(arr) == ["feature_0", "feature_1"]
+
+
+def test_as_list_with_set():
+    # sets are unordered so just check the contents, not the order
+    result = _as_list({"a", "b"})
+    assert sorted(result) == ["a", "b"]
+
+
+def test_as_list_empty_string():
+    # empty string is not None — should return [""] not []
+    assert _as_list("") == [""]
+
+
+def test_as_list_falsy_values():
+    # 0 and False are falsy but they're not None — easy bug to introduce
+    assert _as_list(0) == [0]
+    assert _as_list(False) == [False]


### PR DESCRIPTION
Follow-up to #270 as suggested by @rodrigo-arenas in #274.

Covers four edge cases that #270 doesn't have- empty string, falsy values
(0, False), numpy arrays, and sets. All felt worth having given how this
helper actually gets called. No behaviour changes, tests only.

## Summary

Adds four edge-case tests for the internal `_as_list` helper that weren't
covered by #270. No behaviour changes, tests only.

## Related Issue

<!-- #256 is already closed by #270 — this is an additive follow-up, not a duplicate -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / cleanup
- [x] Other (describe): additional test coverage for internal helper

## Checklist

- [x] I checked the linked issue is open and not already covered by another PR
- [x] Tests pass locally (`pytest sklearn_genetic/`)
- [x] Code is formatted with Black (`black sklearn_genetic/`)
- [x] New functionality is covered by tests
- [ ] Documentation updated if needed