### PR TITLE
Restore fitness cache on checkpoint resume (part of #299)

### DIFF
--- a/sklearn_genetic/callbacks/model_checkpoint.py
+++ b/sklearn_genetic/callbacks/model_checkpoint.py
@@ -40,7 +40,16 @@ class ModelCheckpoint(BaseCallback):
                 "sharing_radius": getattr(estimator, "sharing_radius", 0.2),
                 "sharing_alpha": getattr(estimator, "sharing_alpha", 1.0),
             }
-            checkpoint_data = {"estimator_state": estimator_state, "logbook": deepcopy(logbook)}
+            # Runtime state is kept separate from ``estimator_state`` so the
+            # latter stays constructor-compatible (it is consumed as
+            # ``GASearchCV(**estimator_state)``). Restoring the fitness cache on
+            # resume lets already-evaluated candidates be reused (see fit()).
+            runtime_state = {"fitness_cache": getattr(estimator, "fitness_cache", {})}
+            checkpoint_data = {
+                "estimator_state": estimator_state,
+                "logbook": deepcopy(logbook),
+                "runtime_state": runtime_state,
+            }
             with open(self.checkpoint_path, "wb") as f:
                 pickle.dump(checkpoint_data, f)
                 print(f"Checkpoint saved to {self.checkpoint_path}")

--- a/sklearn_genetic/genetic_search.py
+++ b/sklearn_genetic/genetic_search.py
@@ -1073,6 +1073,14 @@ class GASearchCV(GeneticEstimatorMixin, BaseSearchCV):
                     if checkpoint_data:
                         self.__dict__.update(checkpoint_data["estimator_state"])  # noqa
                         self.logbook = checkpoint_data["logbook"]
+                        # Restore the fitness cache so already-evaluated
+                        # candidates are reused instead of re-evaluated. Older
+                        # checkpoints have no ``runtime_state``, so guard with
+                        # .get() for backward compatibility.
+                        runtime_state = checkpoint_data.get("runtime_state") or {}
+                        cached = runtime_state.get("fitness_cache")
+                        if cached is not None:
+                            self.fitness_cache = cached
                         checkpoint_loaded = True
                     break
 
@@ -1975,6 +1983,14 @@ class GAFeatureSelectionCV(GeneticEstimatorMixin, MetaEstimatorMixin, SelectorMi
                     if checkpoint_data:
                         self.__dict__.update(checkpoint_data["estimator_state"])  # noqa
                         self.logbook = checkpoint_data["logbook"]
+                        # Restore the fitness cache so already-evaluated
+                        # candidates are reused instead of re-evaluated. Older
+                        # checkpoints have no ``runtime_state``, so guard with
+                        # .get() for backward compatibility.
+                        runtime_state = checkpoint_data.get("runtime_state") or {}
+                        cached = runtime_state.get("fitness_cache")
+                        if cached is not None:
+                            self.fitness_cache = cached
                         checkpoint_loaded = True
                     break
 

--- a/sklearn_genetic/tests/test_genetic_search.py
+++ b/sklearn_genetic/tests/test_genetic_search.py
@@ -1403,6 +1403,82 @@ def test_checkpoint_functionality():
         os.remove(checkpoint_path)
 
 
+def test_checkpoint_resume_restores_fitness_cache(tmp_path):
+    """Resuming from a checkpoint restores the fitness cache (#299).
+
+    The cache lives under a separate ``runtime_state`` key (kept out of the
+    constructor-compatible ``estimator_state``) so a resumed run reuses
+    already-evaluated candidates instead of re-evaluating them.
+    """
+    import pickle
+
+    clf = SGDClassifier(loss="modified_huber", fit_intercept=True)
+    checkpoint_path = str(tmp_path / "resume_checkpoint.pkl")
+
+    def build():
+        return GASearchCV(
+            clf,
+            cv=3,
+            scoring="accuracy",
+            population_size=6,
+            generations=3,
+            param_grid={"alpha": Continuous(1e-4, 1)},
+        )
+
+    build().fit(X_train, y_train, callbacks=ModelCheckpoint(checkpoint_path=checkpoint_path))
+
+    with open(checkpoint_path, "rb") as f:
+        checkpoint_data = pickle.load(f)
+    assert "runtime_state" in checkpoint_data
+    saved_cache = checkpoint_data["runtime_state"]["fitness_cache"]
+    assert isinstance(saved_cache, dict) and len(saved_cache) > 0
+
+    # Inject a sentinel entry, then confirm a resumed run restores it. The
+    # sentinel is never regenerated during fit, so its presence proves the
+    # saved cache was reloaded onto the resumed estimator.
+    sentinel_key = ("__resume_sentinel__",)
+    saved_cache[sentinel_key] = {"fitness": (0.5,)}
+    with open(checkpoint_path, "wb") as f:
+        pickle.dump(checkpoint_data, f)
+
+    resumed = build()
+    resumed.fit(X_train, y_train, callbacks=ModelCheckpoint(checkpoint_path=checkpoint_path))
+    assert sentinel_key in resumed.fitness_cache
+
+
+def test_checkpoint_resume_without_runtime_state_is_backward_compatible(tmp_path):
+    """A pre-#299 checkpoint (no ``runtime_state``) still resumes cleanly (#299)."""
+    import pickle
+
+    clf = SGDClassifier(loss="modified_huber", fit_intercept=True)
+    checkpoint_path = str(tmp_path / "old_checkpoint.pkl")
+
+    def build():
+        return GASearchCV(
+            clf,
+            cv=3,
+            scoring="accuracy",
+            population_size=6,
+            generations=2,
+            param_grid={"alpha": Continuous(1e-4, 1)},
+        )
+
+    build().fit(X_train, y_train, callbacks=ModelCheckpoint(checkpoint_path=checkpoint_path))
+
+    # Simulate an old checkpoint by dropping the runtime_state key.
+    with open(checkpoint_path, "rb") as f:
+        checkpoint_data = pickle.load(f)
+    checkpoint_data.pop("runtime_state", None)
+    with open(checkpoint_path, "wb") as f:
+        pickle.dump(checkpoint_data, f)
+
+    resumed = build()
+    resumed.fit(X_train, y_train, callbacks=ModelCheckpoint(checkpoint_path=checkpoint_path))
+    # Resume must not crash and the estimator remains fitted/usable.
+    assert isinstance(resumed.fitness_cache, dict)
+    assert resumed.best_params_ is not None
+
+
 def test_random_state_makes_gasearch_reproducible():
     """A single random_state on the estimator should fully drive reproducibility,
     without callers seeding the global random / numpy RNGs themselves."""

--- a/sklearn_genetic/tests/test_persistence_and_helpers.py
+++ b/sklearn_genetic/tests/test_persistence_and_helpers.py
@@ -238,3 +238,39 @@ def test_model_checkpoint_estimator_state_keys(tmp_path):
     assert estimator_state["param_grid"]["max_depth"].lower == 1
     assert estimator_state["param_grid"]["max_depth"].upper == 2
     assert estimator_state["algorithm"] == "eaSimple"
+
+
+def test_feature_selection_checkpoint_resume_restores_fitness_cache(tmp_path):
+    """GAFeatureSelectionCV restores its fitness cache on resume (#299).
+
+    Covers the ``runtime_state`` restore branch in GAFeatureSelectionCV.fit,
+    mirroring the GASearchCV path. The checkpoint is built directly so the test
+    targets the restore branch specifically (feature-selection checkpoint
+    *saving* is fixed separately).
+    """
+    import pickle
+
+    X, y = load_iris(return_X_y=True)
+    checkpoint_path = str(tmp_path / "fs_resume_checkpoint.pkl")
+
+    # A minimal pre-existing checkpoint carrying a sentinel cache entry. The
+    # sentinel is never generated during fit, so its presence afterwards proves
+    # the resume path reloaded the cache onto the estimator.
+    sentinel_key = ("__fs_resume_sentinel__",)
+    checkpoint_data = {
+        "estimator_state": {},
+        "logbook": None,
+        "runtime_state": {"fitness_cache": {sentinel_key: {"fitness": (0.5,)}}},
+    }
+    with open(checkpoint_path, "wb") as f:
+        pickle.dump(checkpoint_data, f)
+
+    resumed = GAFeatureSelectionCV(
+        estimator=DecisionTreeClassifier(random_state=0),
+        cv=2,
+        scoring="accuracy",
+        population_size=4,
+        generations=2,
+    )
+    resumed.fit(X, y, callbacks=ModelCheckpoint(checkpoint_path=checkpoint_path))
+    assert sentinel_key in resumed.fitness_cache


### PR DESCRIPTION
Delivers the **cache-reuse** portion of #299. **This does not close #299** — the broader resume-state work is intentionally left open (see scope note).

## Problem
When a run resumes from a `ModelCheckpoint`, `fit()` restores the estimator config and `logbook`, but **not** the `fitness_cache`. Every candidate evaluated before the checkpoint is therefore re-evaluated on resume.

## Change
- `ModelCheckpoint.on_step` saves the estimator's `fitness_cache` under a new, separate `runtime_state` key.
- `GASearchCV.fit` and `GAFeatureSelectionCV.fit` restore it on resume.

`runtime_state` is kept **separate** from `estimator_state` because the latter is consumed as constructor kwargs (`GASearchCV(**checkpoint_data["estimator_state"])`); adding non-constructor keys there would break that contract. The restore is guarded with `.get("runtime_state")`, so **pre-#299 checkpoint files still load** unchanged.

## Tests (addressing the review)
- `test_checkpoint_resume_restores_fitness_cache` — GASearchCV restore branch (sentinel cache entry survives resume).
- `test_feature_selection_checkpoint_resume_restores_fitness_cache` — **GAFeatureSelectionCV restore branch** (the PR touches both fit methods).
- `test_checkpoint_resume_without_runtime_state_is_backward_compatible` — **backward-compat**: a checkpoint with no `runtime_state` resumes cleanly.

These exercise both restore branches and the `.get()` fallback, covering the previously-missing `codecov/patch` lines. `black --check` clean.

## Scope note (re: your review)
You're right that #299 is broader than the cache. In particular, as you noted, `_register()` runs after checkpoint loading and resets `self.logbook`, so logbook/history state is not truly preserved yet. Rather than overreach, this PR is scoped to the cache-reuse win and **does not close #299**; the remaining runtime-state work (history/logbook/fit_stats_ preservation, deterministic resume) is left open for a focused follow-up.

— Contributed by **Mayoka Labs**
