### PR TITLE
Unify checkpoint serialization with a validated save/load contract (#297)

### DIFF
--- a/sklearn_genetic/_base.py
+++ b/sklearn_genetic/_base.py
@@ -19,12 +19,64 @@ def history_record(history, index):
 class GeneticEstimatorMixin:
     _volatile_pickle_attrs = {"toolbox", "_stats", "_pop", "_hof", "hof"}
 
+    # Contract for the two serialization paths (see #297):
+    #
+    # * ``_serializable_state()`` is the FULL snapshot used by ``save``/``load``.
+    #   It is restored with ``setattr`` onto an existing instance, so it may hold
+    #   non-constructor attributes (``X_``, ``cv_results_``, ``best_estimator_``…).
+    # * ``_checkpoint_state()`` is the CONSTRUCTOR-COMPATIBLE subset used by
+    #   ``ModelCheckpoint`` to resume a search. Every key is an ``__init__``
+    #   parameter, so it can be replayed as ``ClassName(**state)``, and it is a
+    #   strict subset of ``_serializable_state()``.
+    #
+    # The serialization contract test enforces that relationship (every
+    # checkpoint key is an __init__ parameter and lives in _serializable_state)
+    # so the two paths cannot silently drift apart.
+    _checkpoint_core_keys = (
+        "estimator",
+        "cv",
+        "scoring",
+        "population_size",
+        "generations",
+        "crossover_probability",
+        "mutation_probability",
+        "algorithm",
+    )
+    _checkpoint_optional_defaults = {
+        "local_search": False,
+        "local_search_top_k": 1,
+        "local_search_steps": 1,
+        "local_search_radius": 0.1,
+        "diversity_control": False,
+        "diversity_threshold": 0.1,
+        "diversity_stagnation_generations": 5,
+        "diversity_mutation_boost": 2.0,
+        "random_immigrants_fraction": 0.1,
+        "fitness_sharing": False,
+        "sharing_radius": 0.2,
+        "sharing_alpha": 1.0,
+    }
+
     def _serializable_state(self):
         return {
             key: value
             for key, value in self.__dict__.items()
             if key not in self._volatile_pickle_attrs
         }
+
+    def _checkpoint_state(self):
+        """Constructor-compatible subset of the state used to resume a search.
+
+        ``param_grid`` is only included when the estimator defines it
+        (GAFeatureSelectionCV does not), so this works for both estimators and a
+        feature selector never raises ``AttributeError`` while checkpointing.
+        """
+        state = {key: getattr(self, key) for key in self._checkpoint_core_keys}
+        if hasattr(self, "param_grid"):
+            state["param_grid"] = self.param_grid
+        for key, default in self._checkpoint_optional_defaults.items():
+            state[key] = getattr(self, key, default)
+        return state
 
     def save(self, filepath):
         """Save the current state of the estimator instance to a file."""

--- a/sklearn_genetic/callbacks/model_checkpoint.py
+++ b/sklearn_genetic/callbacks/model_checkpoint.py
@@ -3,52 +3,6 @@ from .base import BaseCallback
 from .loggers import LogbookSaver
 from copy import deepcopy
 
-# Single source of truth for the constructor-compatible state persisted in a
-# checkpoint, so the key set cannot silently drift or duplicate.
-#
-# Core keys exist on both GASearchCV and GAFeatureSelectionCV and are read
-# directly. Optional keys map to the default used when the estimator does not
-# define them.
-_CHECKPOINT_CORE_KEYS = (
-    "estimator",
-    "cv",
-    "scoring",
-    "population_size",
-    "generations",
-    "crossover_probability",
-    "mutation_probability",
-    "algorithm",
-)
-_CHECKPOINT_OPTIONAL_DEFAULTS = {
-    "local_search": False,
-    "local_search_top_k": 1,
-    "local_search_steps": 1,
-    "local_search_radius": 0.1,
-    "diversity_control": False,
-    "diversity_threshold": 0.1,
-    "diversity_stagnation_generations": 5,
-    "diversity_mutation_boost": 2.0,
-    "random_immigrants_fraction": 0.1,
-    "fitness_sharing": False,
-    "sharing_radius": 0.2,
-    "sharing_alpha": 1.0,
-}
-
-
-def _build_estimator_state(estimator):
-    """Build the constructor-compatible checkpoint state for an estimator.
-
-    Works for both GASearchCV and GAFeatureSelectionCV: ``param_grid`` is only
-    included when the estimator actually defines it (GAFeatureSelectionCV does
-    not), so checkpointing a feature selector no longer raises AttributeError.
-    """
-    state = {key: getattr(estimator, key) for key in _CHECKPOINT_CORE_KEYS}
-    if hasattr(estimator, "param_grid"):
-        state["param_grid"] = estimator.param_grid
-    for key, default in _CHECKPOINT_OPTIONAL_DEFAULTS.items():
-        state[key] = getattr(estimator, key, default)
-    return state
-
 
 class ModelCheckpoint(BaseCallback):
     def __init__(self, checkpoint_path, **dump_options):
@@ -61,7 +15,7 @@ class ModelCheckpoint(BaseCallback):
                 logbook_saver = LogbookSaver(self.checkpoint_path, **self.dump_options)  # noqa
                 logbook_saver.on_step(record, logbook, estimator)
 
-            estimator_state = _build_estimator_state(estimator)
+            estimator_state = estimator._checkpoint_state()
             # Runtime state is kept separate from ``estimator_state`` so the
             # latter stays constructor-compatible (it is consumed as
             # ``GASearchCV(**estimator_state)``). Restoring the fitness cache on

--- a/sklearn_genetic/tests/test_persistence_and_helpers.py
+++ b/sklearn_genetic/tests/test_persistence_and_helpers.py
@@ -1,5 +1,3 @@
-from types import SimpleNamespace
-
 import pytest
 from sklearn.datasets import load_iris
 from sklearn.exceptions import NotFittedError
@@ -168,18 +166,19 @@ def test_ga_feature_selection_support_mask_requires_fit():
         selector._get_support_mask()
 
 
-def test_model_checkpoint_save_load_and_error_paths(tmp_path, capsys):
-    estimator = SimpleNamespace(
+def _checkpoint_estimator():
+    return GASearchCV(
         estimator=DecisionTreeClassifier(),
+        param_grid={"max_depth": Integer(1, 2), "min_samples_split": Integer(2, 5)},
         cv=2,
         scoring="accuracy",
         population_size=4,
         generations=2,
-        crossover_probability=0.8,
-        mutation_probability=0.1,
-        param_grid={"max_depth": Integer(1, 2)},
-        algorithm="eaSimple",
     )
+
+
+def test_model_checkpoint_save_load_and_error_paths(tmp_path, capsys):
+    estimator = _checkpoint_estimator()
     checkpoint_path = tmp_path / "checkpoint.pkl"
     checkpoint = ModelCheckpoint(checkpoint_path)
 
@@ -200,17 +199,7 @@ def test_model_checkpoint_save_load_and_error_paths(tmp_path, capsys):
 
 
 def test_model_checkpoint_estimator_state_keys(tmp_path):
-    estimator = SimpleNamespace(
-        estimator=DecisionTreeClassifier(),
-        cv=2,
-        scoring="accuracy",
-        population_size=4,
-        generations=2,
-        crossover_probability=0.8,
-        mutation_probability=0.1,
-        param_grid={"max_depth": Integer(1, 2)},
-        algorithm="eaSimple",
-    )
+    estimator = _checkpoint_estimator()
     checkpoint_path = tmp_path / "checkpoint.pkl"
     checkpoint = ModelCheckpoint(checkpoint_path)
 
@@ -232,12 +221,44 @@ def test_model_checkpoint_estimator_state_keys(tmp_path):
     assert isinstance(estimator_state["estimator"], DecisionTreeClassifier)
     assert estimator_state["cv"] == 2
     assert estimator_state["scoring"] == "accuracy"
-    assert estimator_state["population_size"] == 4
-    assert estimator_state["generations"] == 2
-    assert list(estimator_state["param_grid"].keys()) == ["max_depth"]
+    assert estimator_state["population_size"] == estimator.population_size
+    assert estimator_state["generations"] == estimator.generations
+    assert list(estimator_state["param_grid"].keys()) == ["max_depth", "min_samples_split"]
     assert estimator_state["param_grid"]["max_depth"].lower == 1
     assert estimator_state["param_grid"]["max_depth"].upper == 2
-    assert estimator_state["algorithm"] == "eaSimple"
+    assert estimator_state["algorithm"] == estimator.algorithm
+
+
+@pytest.mark.parametrize(
+    "estimator",
+    [
+        GASearchCV(
+            estimator=DecisionTreeClassifier(),
+            param_grid={"max_depth": Integer(1, 3), "min_samples_split": Integer(2, 5)},
+        ),
+        GAFeatureSelectionCV(estimator=DecisionTreeClassifier()),
+    ],
+    ids=["GASearchCV", "GAFeatureSelectionCV"],
+)
+def test_checkpoint_state_honors_serialization_contract(estimator):
+    """#297: the checkpoint state is a constructor-compatible subset of save/load.
+
+    Every key ModelCheckpoint persists must be an ``__init__`` parameter (so the
+    checkpoint replays as ``ClassName(**state)``) and must also live in the full
+    ``_serializable_state()`` used by save/load, so the two serialization paths
+    cannot silently drift apart.
+    """
+    checkpoint = estimator._checkpoint_state()
+    full = estimator._serializable_state()
+    params = estimator.get_params(deep=False)
+
+    # Constructor-compatible: every checkpoint key is an __init__ parameter...
+    assert set(checkpoint).issubset(params), set(checkpoint) - set(params)
+    # ...and the checkpoint actually replays through the constructor.
+    type(estimator)(**checkpoint)
+
+    # Consistent with save/load: the checkpoint is a subset of the full state.
+    assert set(checkpoint).issubset(full), set(checkpoint) - set(full)
 
 
 def test_model_checkpoint_supports_feature_selection_estimator(tmp_path, capsys):


### PR DESCRIPTION
Closes #297 — the follow-up you flagged when reopening after #313.

## What this does
Defines and validates the contract between the two serialization paths, in one place.

Before, they lived apart and were only related by convention:
- `save`/`load` use `GeneticEstimatorMixin._serializable_state()` (full snapshot, restored via `setattr`).
- `ModelCheckpoint` hand-built a separate constructor-compatible `estimator_state`.

Now:
- `_checkpoint_state()` moves onto `GeneticEstimatorMixin`, right next to `_serializable_state()` and `save`/`load`, so both serialization shapes live in `_base.py`.
- `ModelCheckpoint.on_step` just calls `estimator._checkpoint_state()` (the ~48 lines of key lists / builder leave the callback).

## The contract, validated
`test_checkpoint_state_honors_serialization_contract` runs for **both** `GASearchCV` and `GAFeatureSelectionCV` and asserts:
1. every checkpoint key is an `__init__` parameter (`⊆ get_params()`), and the checkpoint actually replays through `ClassName(**state)`;
2. the checkpoint is a subset of `_serializable_state()`.

So the two paths can't silently drift apart anymore — if someone adds a checkpoint key that isn't a constructor param, or that save/load doesn't carry, the test fails.

## Notes
- **Behavior unchanged** — same keys are persisted; this is a relocation + validation, not a format change. Existing checkpoint/resume and save/load tests still pass.
- The two `SimpleNamespace`-based callback tests now use real estimators, since state building lives on the estimator itself.
- I kept `estimator_state` an explicit, intentional subset rather than deriving it from all of `get_params()` — the full param set includes grouped-config objects (`evolution_config`, …) whose `__init__` re-resolves overlapping values, so a plain `Class(**all_params)` replay would be riskier. Happy to revisit if you'd prefer the derived approach.

Verified locally: `test_persistence_and_helpers.py` (14 passed) and the checkpoint/resume tests pass; `black --check` clean.

— Contributed by **Mayoka Labs**
