### PR TITLE
Fix outdated external references link in README and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,10 +152,10 @@ We encourage you to follow these guidelines:
 
 # External References
 
-We have a [file](https://github.com/rodrigo-arenas/Sklearn-genetic-opt/blob/master/docs/external_references.rst) 
+We have a [community articles page](https://sklearngeneticopt.rodrigo-arenas.com/versions/latest/community/articles)
 in our docs where you can put external references with the use of sklearn-genetic-opt,
 it could be a blog post, a video or an article.
-You can add the link of the content in that file (following the contribution guides).
+You can add the link of the content there (following the contribution guides).
 
 Take into consideration:
 

--- a/README.rst
+++ b/README.rst
@@ -374,7 +374,7 @@ Good ways to start:
 * **Fix typing, CI, or formatting** — ``black .`` keeps the style consistent.
 * **Answer questions** in open issues.
 * **Share your work** — add a blog post, article, or video to the
-  `external references file <https://github.com/rodrigo-arenas/Sklearn-genetic-opt/blob/master/docs/external_references.rst>`_.
+  `community articles page <https://sklearngeneticopt.rodrigo-arenas.com/versions/latest/community/articles>`_.
 
 .. code-block:: bash
 


### PR DESCRIPTION
## Summary
- docs/external_references.rst no longer exists in the repo, but README.rst and CONTRIBUTING.md still linked to it
- Both now point to the current community articles page at docs-vitepress/versions/latest/community/articles.md (live at sklearngeneticopt.rodrigo-arenas.com)

## Test plan
- [x] `rg external_references|docs/external README.rst CONTRIBUTING.md docs-vitepress` returns no matches (per the issue's validation steps)
- [x] Docs-only change, no code/tests affected

Fixes #293