### PR TITLE
Make fitness cache toggleable in benchmark harness (#300)

### DIFF
--- a/benchmarks/benchmark_fit.py
+++ b/benchmarks/benchmark_fit.py
@@ -259,6 +259,7 @@ def build_gasearch(
     n_jobs: int | None,
     parallel_backend: str,
     population_initializer: str,
+    use_cache: bool = True,
     final_selection: bool = False,
     final_selection_top_k: int = 3,
     final_selection_cv=None,
@@ -275,7 +276,7 @@ def build_gasearch(
         parallel_backend=parallel_backend,
         verbose=False,
         return_train_score=False,
-        use_cache=True,
+        use_cache=use_cache,
     )
     optimization_config = OptimizationConfig(
         local_search=True,
@@ -320,6 +321,7 @@ def build_feature_selector(
     parallel_backend: str,
     population_initializer: str,
     max_features: int,
+    use_cache: bool = True,
 ) -> GAFeatureSelectionCV:
     evolution_config = EvolutionConfig(
         population_size=population_size,
@@ -333,7 +335,7 @@ def build_feature_selector(
         parallel_backend=parallel_backend,
         verbose=False,
         return_train_score=False,
-        use_cache=True,
+        use_cache=use_cache,
     )
     optimization_config = OptimizationConfig(
         local_search=True,
@@ -794,6 +796,14 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--population-size", type=int, default=12, help="GA population size.")
     parser.add_argument("--cv-splits", type=int, default=3, help="Cross-validation splits.")
     parser.add_argument(
+        "--use-cache",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Enable the fitness cache (default). Pass --no-use-cache to "
+        "re-evaluate every candidate and benchmark the cache's effect on the "
+        "cross_validate call count.",
+    )
+    parser.add_argument(
         "--scenarios",
         nargs="+",
         choices=sorted(SCENARIOS),
@@ -920,6 +930,7 @@ def main() -> None:
                                         n_jobs=n_jobs,
                                         parallel_backend=parallel_backend,
                                         population_initializer=population_initializer,
+                                        use_cache=args.use_cache,
                                         final_selection=args.final_selection,
                                         final_selection_top_k=args.final_selection_top_k,
                                         final_selection_cv=args.final_selection_cv_splits,
@@ -951,6 +962,7 @@ def main() -> None:
                                         parallel_backend=parallel_backend,
                                         population_initializer=population_initializer,
                                         max_features=max(2, X_train.shape[1] // 3),
+                                        use_cache=args.use_cache,
                                     ),
                                     X_train=X_train,
                                     X_test=X_test,


### PR DESCRIPTION
Addresses #300 (making cache/duplicate-evaluation behavior measurable).

## Problem
`benchmarks/benchmark_fit.py` reports `actual_cross_validate_calls` and `duplicate_or_cache_reuses`, but `use_cache=True` was **hardcoded** in both `build_gasearch` and `build_feature_selector`. There was no way to run the harness with the cache off, so you couldn't actually measure what the fitness cache buys you.

## Change
- Thread a `use_cache: bool = True` parameter through `build_gasearch` and `build_feature_selector` (replacing the hardcoded `True`).
- Expose it on the CLI as `--use-cache` / `--no-use-cache` (`argparse.BooleanOptionalAction`, default on — existing behavior unchanged).

## Verified locally
Same scenario, quick mode, cache on vs off:

```
--use-cache     cross_validate_calls=25   cache_reuses=1
--no-use-cache  cross_validate_calls=26   cache_reuses=0
```

With `--no-use-cache` every candidate is re-evaluated (zero reuses, more `cross_validate` calls); on a full-size run the gap is far larger. The feature-selection path was smoke-tested the same way. `black --check` is clean. Default runs are unchanged, so existing baselines stay comparable.

— Contributed by **Mayoka Labs**
