### PR TITLE
Add root docs link checking for README and CONTRIBUTING

### DIFF
--- a/docs-vitepress/scripts/check_links.py
+++ b/docs-vitepress/scripts/check_links.py
@@ -32,9 +32,20 @@ VERSION_DIRS = [
     ROOT / "docs-vitepress" / "versions" / "latest",
     ROOT / "docs-vitepress" / "versions" / "0.13",
 ]
+ROOT_DOCS = [
+    ROOT / "README.rst",
+    ROOT / "CONTRIBUTING.md",
+]
+OWN_REPO_BLOB_PREFIXES = (
+    "https://github.com/rodrigo-arenas/Sklearn-genetic-opt/blob/master/",
+    "https://github.com/rodrigo-arenas/Sklearn-genetic-opt/blob/main/",
+)
 
 # [text](target) and ![alt](target) — capture the target up to whitespace or ')'.
 LINK_RE = re.compile(r"!?\[[^\]]*\]\(\s*([^)\s]+)")
+# Basic RST inline links and named hyperlink definitions. Targets are kept
+# single-token so normal prose with angle brackets is not treated as a path.
+RST_LINK_RE = re.compile(r"`[^`<\n]+<([^\s>]+)>`_|^\.\.\s+_[^:]+:\s+(\S+)", re.MULTILINE)
 
 _EXTERNAL_PREFIXES = ("http://", "https://", "mailto:", "//")
 
@@ -66,6 +77,48 @@ def _resolves(md_file: Path, target: str) -> bool:
     return any(candidate.is_file() for candidate in candidates)
 
 
+def _same_repo_blob_path(target: str) -> str | None:
+    for prefix in OWN_REPO_BLOB_PREFIXES:
+        if target.startswith(prefix):
+            return target[len(prefix):]
+    return None
+
+
+def _iter_targets(doc_file: Path) -> list[str]:
+    text = doc_file.read_text(encoding="utf-8")
+    if doc_file.suffix == ".rst":
+        targets = []
+        for inline, named in RST_LINK_RE.findall(text):
+            targets.append(inline or named)
+        return targets
+    return LINK_RE.findall(text)
+
+
+def _resolves_root_doc_link(doc_file: Path, target: str) -> bool:
+    same_repo = _same_repo_blob_path(target)
+    if same_repo is None:
+        if not _is_internal_relative(target):
+            return True
+        path_part = target.split("#", 1)[0].split("?", 1)[0]
+        base = (doc_file.parent / path_part).resolve()
+    else:
+        path_part = same_repo.split("#", 1)[0].split("?", 1)[0]
+        base = (ROOT / path_part).resolve()
+
+    try:
+        base.relative_to(ROOT)
+    except ValueError:
+        return False
+
+    candidates = [
+        base,
+        base.with_name(base.name + ".md"),
+        base.with_name(base.name + ".rst"),
+        base / "index.md",
+    ]
+    return any(candidate.is_file() for candidate in candidates)
+
+
 def check() -> list[tuple[Path, str]]:
     broken: list[tuple[Path, str]] = []
     for version_dir in VERSION_DIRS:
@@ -76,6 +129,12 @@ def check() -> list[tuple[Path, str]]:
             for target in LINK_RE.findall(text):
                 if _is_internal_relative(target) and not _resolves(md_file, target):
                     broken.append((md_file, target))
+    for root_doc in ROOT_DOCS:
+        if not root_doc.exists():
+            continue
+        for target in _iter_targets(root_doc):
+            if not _resolves_root_doc_link(root_doc, target):
+                broken.append((root_doc, target))
     return broken
 
 

--- a/docs-vitepress/scripts/check_links.py
+++ b/docs-vitepress/scripts/check_links.py
@@ -46,6 +46,7 @@ LINK_RE = re.compile(r"!?\[[^\]]*\]\(\s*([^)\s]+)")
 # Basic RST inline links and named hyperlink definitions. Targets are kept
 # single-token so normal prose with angle brackets is not treated as a path.
 RST_LINK_RE = re.compile(r"`[^`<\n]+<([^\s>]+)>`_|^\.\.\s+_[^:]+:\s+(\S+)", re.MULTILINE)
+RST_DIRECTIVE_TARGET_RE = re.compile(r"^\.\.\s+(?:image|figure)::\s+(\S+)", re.MULTILINE)
 
 _EXTERNAL_PREFIXES = ("http://", "https://", "mailto:", "//")
 
@@ -90,6 +91,7 @@ def _iter_targets(doc_file: Path) -> list[str]:
         targets = []
         for inline, named in RST_LINK_RE.findall(text):
             targets.append(inline or named)
+        targets.extend(RST_DIRECTIVE_TARGET_RE.findall(text))
         return targets
     return LINK_RE.findall(text)
 

--- a/docs-vitepress/scripts/check_links.py
+++ b/docs-vitepress/scripts/check_links.py
@@ -81,7 +81,7 @@ def _resolves(md_file: Path, target: str) -> bool:
 def _same_repo_blob_path(target: str) -> str | None:
     for prefix in OWN_REPO_BLOB_PREFIXES:
         if target.startswith(prefix):
-            return target[len(prefix):]
+            return target[len(prefix) :]
     return None
 
 

--- a/docs-vitepress/scripts/test_check_links.py
+++ b/docs-vitepress/scripts/test_check_links.py
@@ -56,3 +56,45 @@ def test_resolves(tmp_path):
     # Broken: missing page, and a directory without an index.md (the edge case).
     assert check_links._resolves(source, "./guide/missing") is False
     assert check_links._resolves(source, "./empty") is False
+
+
+def test_root_doc_valid_local_link_passes(tmp_path, monkeypatch):
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "external_references.rst").write_text("x", encoding="utf-8")
+    root_doc = tmp_path / "CONTRIBUTING.md"
+    root_doc.write_text("[refs](docs/external_references.rst)", encoding="utf-8")
+    monkeypatch.setattr(check_links, "ROOT", tmp_path)
+    monkeypatch.setattr(check_links, "VERSION_DIRS", [])
+    monkeypatch.setattr(check_links, "ROOT_DOCS", [root_doc])
+    assert check_links.check() == []
+
+
+def test_root_doc_missing_local_file_is_reported(tmp_path, monkeypatch):
+    root_doc = tmp_path / "CONTRIBUTING.md"
+    root_doc.write_text("[refs](docs/missing.rst)", encoding="utf-8")
+    monkeypatch.setattr(check_links, "ROOT", tmp_path)
+    monkeypatch.setattr(check_links, "VERSION_DIRS", [])
+    monkeypatch.setattr(check_links, "ROOT_DOCS", [root_doc])
+    assert check_links.check() == [(root_doc, "docs/missing.rst")]
+
+
+def test_root_doc_external_url_is_skipped(tmp_path, monkeypatch):
+    root_doc = tmp_path / "CONTRIBUTING.md"
+    root_doc.write_text("[external](https://example.com/missing)", encoding="utf-8")
+    monkeypatch.setattr(check_links, "ROOT", tmp_path)
+    monkeypatch.setattr(check_links, "VERSION_DIRS", [])
+    monkeypatch.setattr(check_links, "ROOT_DOCS", [root_doc])
+    assert check_links.check() == []
+
+
+def test_root_doc_rst_parser_does_not_capture_multiline_prose(tmp_path, monkeypatch):
+    root_doc = tmp_path / "README.rst"
+    root_doc.write_text(
+        "This paragraph mentions <not-a-link> and then continues\\n"
+        "across lines without creating a filesystem target.",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(check_links, "ROOT", tmp_path)
+    monkeypatch.setattr(check_links, "VERSION_DIRS", [])
+    monkeypatch.setattr(check_links, "ROOT_DOCS", [root_doc])
+    assert check_links.check() == []

--- a/docs-vitepress/scripts/test_check_links.py
+++ b/docs-vitepress/scripts/test_check_links.py
@@ -98,3 +98,16 @@ def test_root_doc_rst_parser_does_not_capture_multiline_prose(tmp_path, monkeypa
     monkeypatch.setattr(check_links, "VERSION_DIRS", [])
     monkeypatch.setattr(check_links, "ROOT_DOCS", [root_doc])
     assert check_links.check() == []
+
+
+def test_root_doc_rst_image_directive_broken_same_repo_blob_is_reported(tmp_path, monkeypatch):
+    root_doc = tmp_path / "README.rst"
+    target = (
+        "https://github.com/rodrigo-arenas/Sklearn-genetic-opt/blob/master/"
+        "docs-vitepress/public/images/missing.png?raw=true"
+    )
+    root_doc.write_text(f".. image:: {target}\n", encoding="utf-8")
+    monkeypatch.setattr(check_links, "ROOT", tmp_path)
+    monkeypatch.setattr(check_links, "VERSION_DIRS", [])
+    monkeypatch.setattr(check_links, "ROOT_DOCS", [root_doc])
+    assert check_links.check() == [(root_doc, target)]


### PR DESCRIPTION
Related to #298.

Hi, this looks well-contained. I did a small local pass in a clean clone.

The bounded patch path is:
- extend `docs-vitepress/scripts/check_links.py` so it also checks root `README.rst` and `CONTRIBUTING.md`;
- keep normal external HTTP URLs skipped;
- treat same-repo GitHub `blob/master/...` / `blob/main/...` links as local repository paths;
- add the requested root-doc tests, plus a small RST parser guard.

Live proof from the current upstream snapshot:
- upstream head: `fede07a70d0a518ee92c217a7c4b62b87995796f`
- `python3 -m pytest docs-vitepress/scripts/test_check_links.py` -> 15 passed
- `python3 docs-vitepress/scripts/check_links.py` -> All internal documentation links resolve.

Patch size:
```text
docs-vitepress/scripts/check_links.py      | 59 ++++++++++++++++++++++++++++++
 docs-vitepress/scripts/test_check_links.py | 42 +++++++++++++++++++++
 2 files changed, 101 insertions(+)
```

This is one small PR. No broad refactor and no external-link validation.
