### PR TITLE
docs: fix outdated external references link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,10 +152,10 @@ We encourage you to follow these guidelines:
 
 # External References
 
-We have a [file](https://github.com/rodrigo-arenas/Sklearn-genetic-opt/blob/master/docs/external_references.rst) 
+We have a [Community Articles page](https://github.com/rodrigo-arenas/Sklearn-genetic-opt/blob/master/docs-vitepress/versions/latest/community/articles.md)
 in our docs where you can put external references with the use of sklearn-genetic-opt,
 it could be a blog post, a video or an article.
-You can add the link of the content in that file (following the contribution guides).
+You can add the link of the content on that page (following the contribution guides).
 
 Take into consideration:
 

--- a/README.rst
+++ b/README.rst
@@ -374,7 +374,7 @@ Good ways to start:
 * **Fix typing, CI, or formatting** — ``black .`` keeps the style consistent.
 * **Answer questions** in open issues.
 * **Share your work** — add a blog post, article, or video to the
-  `external references file <https://github.com/rodrigo-arenas/Sklearn-genetic-opt/blob/master/docs/external_references.rst>`_.
+  `Community Articles page <https://github.com/rodrigo-arenas/Sklearn-genetic-opt/blob/master/docs-vitepress/versions/latest/community/articles.md>`_.
 
 .. code-block:: bash
 


### PR DESCRIPTION
Both `CONTRIBUTING.md` and `README.rst` still linked to `docs/external_references.rst`, which was removed. They now point to the current Community Articles page under `docs-vitepress`.

Closes #293.