### PR TITLE
docs: add gentle GitHub star prompts

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ sklearn-genetic-opt
 
 Hyperparameter tuning and feature selection for scikit-learn models using genetic algorithms.
 
-|Tests|_ |Codecov|_ |PythonVersion|_ |PyPi| |Conda|_ |Docs|_ |GoodFirstIssues|_
+|Tests|_ |Codecov|_ |PythonVersion|_ |PyPi| |Conda|_ |Docs|_ |Stars|_ |GoodFirstIssues|_
 
 .. |Tests| image:: https://github.com/rodrigo-arenas/Sklearn-genetic-opt/actions/workflows/ci-tests.yml/badge.svg?branch=master
 .. _Tests: https://github.com/rodrigo-arenas/Sklearn-genetic-opt/actions/workflows/ci-tests.yml
@@ -31,6 +31,9 @@ Hyperparameter tuning and feature selection for scikit-learn models using geneti
 .. |Docs| image:: https://img.shields.io/badge/docs-GitHub%20Pages-blue
 .. _Docs: https://sklearngeneticopt.rodrigo-arenas.com/
 
+.. |Stars| image:: https://img.shields.io/github/stars/rodrigo-arenas/Sklearn-genetic-opt?style=social
+.. _Stars: https://github.com/rodrigo-arenas/Sklearn-genetic-opt
+
 .. |GoodFirstIssues| image:: https://img.shields.io/github/issues/rodrigo-arenas/Sklearn-genetic-opt/good%20first%20issue?label=good%20first%20issues&color=7057ff
 .. _GoodFirstIssues: https://github.com/rodrigo-arenas/Sklearn-genetic-opt/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22
 
@@ -45,6 +48,10 @@ regions where ``learning_rate × n_estimators`` or ``C × gamma`` are jointly op
 something one-parameter-at-a-time approaches miss. It also provides
 ``GAFeatureSelectionCV``, a wrapper-based selector that searches the full space
 of feature subsets simultaneously instead of eliminating features one at a time.
+
+If ``sklearn-genetic-opt`` saves you time, consider starring the
+`GitHub repository <https://github.com/rodrigo-arenas/Sklearn-genetic-opt>`_.
+It helps more practitioners discover the project.
 
 
 Why use sklearn-genetic-opt?
@@ -387,9 +394,6 @@ Read the `contribution guide <https://github.com/rodrigo-arenas/Sklearn-genetic-
 before opening a pull request. If you are not sure where to start,
 `open an issue <https://github.com/rodrigo-arenas/Sklearn-genetic-opt/issues>`_
 and ask — small contributions are very welcome.
-
-If ``sklearn-genetic-opt`` helps your work, consider starring the repository
-so others can find it.
 
 |Contributors|_
 

--- a/docs-vitepress/.vitepress/theme/components/HomeCommunity.vue
+++ b/docs-vitepress/.vitepress/theme/components/HomeCommunity.vue
@@ -5,7 +5,8 @@
         <h2 class="community-title">Open Source &amp; Community Driven</h2>
         <p class="community-desc">
           sklearn-genetic-opt is MIT licensed and actively maintained. Contributions, bug reports,
-          and feature requests are welcome.
+          and feature requests are welcome. If it saves you time, a GitHub star helps other
+          practitioners discover it.
         </p>
 
         <div class="community-stats">
@@ -29,7 +30,7 @@
             Report an Issue
           </a>
           <a
-            href="https://github.com/rodrigo-arenas/Sklearn-genetic-opt/blob/master/CONTRIBUTING.rst"
+            href="https://github.com/rodrigo-arenas/Sklearn-genetic-opt/blob/master/CONTRIBUTING.md"
             class="community-btn secondary"
           >
             Contributing Guide
@@ -47,7 +48,7 @@
 <script setup>
 const stats = [
   { value: 'MIT', label: 'License' },
-  { value: 'Python 3.8+', label: 'Requirement' },
+  { value: 'Python 3.12+', label: 'Requirement' },
   { value: 'scikit-learn', label: 'Compatible with' },
   { value: '0.13', label: 'Latest stable' },
 ]

--- a/docs-vitepress/versions/latest/index.md
+++ b/docs-vitepress/versions/latest/index.md
@@ -7,6 +7,8 @@ description: Development documentation for sklearn-genetic-opt — tracks the ma
 
 `sklearn-genetic-opt` adds evolutionary optimization tools to the scikit-learn workflow. It can tune hyperparameters with `GASearchCV` and select feature subsets with `GAFeatureSelectionCV` using algorithms powered by DEAP.
 
+If the project helps your work, consider [starring it on GitHub](https://github.com/rodrigo-arenas/Sklearn-genetic-opt). It helps other practitioners find the library.
+
 :::warning Development version
 You are reading the **latest (development)** docs. This version tracks the `master` branch and may contain unreleased features or breaking changes. For stable documentation, see [stable](/stable/).
 :::


### PR DESCRIPTION
## Summary
- add a GitHub stars badge and a short, non-intrusive star prompt near the README introduction
- add a similarly gentle star note to the latest docs landing page
- update the docs community CTA copy and fix its contributing guide link to CONTRIBUTING.md

## Validation
- node docs-vitepress\\node_modules\\vitepress\\bin\\vitepress.js build docs-vitepress