### PR TITLE
Unify ModelCheckpoint and save()/load() checkpoint serialization

### DIFF
--- a/sklearn_genetic/_base.py
+++ b/sklearn_genetic/_base.py
@@ -17,7 +17,7 @@ def history_record(history, index):
 
 
 class GeneticEstimatorMixin:
-    _volatile_pickle_attrs = {"toolbox", "_stats", "_pop", "_hof", "hof"}
+    _volatile_pickle_attrs = {"toolbox", "_stats", "_pop", "_hof", "hof", "callbacks"}
 
     def _serializable_state(self):
         return {

--- a/sklearn_genetic/callbacks/model_checkpoint.py
+++ b/sklearn_genetic/callbacks/model_checkpoint.py
@@ -15,31 +15,11 @@ class ModelCheckpoint(BaseCallback):
                 logbook_saver = LogbookSaver(self.checkpoint_path, **self.dump_options)  # noqa
                 logbook_saver.on_step(record, logbook, estimator)
 
-            estimator_state = {
-                "estimator": estimator.estimator,
-                "cv": estimator.cv,
-                "scoring": estimator.scoring,
-                "population_size": estimator.population_size,
-                "generations": estimator.generations,
-                "crossover_probability": estimator.crossover_probability,
-                "mutation_probability": estimator.mutation_probability,
-                "param_grid": estimator.param_grid,
-                "algorithm": estimator.algorithm,
-                "local_search": getattr(estimator, "local_search", False),
-                "local_search_top_k": getattr(estimator, "local_search_top_k", 1),
-                "local_search_steps": getattr(estimator, "local_search_steps", 1),
-                "local_search_radius": getattr(estimator, "local_search_radius", 0.1),
-                "diversity_control": getattr(estimator, "diversity_control", False),
-                "diversity_threshold": getattr(estimator, "diversity_threshold", 0.1),
-                "diversity_stagnation_generations": getattr(
-                    estimator, "diversity_stagnation_generations", 5
-                ),
-                "diversity_mutation_boost": getattr(estimator, "diversity_mutation_boost", 2.0),
-                "random_immigrants_fraction": getattr(estimator, "random_immigrants_fraction", 0.1),
-                "fitness_sharing": getattr(estimator, "fitness_sharing", False),
-                "sharing_radius": getattr(estimator, "sharing_radius", 0.2),
-                "sharing_alpha": getattr(estimator, "sharing_alpha", 1.0),
-            }
+            if hasattr(estimator, "_serializable_state"):
+                estimator_state = estimator._serializable_state()
+            else:
+                estimator_state = self._legacy_estimator_state(estimator)
+
             checkpoint_data = {"estimator_state": estimator_state, "logbook": deepcopy(logbook)}
             with open(self.checkpoint_path, "wb") as f:
                 pickle.dump(checkpoint_data, f)
@@ -47,6 +27,35 @@ class ModelCheckpoint(BaseCallback):
 
         except Exception as e:
             print(f"Error saving checkpoint: {e}")
+
+    @staticmethod
+    def _legacy_estimator_state(estimator):
+        """Build estimator_state by hand for estimators without _serializable_state."""
+        return {
+            "estimator": estimator.estimator,
+            "cv": estimator.cv,
+            "scoring": estimator.scoring,
+            "population_size": estimator.population_size,
+            "generations": estimator.generations,
+            "crossover_probability": estimator.crossover_probability,
+            "mutation_probability": estimator.mutation_probability,
+            "param_grid": estimator.param_grid,
+            "algorithm": estimator.algorithm,
+            "local_search": getattr(estimator, "local_search", False),
+            "local_search_top_k": getattr(estimator, "local_search_top_k", 1),
+            "local_search_steps": getattr(estimator, "local_search_steps", 1),
+            "local_search_radius": getattr(estimator, "local_search_radius", 0.1),
+            "diversity_control": getattr(estimator, "diversity_control", False),
+            "diversity_threshold": getattr(estimator, "diversity_threshold", 0.1),
+            "diversity_stagnation_generations": getattr(
+                estimator, "diversity_stagnation_generations", 5
+            ),
+            "diversity_mutation_boost": getattr(estimator, "diversity_mutation_boost", 2.0),
+            "random_immigrants_fraction": getattr(estimator, "random_immigrants_fraction", 0.1),
+            "fitness_sharing": getattr(estimator, "fitness_sharing", False),
+            "sharing_radius": getattr(estimator, "sharing_radius", 0.2),
+            "sharing_alpha": getattr(estimator, "sharing_alpha", 1.0),
+        }
 
     def load(self):
         """Load the model state from the checkpoint file."""

--- a/sklearn_genetic/tests/test_genetic_search.py
+++ b/sklearn_genetic/tests/test_genetic_search.py
@@ -1376,7 +1376,20 @@ def test_checkpoint_functionality():
     assert "algorithm" in checkpoint_data["estimator_state"]
     assert "logbook" in checkpoint_data
 
-    restored_estimator = GASearchCV(**checkpoint_data["estimator_state"])
+    restored_estimator = GASearchCV(
+        clf,
+        cv=3,
+        scoring="accuracy",
+        population_size=6,
+        generations=gen,
+        tournament_size=3,
+        param_grid={
+            "l1_ratio": Continuous(0, 1),
+            "alpha": Continuous(1e-4, 1),
+            "average": Categorical([True, False]),
+        },
+    )
+    restored_estimator.load(checkpoint_path)
 
     assert restored_estimator.algorithm == checkpoint_data["estimator_state"]["algorithm"]  # noqa
 

--- a/sklearn_genetic/tests/test_persistence_and_helpers.py
+++ b/sklearn_genetic/tests/test_persistence_and_helpers.py
@@ -1,3 +1,4 @@
+import pickle
 from types import SimpleNamespace
 
 import pytest
@@ -238,3 +239,100 @@ def test_model_checkpoint_estimator_state_keys(tmp_path):
     assert estimator_state["param_grid"]["max_depth"].lower == 1
     assert estimator_state["param_grid"]["max_depth"].upper == 2
     assert estimator_state["algorithm"] == "eaSimple"
+
+
+def test_model_checkpoint_matches_save_state(tmp_path):
+    X, y = load_iris(return_X_y=True)
+    X_train, _, y_train, _ = train_test_split(X, y, test_size=0.25, stratify=y, random_state=0)
+
+    search = GASearchCV(
+        estimator=DecisionTreeClassifier(random_state=0),
+        param_grid={"max_depth": Integer(1, 3)},
+        cv=2,
+        scoring="accuracy",
+        population_size=3,
+        generations=1,
+        verbose=False,
+    )
+    search.fit(X_train, y_train)
+
+    save_path = tmp_path / "save.pkl"
+    search.save(save_path)
+    with open(save_path, "rb") as f:
+        saved_state = pickle.load(f)["estimator_state"]
+
+    checkpoint_path = tmp_path / "checkpoint.pkl"
+    checkpoint = ModelCheckpoint(checkpoint_path)
+    checkpoint.on_step(logbook=search.logbook, estimator=search)
+    checkpoint_state = checkpoint.load()["estimator_state"]
+
+    assert checkpoint_state.keys() == saved_state.keys()
+
+    for key in ("cv", "scoring", "population_size", "generations", "algorithm"):
+        assert checkpoint_state[key] == saved_state[key]
+
+    assert list(checkpoint_state["param_grid"].keys()) == list(saved_state["param_grid"].keys())
+    assert (
+        checkpoint_state["param_grid"]["max_depth"].lower
+        == saved_state["param_grid"]["max_depth"].lower
+    )
+    assert (
+        checkpoint_state["param_grid"]["max_depth"].upper
+        == saved_state["param_grid"]["max_depth"].upper
+    )
+
+
+def test_model_checkpoint_output_restorable_via_load(tmp_path):
+    X, y = load_iris(return_X_y=True)
+    X_train, X_test, y_train, _ = train_test_split(X, y, test_size=0.25, stratify=y, random_state=0)
+
+    search = GASearchCV(
+        estimator=DecisionTreeClassifier(random_state=0),
+        param_grid={"max_depth": Integer(1, 3)},
+        cv=2,
+        scoring="accuracy",
+        population_size=3,
+        generations=1,
+        verbose=False,
+    )
+    search.fit(X_train, y_train)
+
+    checkpoint_path = tmp_path / "checkpoint.pkl"
+    checkpoint = ModelCheckpoint(checkpoint_path)
+    checkpoint.on_step(logbook=None, estimator=search)
+
+    restored = GASearchCV(
+        estimator=DecisionTreeClassifier(random_state=0),
+        param_grid={"max_depth": Integer(1, 3)},
+        cv=2,
+        scoring="accuracy",
+    )
+    restored.load(checkpoint_path)
+
+    assert restored.best_score_ == search.best_score_
+    assert restored.best_params_ == search.best_params_
+    assert restored.predict(X_test).shape[0] == X_test.shape[0]
+
+
+def test_model_checkpoint_excludes_volatile_attributes(tmp_path):
+    X, y = load_iris(return_X_y=True)
+    X_train, _, y_train, _ = train_test_split(X, y, test_size=0.25, stratify=y, random_state=0)
+
+    checkpoint_path = tmp_path / "checkpoint.pkl"
+    checkpoint = ModelCheckpoint(checkpoint_path)
+
+    search = GASearchCV(
+        estimator=DecisionTreeClassifier(random_state=0),
+        param_grid={"max_depth": Integer(1, 3)},
+        cv=2,
+        scoring="accuracy",
+        population_size=3,
+        generations=1,
+        verbose=False,
+    )
+    search.fit(X_train, y_train, callbacks=[checkpoint])
+
+    estimator_state = checkpoint.load()["estimator_state"]
+
+    volatile_keys = {"callbacks", "toolbox", "_pop", "_hof", "hof", "_stats"}
+    assert volatile_keys.isdisjoint(estimator_state.keys())


### PR DESCRIPTION
## Summary

Unifies checkpoint serialization between `ModelCheckpoint` and `GeneticEstimatorMixin.save()`/`load()`. `ModelCheckpoint.on_step` now reuses `estimator._serializable_state()` when available (falling back to the previous manual dict for non-mixin estimators), instead of maintaining a separately hand-written key list that could drift from what `save()` captures. Also excludes `callbacks` from `_serializable_state()`, since callback objects (including `ModelCheckpoint` itself, mid-`fit()`) shouldn't be pickled as estimator state.

One user-facing behavior change I noticed: `estimator_state` can no longer be unpacked directly as constructor kwargs (`GASearchCV(**estimator_state)`), since it now includes fit-time-only attributes that aren't valid `__init__` arguments. This pattern was never documented anywhere and appeared in exactly one place in the codebase — an internal test (`test_checkpoint_functionality`) — which has been updated to use `.load()` instead, matching the pattern every other save/load test in the suite already used. `.load()` is the actual supported restore mechanism and is unaffected by this change.

## Related Issue

Closes #297

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor / cleanup
- [ ] Other (describe):

## Checklist

- [x] I checked the linked issue is open and not already covered by another PR
- [x] Tests pass locally (`pytest sklearn_genetic/`)
- [x] Code is formatted with Black (`black sklearn_genetic/`)
- [x] New functionality is covered by tests
- [ ] Documentation updated if needed
