### PR TITLE
Fix Categorical priors being ignored during sampling

### DIFF
--- a/sklearn_genetic/space/space.py
+++ b/sklearn_genetic/space/space.py
@@ -184,7 +184,9 @@ class Categorical(BaseDimension):
         self.distribution = distribution
         self.random_state = random_state
         random.seed(random_state)
-        self.rng = None if not self.random_state else np.random.default_rng(self.random_state)
+        self.rng = (
+            np.random.default_rng(self.random_state) if self.random_state is not None else None
+        )
 
         if self.distribution == CategoricalDistributions.choice.value:
             self.rvs = self.rng.choice if self.rng else random.choice
@@ -198,7 +200,11 @@ class Categorical(BaseDimension):
     def sample(self) -> Any:
         """Sample a random value from the assigned distribution"""
 
-        return self.rvs(self.choices)
+        if self.priors is None:
+            return self.rvs(self.choices)
+        if self.rng is not None:
+            return self.rvs(self.choices, p=self.priors)
+        return random.choices(self.choices, weights=self.priors, k=1)[0]
 
 
 def check_space(param_grid: dict = None):

--- a/sklearn_genetic/space/tests/test_space.py
+++ b/sklearn_genetic/space/tests/test_space.py
@@ -1,3 +1,4 @@
+from collections import Counter
 from typing import Any
 
 import pytest
@@ -144,6 +145,38 @@ def test_categorical_sampling_with_priors_stays_in_choices():
 
     assert dimension.priors == [0.2, 0.3, 0.5]
     assert all(dimension.sample() in choices for _ in range(50))
+
+
+def test_categorical_priors_skew_sampling_with_numpy_rng():
+    """Priors must actually bias sampling, not just be stored (#314).
+
+    Uses the seeded ``rng.choice`` path (random_state is given). With a heavy
+    98/2 skew over 4000 draws, an unweighted 50/50 draw is statistically
+    impossible to land in the assertion window below.
+    """
+    dimension = Categorical(["a", "b"], priors=[0.98, 0.02], random_state=1)
+
+    counts = Counter(dimension.sample() for _ in range(4000))
+
+    assert counts["a"] > 3500
+    assert counts["b"] < 500
+
+
+def test_categorical_priors_skew_sampling_with_stdlib_random():
+    """Same as above, but exercising the unseeded ``random.choices`` path (#314)."""
+    dimension = Categorical(["a", "b"], priors=[0.98, 0.02])
+
+    counts = Counter(dimension.sample() for _ in range(4000))
+
+    assert counts["a"] > 3500
+    assert counts["b"] < 500
+
+
+def test_categorical_random_state_zero_uses_numpy_generator():
+    """random_state=0 must not be treated as falsy and silently ignored (#314)."""
+    dimension = Categorical(["a", "b"], random_state=0)
+
+    assert dimension.rng is not None
 
 
 def test_space_classes_have_complete_type_annotations():


### PR DESCRIPTION
Fixes #314

`Categorical.sample()` called `self.rvs(self.choices)` without ever passing
`self.priors` along, so priors were validated and stored on the object but
had zero effect on sampling, neaning that every choice was drawn with equal probability
regardless of documented weights. This affects both sampling backends
(`numpy.random.Generator.choice` when `random_state` is set, `random.choice`
otherwise), which need different call signatures to support weights
(`p=` vs. `random.choices(..., weights=...)`).

Also fixes a related bug in the same constructor: `random_state=0` was
treated as falsy (`None if not self.random_state else ...`), so seed `0`
silently fell back to the unseeded stdlib path instead of the numpy
generator.

## Changes
- `Categorical.sample()` now passes `self.priors` to the numpy `Generator.choice`
  path (`p=`), and uses `random.choices(..., weights=...)` for the stdlib path
  when priors are set.
- Fixed the `random_state=0` falsy check in `Categorical.__init__`.
- Added 3 regression tests: priors actually skew sampling on both backends
  (verified against a heavy 98/2 split, matching the issue's repro), and
  `random_state=0` correctly activates the numpy generator.

Ran `black --check` and the full suite locally: 361 passed, 4 skipped.