### PR TITLE
Fix Integer and Continuous ignoring random_state=0

### DIFF
--- a/sklearn_genetic/space/space.py
+++ b/sklearn_genetic/space/space.py
@@ -55,7 +55,9 @@ class Integer(BaseDimension):
         self.upper = upper
         self.distribution = distribution
         self.random_state = random_state
-        self.rng = None if not self.random_state else np.random.default_rng(self.random_state)
+        self.rng = (
+            np.random.default_rng(self.random_state) if self.random_state is not None else None
+        )
 
         if self.distribution == IntegerDistributions.uniform.value:
             self.rvs = stats.randint.rvs
@@ -116,7 +118,9 @@ class Continuous(BaseDimension):
         self.distribution = distribution
         self.shifted_upper = self.upper
         self.random_state = random_state
-        self.rng = None if not self.random_state else np.random.default_rng(self.random_state)
+        self.rng = (
+            np.random.default_rng(self.random_state) if self.random_state is not None else None
+        )
 
         if self.distribution == ContinuousDistributions.uniform.value:
             self.rvs = stats.uniform.rvs

--- a/sklearn_genetic/space/tests/test_space.py
+++ b/sklearn_genetic/space/tests/test_space.py
@@ -179,6 +179,38 @@ def test_categorical_random_state_zero_uses_numpy_generator():
     assert dimension.rng is not None
 
 
+@pytest.mark.parametrize(
+    "data_object, parameters",
+    [
+        (Integer, {"lower": 1, "upper": 1000}),
+        (Continuous, {"lower": 0.0, "upper": 1.0}),
+    ],
+)
+def test_integer_and_continuous_random_state_zero_uses_numpy_generator(data_object, parameters):
+    """random_state=0 must not be treated as falsy and silently ignored (#322)."""
+    dimension = data_object(random_state=0, **parameters)
+
+    assert dimension.rng is not None
+
+
+@pytest.mark.parametrize(
+    "data_object, parameters",
+    [
+        (Integer, {"lower": 1, "upper": 1000}),
+        (Continuous, {"lower": 0.0, "upper": 1.0}),
+    ],
+)
+def test_integer_and_continuous_random_state_zero_is_deterministic(data_object, parameters):
+    """Same random_state=0 yields the same sample sequence (#322)."""
+    first = data_object(random_state=0, **parameters)
+    second = data_object(random_state=0, **parameters)
+
+    seq_first = [first.sample() for _ in range(5)]
+    seq_second = [second.sample() for _ in range(5)]
+
+    assert seq_first == seq_second
+
+
 def test_space_classes_have_complete_type_annotations():
     """random_state and sample() carry annotations on every space class (#209)."""
     import inspect


### PR DESCRIPTION
Fixes #322

Same falsy-zero bug already fixed for Categorical in #320:
`self.rng = None if not self.random_state else np.random.default_rng(self.random_state)`
treats seed `0` as falsy, so no numpy Generator is created and sampling
silently falls back to being unseeded and leads to reproducibility breaks specifically
for `random_state=0`.

## Changes
- Fixed the falsy-zero check in both `Integer.__init__` and `Continuous.__init__`
  (`is not None` instead of truthiness).
- Added parametrized regression tests covering both classes: `random_state=0`
  now activates the numpy generator, and produces a deterministic sample
  sequence across two independently constructed instances.

Ran `black --check` and the full suite locally: 368 passed, 4 skipped.