### PR TITLE
test(space): cover Categorical random_state determinism (#296)

### DIFF
--- a/sklearn_genetic/space/tests/test_space.py
+++ b/sklearn_genetic/space/tests/test_space.py
@@ -119,6 +119,33 @@ def test_categorical_bad_parameters(data_object, parameters, message):
     assert str(excinfo.value) == message
 
 
+def test_categorical_random_state_is_deterministic():
+    """Same random_state yields the same sample sequence (#296).
+
+    This exercises the seeded ``rng.choice`` path, which the existing sampling
+    tests (using no ``random_state``) do not cover.
+    """
+    choices = ["a", "b", "c", "d"]
+    first = Categorical(choices, random_state=42)
+    second = Categorical(choices, random_state=42)
+
+    seq_first = [first.sample() for _ in range(15)]
+    seq_second = [second.sample() for _ in range(15)]
+
+    assert seq_first == seq_second
+    # Every draw is a valid choice.
+    assert all(value in choices for value in seq_first)
+
+
+def test_categorical_sampling_with_priors_stays_in_choices():
+    """A priored categorical only ever samples declared choices (#296)."""
+    choices = ["x", "y", "z"]
+    dimension = Categorical(choices, priors=[0.2, 0.3, 0.5], random_state=7)
+
+    assert dimension.priors == [0.2, 0.3, 0.5]
+    assert all(dimension.sample() in choices for _ in range(50))
+
+
 def test_space_classes_have_complete_type_annotations():
     """random_state and sample() carry annotations on every space class (#209)."""
     import inspect


### PR DESCRIPTION
## Summary

Adds focused tests for `Categorical` sampling edge cases (#296).

## Related Issue

Closes #296

## Note on scope (to avoid duplication)

The issue lists four asks. Asks **1–3** (empty `choices`, `priors` sum ≠ 1, `priors`/`choices` length mismatch) are **already covered** by the existing `test_categorical_bad_parameters`, so this PR focuses on the genuinely-missing coverage:

- **`test_categorical_random_state_is_deterministic`** (ask #4) — same `random_state` → same sample sequence. This exercises the seeded `rng.choice` branch, which the existing no-seed sampling tests don't touch.
- **`test_categorical_sampling_with_priors_stays_in_choices`** — a priored categorical only ever samples declared choices, and `priors` is stored.

## One heads-up (not addressed here — this PR is test-only per the issue)

While writing these I noticed `priors` don't appear to influence the sampling **distribution**: `Categorical.sample()` calls `self.rng.choice(self.choices)` / `random.choice(self.choices)` without passing `p=self.priors`, so `priors=[0.99, 0.01]` still samples ~50/50. Validation of `priors` works, but they seem not to bias sampling. I deliberately did **not** assert a priors distribution here (it would lock in current behavior) or change the sampler (out of scope for a test-only issue) — flagging it in case it's worth a separate issue.

## Checklist
- [x] Tests pass (`pytest sklearn_genetic/space/tests/test_space.py`) — 38 passed, deterministic across repeated runs
- [x] Black clean
- [x] No overlap with existing tests

— Contributed by **Mayoka Labs**