### PR TITLE
Fix GAFeatureSelectionCV checkpointing via shared state builder (#297)

### DIFF
--- a/sklearn_genetic/callbacks/model_checkpoint.py
+++ b/sklearn_genetic/callbacks/model_checkpoint.py
@@ -3,6 +3,52 @@ from .base import BaseCallback
 from .loggers import LogbookSaver
 from copy import deepcopy
 
+# Single source of truth for the constructor-compatible state persisted in a
+# checkpoint, so the key set cannot silently drift or duplicate.
+#
+# Core keys exist on both GASearchCV and GAFeatureSelectionCV and are read
+# directly. Optional keys map to the default used when the estimator does not
+# define them.
+_CHECKPOINT_CORE_KEYS = (
+    "estimator",
+    "cv",
+    "scoring",
+    "population_size",
+    "generations",
+    "crossover_probability",
+    "mutation_probability",
+    "algorithm",
+)
+_CHECKPOINT_OPTIONAL_DEFAULTS = {
+    "local_search": False,
+    "local_search_top_k": 1,
+    "local_search_steps": 1,
+    "local_search_radius": 0.1,
+    "diversity_control": False,
+    "diversity_threshold": 0.1,
+    "diversity_stagnation_generations": 5,
+    "diversity_mutation_boost": 2.0,
+    "random_immigrants_fraction": 0.1,
+    "fitness_sharing": False,
+    "sharing_radius": 0.2,
+    "sharing_alpha": 1.0,
+}
+
+
+def _build_estimator_state(estimator):
+    """Build the constructor-compatible checkpoint state for an estimator.
+
+    Works for both GASearchCV and GAFeatureSelectionCV: ``param_grid`` is only
+    included when the estimator actually defines it (GAFeatureSelectionCV does
+    not), so checkpointing a feature selector no longer raises AttributeError.
+    """
+    state = {key: getattr(estimator, key) for key in _CHECKPOINT_CORE_KEYS}
+    if hasattr(estimator, "param_grid"):
+        state["param_grid"] = estimator.param_grid
+    for key, default in _CHECKPOINT_OPTIONAL_DEFAULTS.items():
+        state[key] = getattr(estimator, key, default)
+    return state
+
 
 class ModelCheckpoint(BaseCallback):
     def __init__(self, checkpoint_path, **dump_options):
@@ -15,31 +61,7 @@ class ModelCheckpoint(BaseCallback):
                 logbook_saver = LogbookSaver(self.checkpoint_path, **self.dump_options)  # noqa
                 logbook_saver.on_step(record, logbook, estimator)
 
-            estimator_state = {
-                "estimator": estimator.estimator,
-                "cv": estimator.cv,
-                "scoring": estimator.scoring,
-                "population_size": estimator.population_size,
-                "generations": estimator.generations,
-                "crossover_probability": estimator.crossover_probability,
-                "mutation_probability": estimator.mutation_probability,
-                "param_grid": estimator.param_grid,
-                "algorithm": estimator.algorithm,
-                "local_search": getattr(estimator, "local_search", False),
-                "local_search_top_k": getattr(estimator, "local_search_top_k", 1),
-                "local_search_steps": getattr(estimator, "local_search_steps", 1),
-                "local_search_radius": getattr(estimator, "local_search_radius", 0.1),
-                "diversity_control": getattr(estimator, "diversity_control", False),
-                "diversity_threshold": getattr(estimator, "diversity_threshold", 0.1),
-                "diversity_stagnation_generations": getattr(
-                    estimator, "diversity_stagnation_generations", 5
-                ),
-                "diversity_mutation_boost": getattr(estimator, "diversity_mutation_boost", 2.0),
-                "random_immigrants_fraction": getattr(estimator, "random_immigrants_fraction", 0.1),
-                "fitness_sharing": getattr(estimator, "fitness_sharing", False),
-                "sharing_radius": getattr(estimator, "sharing_radius", 0.2),
-                "sharing_alpha": getattr(estimator, "sharing_alpha", 1.0),
-            }
+            estimator_state = _build_estimator_state(estimator)
             # Runtime state is kept separate from ``estimator_state`` so the
             # latter stays constructor-compatible (it is consumed as
             # ``GASearchCV(**estimator_state)``). Restoring the fitness cache on

--- a/sklearn_genetic/tests/test_persistence_and_helpers.py
+++ b/sklearn_genetic/tests/test_persistence_and_helpers.py
@@ -240,6 +240,45 @@ def test_model_checkpoint_estimator_state_keys(tmp_path):
     assert estimator_state["algorithm"] == "eaSimple"
 
 
+def test_model_checkpoint_supports_feature_selection_estimator(tmp_path, capsys):
+    """Checkpointing and resuming a GAFeatureSelectionCV must work (#297).
+
+    GAFeatureSelectionCV has no ``param_grid`` attribute; the checkpoint state
+    builder used to read ``estimator.param_grid`` unconditionally, so every
+    on_step call failed with AttributeError and the estimator state was never
+    saved. ``param_grid`` is now only included when the estimator defines it, so
+    the saved state is both correct and usable by the resume path.
+    """
+    X, y = load_iris(return_X_y=True)
+    checkpoint_path = str(tmp_path / "fs_checkpoint.pkl")
+
+    def build():
+        return GAFeatureSelectionCV(
+            estimator=DecisionTreeClassifier(random_state=0),
+            cv=2,
+            scoring="accuracy",
+            population_size=4,
+            generations=2,
+        )
+
+    build().fit(X, y, callbacks=ModelCheckpoint(checkpoint_path=checkpoint_path))
+    output = capsys.readouterr().out
+    assert "Error saving checkpoint" not in output
+
+    loaded = ModelCheckpoint(checkpoint_path=checkpoint_path).load()
+    assert "estimator_state" in loaded
+    # param_grid is GASearchCV-only, so it must be absent for a feature selector.
+    assert "param_grid" not in loaded["estimator_state"]
+    assert loaded["estimator_state"]["scoring"] == "accuracy"
+
+    # Round trip: the real saved checkpoint must feed the resume path without
+    # error and yield a fitted selector.
+    resumed = build()
+    resumed.fit(X, y, callbacks=ModelCheckpoint(checkpoint_path=checkpoint_path))
+    assert resumed.support_.shape[0] == X.shape[1]
+    assert resumed.support_.any()
+
+
 def test_feature_selection_checkpoint_resume_restores_fitness_cache(tmp_path):
     """GAFeatureSelectionCV restores its fitness cache on resume (#299).
 


### PR DESCRIPTION
Fixes a real, silent bug in `ModelCheckpoint` and centralizes the checkpoint state construction. **This does not close #297** — see scope note below.

## Bug: feature-selection checkpointing is silently broken
`ModelCheckpoint.on_step` built `estimator_state` as a hand-written literal that read `estimator.param_grid` **unconditionally**. `GAFeatureSelectionCV` has no `param_grid`, so every `on_step` raised `AttributeError`, which the surrounding `try/except` swallowed as `Error saving checkpoint: ...`. The estimator state was therefore **never saved for feature selectors**, so checkpoint/resume silently did nothing.

## Change
Extracted a single `_build_estimator_state()` helper backed by one declared set of constructor-compatible keys, replacing the literal. `param_grid` is only included when the estimator defines it, so both `GASearchCV` and `GAFeatureSelectionCV` serialize correctly, and the key set can no longer drift or duplicate.

`estimator_state` stays constructor-compatible — the `GASearchCV` key set is unchanged, so `GASearchCV(**checkpoint_data["estimator_state"])` and the resume path keep working.

## Test
`test_model_checkpoint_supports_feature_selection_estimator`: fits a `GAFeatureSelectionCV` with a `ModelCheckpoint`, asserts no "Error saving checkpoint", that the reloaded state has no `param_grid`, and — per review — that the saved state **round-trips through the resume path to a fitted selector** (`resumed.support_`). Existing checkpoint/persistence tests pass; `black --check` clean; patch coverage is full.

## Scope (re: #297)
Per review, this PR is intentionally narrowed to the concrete feature-selection bug plus centralizing the checkpoint state. It **does not** attempt the broader #297 goal of sharing/validating a contract with `GeneticEstimatorMixin.save/load` (whose `_serializable_state()` uses a different, non-constructor contract). #297 is left open for a focused follow-up.

Rebased onto current `master`, preserving the merged `Checkpoint saved to ...` message (#308) and the dedup from #303.

— Contributed by **Mayoka Labs**
