### PR TITLE
Fix duplicate param_grid key in ModelCheckpoint.estimator_state and add regression test for core state keys

### DIFF
--- a/sklearn_genetic/callbacks/model_checkpoint.py
+++ b/sklearn_genetic/callbacks/model_checkpoint.py
@@ -25,7 +25,6 @@ class ModelCheckpoint(BaseCallback):
                 "mutation_probability": estimator.mutation_probability,
                 "param_grid": estimator.param_grid,
                 "algorithm": estimator.algorithm,
-                "param_grid": estimator.param_grid,
                 "local_search": getattr(estimator, "local_search", False),
                 "local_search_top_k": getattr(estimator, "local_search_top_k", 1),
                 "local_search_steps": getattr(estimator, "local_search_steps", 1),

--- a/sklearn_genetic/tests/test_persistence_and_helpers.py
+++ b/sklearn_genetic/tests/test_persistence_and_helpers.py
@@ -234,5 +234,7 @@ def test_model_checkpoint_estimator_state_keys(tmp_path):
     assert estimator_state["scoring"] == "accuracy"
     assert estimator_state["population_size"] == 4
     assert estimator_state["generations"] == 2
-    assert estimator_state["algorithm"] == "eaSimple"
     assert list(estimator_state["param_grid"].keys()) == ["max_depth"]
+    assert estimator_state["param_grid"]["max_depth"].lower == 1
+    assert estimator_state["param_grid"]["max_depth"].upper == 2
+    assert estimator_state["algorithm"] == "eaSimple"

--- a/sklearn_genetic/tests/test_persistence_and_helpers.py
+++ b/sklearn_genetic/tests/test_persistence_and_helpers.py
@@ -197,3 +197,42 @@ def test_model_checkpoint_save_load_and_error_paths(tmp_path, capsys):
     assert loaded_checkpoint["estimator_state"]["scoring"] == "accuracy"
     assert loaded_checkpoint["logbook"] is None
     assert missing_checkpoint is None
+
+
+def test_model_checkpoint_estimator_state_keys(tmp_path):
+    estimator = SimpleNamespace(
+        estimator=DecisionTreeClassifier(),
+        cv=2,
+        scoring="accuracy",
+        population_size=4,
+        generations=2,
+        crossover_probability=0.8,
+        mutation_probability=0.1,
+        param_grid={"max_depth": Integer(1, 2)},
+        algorithm="eaSimple",
+    )
+    checkpoint_path = tmp_path / "checkpoint.pkl"
+    checkpoint = ModelCheckpoint(checkpoint_path)
+
+    checkpoint.on_step(logbook=None, estimator=estimator)
+    loaded_checkpoint = checkpoint.load()
+
+    estimator_state = loaded_checkpoint["estimator_state"]
+    expected_keys = {
+        "estimator",
+        "cv",
+        "scoring",
+        "population_size",
+        "generations",
+        "param_grid",
+        "algorithm",
+    }
+    assert expected_keys.issubset(estimator_state.keys())
+
+    assert isinstance(estimator_state["estimator"], DecisionTreeClassifier)
+    assert estimator_state["cv"] == 2
+    assert estimator_state["scoring"] == "accuracy"
+    assert estimator_state["population_size"] == 4
+    assert estimator_state["generations"] == 2
+    assert estimator_state["algorithm"] == "eaSimple"
+    assert list(estimator_state["param_grid"].keys()) == ["max_depth"]


### PR DESCRIPTION
## Summary

`ModelCheckpoint.on_step` built its `estimator_state` dictionary with the `param_grid` key assigned twice, silently overwriting the first entry. This PR removes the duplicate and adds a regression test covering the checkpoint's core state keys.

## Related Issue

Closes #294

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] Other (describe):

## Checklist

- [x] I checked the linked issue is open and not already covered by another PR
- [x] Tests pass locally (`pytest sklearn_genetic/`)
- [x] Code is formatted with Black (`black sklearn_genetic/`)
- [x] New functionality is covered by tests
- [ ] Documentation updated if needed
