### PR TITLE
docs: check root doc links

### DIFF
--- a/docs-vitepress/scripts/check_links.py
+++ b/docs-vitepress/scripts/check_links.py
@@ -1,9 +1,9 @@
-"""Check internal Markdown links in the versioned VitePress docs.
+"""Check internal documentation links.
 
-Scans every Markdown file under the versioned docs trees and verifies that
-*relative* links point at a file that exists. VitePress lets you omit the
-``.md`` extension and link to a directory's ``index.md``, so this resolver
-mirrors that behaviour.
+Scans every Markdown file under the versioned docs trees, plus the root
+contributor docs, and verifies that *relative* links point at a file that
+exists. VitePress lets you omit the ``.md`` extension and link to a directory's
+``index.md``, so this resolver mirrors that behaviour.
 
 What is checked / skipped:
 
@@ -32,9 +32,17 @@ VERSION_DIRS = [
     ROOT / "docs-vitepress" / "versions" / "latest",
     ROOT / "docs-vitepress" / "versions" / "0.13",
 ]
+ROOT_DOCS = [
+    ROOT / "README.rst",
+    ROOT / "CONTRIBUTING.md",
+]
 
 # [text](target) and ![alt](target) — capture the target up to whitespace or ')'.
 LINK_RE = re.compile(r"!?\[[^\]]*\]\(\s*([^)\s]+)")
+RST_INLINE_LINK_RE = re.compile(r"`[^`\n<>]+<([^\s>]+)>`_")
+RST_REFERENCE_RE = re.compile(r"^\s*\.\. _[^:]+:\s*([^\s]+)", re.MULTILINE)
+RST_DIRECTIVE_TARGET_RE = re.compile(r"^\s*\.\. image::\s*([^\s]+)", re.MULTILINE)
+RST_OPTION_TARGET_RE = re.compile(r"^\s*:target:\s*([^\s]+)", re.MULTILINE)
 
 _EXTERNAL_PREFIXES = ("http://", "https://", "mailto:", "//")
 
@@ -66,16 +74,36 @@ def _resolves(md_file: Path, target: str) -> bool:
     return any(candidate.is_file() for candidate in candidates)
 
 
+def _targets_in_doc(doc_file: Path) -> list[str]:
+    text = doc_file.read_text(encoding="utf-8")
+    if doc_file.suffix == ".rst":
+        return (
+            RST_INLINE_LINK_RE.findall(text)
+            + RST_REFERENCE_RE.findall(text)
+            + RST_DIRECTIVE_TARGET_RE.findall(text)
+            + RST_OPTION_TARGET_RE.findall(text)
+        )
+    return LINK_RE.findall(text)
+
+
+def _check_doc(doc_file: Path) -> list[tuple[Path, str]]:
+    broken: list[tuple[Path, str]] = []
+    for target in _targets_in_doc(doc_file):
+        if _is_internal_relative(target) and not _resolves(doc_file, target):
+            broken.append((doc_file, target))
+    return broken
+
+
 def check() -> list[tuple[Path, str]]:
     broken: list[tuple[Path, str]] = []
     for version_dir in VERSION_DIRS:
         if not version_dir.exists():
             continue
         for md_file in sorted(version_dir.rglob("*.md")):
-            text = md_file.read_text(encoding="utf-8")
-            for target in LINK_RE.findall(text):
-                if _is_internal_relative(target) and not _resolves(md_file, target):
-                    broken.append((md_file, target))
+            broken.extend(_check_doc(md_file))
+    for root_doc in ROOT_DOCS:
+        if root_doc.exists():
+            broken.extend(_check_doc(root_doc))
     return broken
 
 

--- a/docs-vitepress/scripts/test_check_links.py
+++ b/docs-vitepress/scripts/test_check_links.py
@@ -56,3 +56,64 @@ def test_resolves(tmp_path):
     # Broken: missing page, and a directory without an index.md (the edge case).
     assert check_links._resolves(source, "./guide/missing") is False
     assert check_links._resolves(source, "./empty") is False
+
+
+def test_root_docs_valid_local_links_pass(tmp_path, monkeypatch):
+    readme = tmp_path / "README.rst"
+    contributing = tmp_path / "CONTRIBUTING.md"
+    guide = tmp_path / "docs-vitepress" / "versions" / "latest" / "guide"
+    guide.mkdir(parents=True)
+    (guide / "index.md").write_text("x", encoding="utf-8")
+    contributing.write_text("[README](README.rst)\n", encoding="utf-8")
+    readme.write_text(
+        "`Contributing <CONTRIBUTING.md>`_\n"
+        "`Latest guide <docs-vitepress/versions/latest/guide>`_\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(check_links, "ROOT", tmp_path)
+    monkeypatch.setattr(check_links, "VERSION_DIRS", [])
+    monkeypatch.setattr(check_links, "ROOT_DOCS", [readme, contributing])
+
+    assert check_links.check() == []
+
+
+def test_root_docs_report_missing_local_links(tmp_path, monkeypatch):
+    readme = tmp_path / "README.rst"
+    readme.write_text("`Missing <missing-page.md>`_\n", encoding="utf-8")
+
+    monkeypatch.setattr(check_links, "ROOT", tmp_path)
+    monkeypatch.setattr(check_links, "VERSION_DIRS", [])
+    monkeypatch.setattr(check_links, "ROOT_DOCS", [readme])
+
+    assert check_links.check() == [(readme, "missing-page.md")]
+
+
+def test_root_docs_skip_external_links(tmp_path, monkeypatch):
+    contributing = tmp_path / "CONTRIBUTING.md"
+    contributing.write_text(
+        "[GitHub](https://github.com/rodrigo-arenas/Sklearn-genetic-opt)\n"
+        "[Email](mailto:dev@example.com)\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(check_links, "ROOT", tmp_path)
+    monkeypatch.setattr(check_links, "VERSION_DIRS", [])
+    monkeypatch.setattr(check_links, "ROOT_DOCS", [contributing])
+
+    assert check_links.check() == []
+
+
+def test_rst_prose_with_angle_brackets_is_not_a_link(tmp_path, monkeypatch):
+    readme = tmp_path / "README.rst"
+    readme.write_text(
+        "Use this when your model takes < 1 s per fit) and keep reading.\n"
+        "``code`` later in the same file should not turn it into a link.\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(check_links, "ROOT", tmp_path)
+    monkeypatch.setattr(check_links, "VERSION_DIRS", [])
+    monkeypatch.setattr(check_links, "ROOT_DOCS", [readme])
+
+    assert check_links.check() == []


### PR DESCRIPTION
## Summary
- extend `docs-vitepress/scripts/check_links.py` to scan root `README.rst` and `CONTRIBUTING.md` in addition to versioned VitePress Markdown docs
- add RST target extraction for inline links, reference definitions, image directives, and directive targets
- add tests for valid root-doc links, missing local root-doc links, external link skipping, and an RST prose false-positive guard

## Validation
- `python -m pytest docs-vitepress/scripts/test_check_links.py`
- `PYTHONIOENCODING=utf-8 python docs-vitepress/scripts/check_links.py`
- `.venv/Scripts/python.exe -m black --check docs-vitepress/scripts/check_links.py docs-vitepress/scripts/test_check_links.py`
- `git diff --check`

Note: only Python 3.11.9 is available in this environment. Black reported both touched files unchanged, with its standard warning that the local Python is older than the project target.

Closes #298