### PR TITLE
docs: refresh release notes and navbar links

### DIFF
--- a/docs-vitepress/.vitepress/config.ts
+++ b/docs-vitepress/.vitepress/config.ts
@@ -31,6 +31,26 @@ const versionNavItems = [
   { text: 'latest (dev)', link: '/versions/latest/' },
 ]
 
+const starIcon = {
+  svg: '<svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="m12 2.6 2.9 5.9 6.5.9-4.7 4.6 1.1 6.5L12 17.4l-5.8 3.1 1.1-6.5-4.7-4.6 6.5-.9L12 2.6Z"/></svg>',
+}
+
+const forkIcon = {
+  svg: '<svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M7 3a3 3 0 0 0-1 5.83V15a4 4 0 0 0 4 4h4a3 3 0 1 0 0-2h-4a2 2 0 0 1-2-2V8.83A3 3 0 0 0 7 3Zm0 2a1 1 0 1 1 0 2 1 1 0 0 1 0-2Zm10 12a1 1 0 1 1 0 2 1 1 0 0 1 0-2Zm0-14a3 3 0 0 0-1 5.83V11a2 2 0 0 1-2 2h-2v2h2a4 4 0 0 0 4-4V8.83A3 3 0 0 0 17 3Zm0 2a1 1 0 1 1 0 2 1 1 0 0 1 0-2Z"/></svg>',
+}
+
+const issuesIcon = {
+  svg: '<svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12 2a10 10 0 1 0 .01 0H12Zm0 2a8 8 0 1 1-.01 0H12Zm-1 3h2v7h-2V7Zm0 9h2v2h-2v-2Z"/></svg>',
+}
+
+const discussionsIcon = {
+  svg: '<svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M4 4h16a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H9.8L5 21v-4H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2Zm0 2v9h3v1.7L9.1 15H20V6H4Zm3 3h10v2H7V9Zm0 3h7v2H7v-2Z"/></svg>',
+}
+
+const packageIcon = {
+  svg: '<svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="m12 2 9 5v10l-9 5-9-5V7l9-5Zm0 2.3L6.1 7.6 12 10.9l5.9-3.3L12 4.3ZM5 9.3v6.5l6 3.3v-6.5L5 9.3Zm14 0-6 3.3v6.5l6-3.3V9.3Z"/></svg>',
+}
+
 const versionSidebarEntries = Object.fromEntries([
   ...releaseVersions.map((version) => [
     `/versions/${version}/`,
@@ -277,19 +297,41 @@ export default defineConfig({
         text: 'Version',
         items: versionNavItems,
       },
-      {
-        text: 'Links',
-        items: [
-          { text: 'GitHub', link: 'https://github.com/rodrigo-arenas/Sklearn-genetic-opt' },
-          { text: 'PyPI', link: 'https://pypi.org/project/sklearn-genetic-opt/' },
-        ],
-      },
     ],
 
     sidebar: versionSidebarEntries,
 
     socialLinks: [
-      { icon: 'github', link: 'https://github.com/rodrigo-arenas/Sklearn-genetic-opt' },
+      {
+        icon: 'github',
+        link: 'https://github.com/rodrigo-arenas/Sklearn-genetic-opt',
+        ariaLabel: 'GitHub repository',
+      },
+      {
+        icon: starIcon,
+        link: 'https://github.com/rodrigo-arenas/Sklearn-genetic-opt',
+        ariaLabel: 'Star on GitHub',
+      },
+      {
+        icon: forkIcon,
+        link: 'https://github.com/rodrigo-arenas/Sklearn-genetic-opt/fork',
+        ariaLabel: 'Fork on GitHub',
+      },
+      {
+        icon: issuesIcon,
+        link: 'https://github.com/rodrigo-arenas/Sklearn-genetic-opt/issues',
+        ariaLabel: 'GitHub issues',
+      },
+      {
+        icon: discussionsIcon,
+        link: 'https://github.com/rodrigo-arenas/Sklearn-genetic-opt/discussions',
+        ariaLabel: 'GitHub discussions',
+      },
+      {
+        icon: packageIcon,
+        link: 'https://pypi.org/project/sklearn-genetic-opt/',
+        ariaLabel: 'PyPI package',
+      },
     ],
 
     footer: {

--- a/docs-vitepress/.vitepress/config.ts
+++ b/docs-vitepress/.vitepress/config.ts
@@ -282,7 +282,6 @@ export default defineConfig({
         items: [
           { text: 'GitHub', link: 'https://github.com/rodrigo-arenas/Sklearn-genetic-opt' },
           { text: 'PyPI', link: 'https://pypi.org/project/sklearn-genetic-opt/' },
-          { text: 'Legacy Docs (RTD)', link: 'https://sklearn-genetic-opt.readthedocs.io' },
         ],
       },
     ],

--- a/docs-vitepress/versions/latest/release-notes.md
+++ b/docs-vitepress/versions/latest/release-notes.md
@@ -9,6 +9,59 @@ You are reading the **latest (dev)** docs. For the stable version, see [stable](
 
 # Release Notes
 
+## 0.13.4 (unreleased)
+
+### New Features and Behavior
+
+- **Benchmark cache toggle**: `benchmarks/benchmark_fit.py` now exposes `--use-cache` / `--no-use-cache`, and threads the setting through both `GASearchCV` and `GAFeatureSelectionCV` benchmark builders. This makes it possible to measure the real impact of the fitness cache on repeated candidate evaluation.
+- **Safer constructor validation**: `error_score` is now validated during estimator construction, so invalid values fail earlier with a clearer message.
+- **More robust ranking utilities**: internal score ranking now handles `NaN` values consistently when ranking candidates.
+
+### Bug Fixes and Error Messages
+
+- **ModelCheckpoint cleanup**: removed a duplicate `param_grid` entry from `ModelCheckpoint` estimator state and added regression coverage for the core checkpoint keys.
+- **Clearer checkpoint output**: `ModelCheckpoint` now reports successful saves with the clearer message `Checkpoint saved to ...`.
+- **Better plotting errors**:
+  - candidate plots now validate invalid `top_k` values before plotting
+  - metric-column errors now list available metric names
+  - `plot_history` errors now show available fields
+  - plotting helpers now raise more actionable errors when called before fitting
+- **Search-space validation improvements**:
+  - `warm_start_configs` validation now reports clearer errors
+  - feature-name count mismatch errors include the expected and received counts
+  - preset `prefix` now validates its type
+  - unsupported scipy distributions in `from_sklearn_space` now suggest list or `Categorical` alternatives
+- **Optional dependency errors**: missing MLflow now raises a clearer error explaining how to install the optional extra.
+- **Adapter validation**: scheduler adapter errors now include the received type.
+- **Type annotations**: completed type annotations for the search-space parameter classes and fixed the `Categorical.random_state` annotation.
+
+### Documentation
+
+- **Clean canonical URLs**: docs canonical and Open Graph URLs now use clean VitePress-style URLs instead of raw `.html` targets.
+- **Preset pipeline guidance**: added a guide section showing how to use preset search spaces with sklearn `Pipeline` objects via the preset `prefix` argument.
+- **Community articles**:
+  - added a Community Articles page for external posts, videos, tutorials, and articles
+  - updated README and contributor-facing docs to point to the current community articles source file
+  - added the first community article entry comparing `GASearchCV` and `RandomizedSearchCV`
+- **Contributor guidance**: docs now remind contributors to check issue and PR status before starting work to avoid duplicated effort.
+- **README improvements**:
+  - added citation guidance
+  - added a gentle GitHub star prompt and stars badge
+  - updated community article contribution links
+- **Docs navigation cleanup**: removed the legacy Read the Docs link from the new VitePress docs now that the RTD page is no longer available.
+- **TimerStopping example**: callbacks docs now include a runnable `TimerStopping` example.
+- **Troubleshooting expansion**: added error-reference and `parallel_backend` decision tables, plus refreshed stale `parallel_backend` examples.
+
+### Tests and Maintenance
+
+- Added direct tests for `_as_list` and extra edge cases including NumPy arrays, sets, empty strings, and falsy scalar values.
+- Added `_candidate_label` tests covering hidden-parameter counts, `label_params`, truncation, and compact float formatting.
+- Added `Categorical.random_state` determinism coverage and priors sampling validation.
+- Added an internal Markdown link checker for versioned docs pages.
+- Added `CITATION.cff` for GitHub citation support.
+
+---
+
 ## 0.13.3
 
 ### New Features

--- a/docs-vitepress/versions/latest/release-notes.md
+++ b/docs-vitepress/versions/latest/release-notes.md
@@ -48,7 +48,7 @@ You are reading the **latest (dev)** docs. For the stable version, see [stable](
   - added citation guidance
   - added a gentle GitHub star prompt and stars badge
   - updated community article contribution links
-- **Docs navigation cleanup**: removed the legacy Read the Docs link from the new VitePress docs now that the RTD page is no longer available.
+- **Docs navigation cleanup**: replaced the generic Links dropdown with direct navbar icons for GitHub, Star, Fork, Issues, Discussions, and PyPI; also removed the legacy Read the Docs link now that the RTD page is no longer available.
 - **TimerStopping example**: callbacks docs now include a runnable `TimerStopping` example.
 - **Troubleshooting expansion**: added error-reference and `parallel_backend` decision tables, plus refreshed stale `parallel_backend` examples.
 


### PR DESCRIPTION
## Summary
- add an unreleased 0.13.4 section to the latest docs release notes covering recent merged PRs
- replace the generic Links dropdown with direct navbar icons for GitHub, Star, Fork, Issues, Discussions, and PyPI
- remove the Legacy Docs (RTD) item from the VitePress links now that the Read the Docs page has been deleted

## Validation
- node docs-vitepress\\node_modules\\vitepress\\bin\\vitepress.js build docs-vitepress