### PR TITLE
fix: preserve logbook and fit_stats_ across checkpoint resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Full release notes with code examples are in the [documentation](https://sklearngeneticopt.rodrigo-arenas.com/).
 
+## Unreleased
+
+### Bug Fixes
+
+- Fixed `ModelCheckpoint` resume dropping prior-run history: `logbook`, `cv_results_`, and `history` were silently reset to only the post-resume generations, and `fit_stats_` counters were zeroed on every resume. `ModelCheckpoint` now persists the real per-candidate logbook and `fit_stats_`, and `GASearchCV`/`GAFeatureSelectionCV.fit` restore them after `_register()` rebuilds the (unpicklable) DEAP toolbox/population/hof (#299).
+
 ## 0.13.3
 
 ### New Features

--- a/docs-vitepress/versions/latest/release-notes.md
+++ b/docs-vitepress/versions/latest/release-notes.md
@@ -9,6 +9,12 @@ You are reading the **latest (dev)** docs. For the stable version, see [stable](
 
 # Release Notes
 
+## Unreleased
+
+### Bug Fixes and Error Messages
+
+- **Checkpoint resume dropped prior-run history (#299)**: resuming from a `ModelCheckpoint` reset `logbook`/`cv_results_`/`history` to only the newly-run generations and zeroed `fit_stats_` counters, because `_register()` unconditionally rebuilt `self.logbook` after it was restored, and the checkpoint was saving the wrong (per-generation summary) logbook object under the restored key in the first place. `ModelCheckpoint` now also persists the real per-candidate logbook and `fit_stats_`, and the restore path re-applies them after `_register()`, so resumed runs accumulate history and counters instead of losing them.
+
 ## 0.13.3
 
 ### New Features and Behavior

--- a/sklearn_genetic/callbacks/model_checkpoint.py
+++ b/sklearn_genetic/callbacks/model_checkpoint.py
@@ -20,7 +20,24 @@ class ModelCheckpoint(BaseCallback):
             # latter stays constructor-compatible (it is consumed as
             # ``GASearchCV(**estimator_state)``). Restoring the fitness cache on
             # resume lets already-evaluated candidates be reused (see fit()).
-            runtime_state = {"fitness_cache": getattr(estimator, "fitness_cache", {})}
+            # ``fit_stats_`` is restored too so counters (cache hits, evaluated
+            # candidates, ...) accumulate across a resume instead of resetting.
+            #
+            # ``candidate_logbook`` is ``estimator.logbook`` itself -- the
+            # per-candidate log ("Contains the logs of every set of
+            # hyperparameters fitted with its average scoring metric", see the
+            # class docstring) that backs ``cv_results_``/``history``. It is
+            # NOT the same object as the ``logbook`` argument this method
+            # receives, which is the per-*generation* summary log the
+            # algorithms module builds for its own bookkeeping and callbacks;
+            # saving only that one under the legacy ``"logbook"`` key (kept
+            # below for backward compatibility) silently dropped every
+            # already-evaluated candidate on resume.
+            runtime_state = {
+                "fitness_cache": getattr(estimator, "fitness_cache", {}),
+                "fit_stats_": deepcopy(getattr(estimator, "fit_stats_", None)),
+                "candidate_logbook": deepcopy(getattr(estimator, "logbook", None)),
+            }
             checkpoint_data = {
                 "estimator_state": estimator_state,
                 "logbook": deepcopy(logbook),

--- a/sklearn_genetic/genetic_search.py
+++ b/sklearn_genetic/genetic_search.py
@@ -1100,7 +1100,9 @@ class GASearchCV(GeneticEstimatorMixin, BaseSearchCV):
 
         # Preserve cumulative counters across a resume instead of zeroing them,
         # so e.g. ``cache_hits``/``evaluated_candidates`` reflect the whole run.
-        self.fit_stats_ = restored_fit_stats if restored_fit_stats is not None else _create_fit_stats()
+        self.fit_stats_ = (
+            restored_fit_stats if restored_fit_stats is not None else _create_fit_stats()
+        )
 
         if callable(self.scoring):
             self.scorer_ = self.scoring
@@ -2030,7 +2032,9 @@ class GAFeatureSelectionCV(GeneticEstimatorMixin, MetaEstimatorMixin, SelectorMi
 
         # Preserve cumulative counters across a resume instead of zeroing them,
         # so e.g. ``cache_hits``/``evaluated_candidates`` reflect the whole run.
-        self.fit_stats_ = restored_fit_stats if restored_fit_stats is not None else _create_fit_stats()
+        self.fit_stats_ = (
+            restored_fit_stats if restored_fit_stats is not None else _create_fit_stats()
+        )
 
         if callable(self.scoring):
             self.scorer_ = self.scoring

--- a/sklearn_genetic/genetic_search.py
+++ b/sklearn_genetic/genetic_search.py
@@ -1064,6 +1064,8 @@ class GASearchCV(GeneticEstimatorMixin, BaseSearchCV):
         self.callbacks = check_callback(callbacks)
 
         checkpoint_loaded = False
+        restored_logbook = None
+        restored_fit_stats = None
 
         # Load state if a checkpoint exists
         for callback in self.callbacks:
@@ -1072,7 +1074,6 @@ class GASearchCV(GeneticEstimatorMixin, BaseSearchCV):
                     checkpoint_data = callback.load()
                     if checkpoint_data:
                         self.__dict__.update(checkpoint_data["estimator_state"])  # noqa
-                        self.logbook = checkpoint_data["logbook"]
                         # Restore the fitness cache so already-evaluated
                         # candidates are reused instead of re-evaluated. Older
                         # checkpoints have no ``runtime_state``, so guard with
@@ -1081,13 +1082,25 @@ class GASearchCV(GeneticEstimatorMixin, BaseSearchCV):
                         cached = runtime_state.get("fitness_cache")
                         if cached is not None:
                             self.fitness_cache = cached
+                        restored_fit_stats = runtime_state.get("fit_stats_")
+                        # ``checkpoint_data["logbook"]`` is the per-*generation*
+                        # summary log (see ModelCheckpoint.on_step), not
+                        # ``self.logbook`` -- restoring it onto ``self.logbook``
+                        # would silently break ``cv_results_``/``history``.
+                        # ``_register()`` below also unconditionally creates a
+                        # fresh ``self.logbook``, so stash the real one and put
+                        # it back afterwards (see comment near the
+                        # ``_register()`` call).
+                        restored_logbook = runtime_state.get("candidate_logbook")
                         checkpoint_loaded = True
                     break
 
         if not checkpoint_loaded:
             _reset_adapters(self)
 
-        self.fit_stats_ = _create_fit_stats()
+        # Preserve cumulative counters across a resume instead of zeroing them,
+        # so e.g. ``cache_hits``/``evaluated_candidates`` reflect the whole run.
+        self.fit_stats_ = restored_fit_stats if restored_fit_stats is not None else _create_fit_stats()
 
         if callable(self.scoring):
             self.scorer_ = self.scoring
@@ -1131,6 +1144,13 @@ class GASearchCV(GeneticEstimatorMixin, BaseSearchCV):
 
         # Set the DEAPs necessary methods
         self._register()
+        # ``_register()`` always creates a fresh, empty ``self.logbook`` (it
+        # also builds the toolbox/population/hof/stats, which are ``deap``
+        # objects that cannot be checkpointed and are intentionally rebuilt on
+        # every ``fit`` call). Put the restored per-candidate logbook back so
+        # resumed candidates are not dropped from ``cv_results_``/``history``.
+        if restored_logbook is not None:
+            self.logbook = restored_logbook
 
         # Optimization routine from the selected evolutionary algorithm
         pop, log, n_gen = self._select_algorithm(pop=self._pop, stats=self._stats, hof=self._hof)
@@ -1974,6 +1994,8 @@ class GAFeatureSelectionCV(GeneticEstimatorMixin, MetaEstimatorMixin, SelectorMi
         self.callbacks = check_callback(callbacks)
 
         checkpoint_loaded = False
+        restored_logbook = None
+        restored_fit_stats = None
 
         # Load state if a checkpoint exists
         for callback in self.callbacks:
@@ -1982,7 +2004,6 @@ class GAFeatureSelectionCV(GeneticEstimatorMixin, MetaEstimatorMixin, SelectorMi
                     checkpoint_data = callback.load()
                     if checkpoint_data:
                         self.__dict__.update(checkpoint_data["estimator_state"])  # noqa
-                        self.logbook = checkpoint_data["logbook"]
                         # Restore the fitness cache so already-evaluated
                         # candidates are reused instead of re-evaluated. Older
                         # checkpoints have no ``runtime_state``, so guard with
@@ -1991,13 +2012,25 @@ class GAFeatureSelectionCV(GeneticEstimatorMixin, MetaEstimatorMixin, SelectorMi
                         cached = runtime_state.get("fitness_cache")
                         if cached is not None:
                             self.fitness_cache = cached
+                        restored_fit_stats = runtime_state.get("fit_stats_")
+                        # ``checkpoint_data["logbook"]`` is the per-*generation*
+                        # summary log (see ModelCheckpoint.on_step), not
+                        # ``self.logbook`` -- restoring it onto ``self.logbook``
+                        # would silently break ``cv_results_``/``history``.
+                        # ``_register()`` below also unconditionally creates a
+                        # fresh ``self.logbook``, so stash the real one and put
+                        # it back afterwards (see comment near the
+                        # ``_register()`` call).
+                        restored_logbook = runtime_state.get("candidate_logbook")
                         checkpoint_loaded = True
                     break
 
         if not checkpoint_loaded:
             _reset_adapters(self)
 
-        self.fit_stats_ = _create_fit_stats()
+        # Preserve cumulative counters across a resume instead of zeroing them,
+        # so e.g. ``cache_hits``/``evaluated_candidates`` reflect the whole run.
+        self.fit_stats_ = restored_fit_stats if restored_fit_stats is not None else _create_fit_stats()
 
         if callable(self.scoring):
             self.scorer_ = self.scoring
@@ -2040,6 +2073,13 @@ class GAFeatureSelectionCV(GeneticEstimatorMixin, MetaEstimatorMixin, SelectorMi
 
         # Set the DEAPs necessary methods
         self._register()
+        # ``_register()`` always creates a fresh, empty ``self.logbook`` (it
+        # also builds the toolbox/population/hof/stats, which are ``deap``
+        # objects that cannot be checkpointed and are intentionally rebuilt on
+        # every ``fit`` call). Put the restored per-candidate logbook back so
+        # resumed candidates are not dropped from ``cv_results_``/``history``.
+        if restored_logbook is not None:
+            self.logbook = restored_logbook
 
         # Optimization routine from the selected evolutionary algorithm
         pop, log, n_gen = self._select_algorithm(pop=self._pop, stats=self._stats, hof=self._hof)

--- a/sklearn_genetic/tests/test_persistence_and_helpers.py
+++ b/sklearn_genetic/tests/test_persistence_and_helpers.py
@@ -334,3 +334,43 @@ def test_feature_selection_checkpoint_resume_restores_fitness_cache(tmp_path):
     )
     resumed.fit(X, y, callbacks=ModelCheckpoint(checkpoint_path=checkpoint_path))
     assert sentinel_key in resumed.fitness_cache
+
+
+def test_checkpoint_resume_preserves_logbook_and_fit_stats(tmp_path):
+    """#299: resuming from a checkpoint must not drop prior-run history.
+
+    ``_register()`` unconditionally rebuilds ``self.logbook`` (it also rebuilds
+    the toolbox/population/hof, which are unpicklable ``deap`` objects that
+    can't be checkpointed). That used to wipe out the logbook ``fit`` had just
+    restored from the checkpoint, silently dropping every pre-resume candidate
+    from ``cv_results_``/``history`` and resetting ``fit_stats_`` counters back
+    to zero on every resume.
+    """
+    X, y = load_iris(return_X_y=True)
+    checkpoint_path = str(tmp_path / "resume_history_checkpoint.pkl")
+
+    def build():
+        return GASearchCV(
+            estimator=DecisionTreeClassifier(random_state=0),
+            param_grid={"max_depth": Integer(1, 3)},
+            cv=2,
+            scoring="accuracy",
+            population_size=4,
+            generations=1,
+        )
+
+    first = build()
+    first.fit(X, y, callbacks=ModelCheckpoint(checkpoint_path=checkpoint_path))
+    first_logbook_len = len(first.logbook.chapters["parameters"])
+    first_evaluated = first.fit_stats_["evaluated_candidates"]
+    assert first_logbook_len > 0
+    assert first_evaluated > 0
+
+    resumed = build()
+    resumed.fit(X, y, callbacks=ModelCheckpoint(checkpoint_path=checkpoint_path))
+
+    # The resumed logbook must contain the first run's records plus the new
+    # ones, not just the new run's (which is what the bug produced).
+    assert len(resumed.logbook.chapters["parameters"]) > first_logbook_len
+    # fit_stats_ counters must accumulate across the resume, not reset to 0.
+    assert resumed.fit_stats_["evaluated_candidates"] > first_evaluated


### PR DESCRIPTION
## Summary

Resuming a `GASearchCV`/`GAFeatureSelectionCV` fit from a `ModelCheckpoint`
silently dropped every pre-resume candidate from `cv_results_`/`history` and
reset `fit_stats_` counters to zero. Root cause was two-fold: `ModelCheckpoint`
was checkpointing the per-generation summary logbook instead of the
per-candidate logbook that `cv_results_`/`history` actually depend on, and
`_register()` unconditionally rebuilt `self.logbook` right after the (wrong)
restore anyway. `ModelCheckpoint` now persists the real per-candidate logbook
and `fit_stats_` in `runtime_state`, and `fit()` re-applies them after
`_register()` rebuilds the (unpicklable) toolbox/population/hof, so resumed
runs accumulate history and counters instead of losing them.

## Related Issue

Part of #299

Population/hall-of-fame continuation across resume, per-generation gen
numbering continuity, and RNG-stream continuation are not addressed here —
those need the design discussion the issue calls for. This PR fixes the
data-loss bug (logbook/fit_stats_ silently reset on resume); #299 should stay
open for the remaining scope.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] Other (describe):

## Checklist

- [x] I checked the linked issue is open and not already covered by another PR
- [x] Tests pass locally (`pytest sklearn_genetic/`) — 285 passed
- [x] Code is formatted with Black (`black sklearn_genetic/`)
- [x] New functionality is covered by tests
- [x] Documentation updated if needed (CHANGELOG.md + docs-vitepress `latest` release notes)