### PR TITLE
feat(callbacks): clearer ModelCheckpoint save message (#295)

### DIFF
--- a/docs-vitepress/versions/latest/examples/checkpointing.md
+++ b/docs-vitepress/versions/latest/examples/checkpointing.md
@@ -126,13 +126,13 @@ print("Best CV ROC AUC:", round(search.best_score_, 4))
 ```
 
 ```text
-Checkpoint save in /tmp/ga_artifacts_docs/rf_checkpoint.pkl
-Checkpoint save in /tmp/ga_artifacts_docs/rf_checkpoint.pkl
-Checkpoint save in /tmp/ga_artifacts_docs/rf_checkpoint.pkl
-Checkpoint save in /tmp/ga_artifacts_docs/rf_checkpoint.pkl
-Checkpoint save in /tmp/ga_artifacts_docs/rf_checkpoint.pkl
-Checkpoint save in /tmp/ga_artifacts_docs/rf_checkpoint.pkl
-Checkpoint save in /tmp/ga_artifacts_docs/rf_checkpoint.pkl
+Checkpoint saved to /tmp/ga_artifacts_docs/rf_checkpoint.pkl
+Checkpoint saved to /tmp/ga_artifacts_docs/rf_checkpoint.pkl
+Checkpoint saved to /tmp/ga_artifacts_docs/rf_checkpoint.pkl
+Checkpoint saved to /tmp/ga_artifacts_docs/rf_checkpoint.pkl
+Checkpoint saved to /tmp/ga_artifacts_docs/rf_checkpoint.pkl
+Checkpoint saved to /tmp/ga_artifacts_docs/rf_checkpoint.pkl
+Checkpoint saved to /tmp/ga_artifacts_docs/rf_checkpoint.pkl
 INFO: ConsecutiveStopping callback met its criteria
 INFO: Stopping the algorithm
 

--- a/sklearn_genetic/callbacks/model_checkpoint.py
+++ b/sklearn_genetic/callbacks/model_checkpoint.py
@@ -44,7 +44,7 @@ class ModelCheckpoint(BaseCallback):
             checkpoint_data = {"estimator_state": estimator_state, "logbook": deepcopy(logbook)}
             with open(self.checkpoint_path, "wb") as f:
                 pickle.dump(checkpoint_data, f)
-                print(f"Checkpoint save in {self.checkpoint_path}")
+                print(f"Checkpoint saved to {self.checkpoint_path}")
 
         except Exception as e:
             print(f"Error saving checkpoint: {e}")

--- a/sklearn_genetic/tests/test_persistence_and_helpers.py
+++ b/sklearn_genetic/tests/test_persistence_and_helpers.py
@@ -191,7 +191,7 @@ def test_model_checkpoint_save_load_and_error_paths(tmp_path, capsys):
     missing_checkpoint = ModelCheckpoint(tmp_path / "missing.pkl").load()
     output = capsys.readouterr().out
 
-    assert "Checkpoint save in" in output
+    assert "Checkpoint saved to" in output
     assert "Error saving checkpoint" in output
     assert "Error loading checkpoint" in output
     assert loaded_checkpoint["estimator_state"]["scoring"] == "accuracy"


### PR DESCRIPTION
## Summary

Polishes the `ModelCheckpoint` success message: `Checkpoint save in {path}` → `Checkpoint saved to {path}` (clearer, grammatical).

## Related Issue

Closes #295

## What changed
- `sklearn_genetic/callbacks/model_checkpoint.py` — the success `print`.
- `test_persistence_and_helpers.py` — updated the `capsys` assertion.
- `docs-vitepress/versions/latest/examples/checkpointing.md` — the captured output (7 lines).

Left `versions/0.13/` untouched (released/frozen per the docs versioning policy), and left the error messages (`Error saving checkpoint` / `Error loading checkpoint`) as-is since they're already clear.

## Checklist
- [x] Tests pass (`pytest sklearn_genetic/tests/test_persistence_and_helpers.py`) — 9 passed
- [x] Black clean
- [x] Docs kept in sync

— Contributed by **Mayoka Labs**