### PR TITLE
Align docs canonical URLs with clean URLs

### DIFF
--- a/docs-vitepress/.vitepress/config.ts
+++ b/docs-vitepress/.vitepress/config.ts
@@ -202,6 +202,7 @@ export default defineConfig({
   title: 'sklearn-genetic-opt',
   description: 'Evolutionary hyperparameter tuning and feature selection for scikit-learn',
   base: GITHUB_PAGES_BASE,
+  cleanUrls: true,
 
   titleTemplate: ':title | sklearn-genetic-opt',
 
@@ -223,7 +224,7 @@ export default defineConfig({
     const cleanPath = pageData.relativePath
       .replace(/\\/g, '/')
       .replace(/index\.md$/, '')
-      .replace(/\.md$/, '.html')
+      .replace(/\.md$/, '')
     const pageUrl = `${base}/${cleanPath}`
 
     pageData.frontmatter.head ??= []


### PR DESCRIPTION
## Summary
- enable VitePress clean URLs for the docs site
- generate canonical and Open Graph URLs without the .html suffix
- align sitemap/canonical URLs with the extensionless URLs reported by Google Search Console

## Tests
- node node_modules\\vitepress\\bin\\vitepress.js build .
- python scripts\\check_links.py