### PR TITLE
fix: continue generation numbering across checkpoint resume

### DIFF
--- a/sklearn_genetic/_base.py
+++ b/sklearn_genetic/_base.py
@@ -122,6 +122,7 @@ class GeneticEstimatorMixin:
                 callbacks=self.callbacks,
                 verbose=self.verbose,
                 estimator=self,
+                resume_log=getattr(self, "_resume_generation_log", None),
             )
         else:
             raise ValueError(

--- a/sklearn_genetic/algorithms.py
+++ b/sklearn_genetic/algorithms.py
@@ -94,7 +94,7 @@ def _verbose_events(record):
     return ",".join(events) if events else "-"
 
 
-def _print_verbose_record(gen, nevals, record):
+def _print_verbose_record(gen, nevals, record, print_header=False):
     display_record = {
         "gen": gen,
         "nevals": nevals,
@@ -102,7 +102,7 @@ def _print_verbose_record(gen, nevals, record):
         **record,
     }
 
-    if gen == 0:
+    if print_header:
         header = " ".join(label.rjust(width) for _, label, width, _ in VERBOSE_COLUMNS)
         separator = " ".join("-" * width for _, _, width, _ in VERBOSE_COLUMNS)
         print(header)
@@ -287,6 +287,24 @@ def _refresh_last_record_after_local_refinement(
     )
 
 
+def _seed_logbook(resume_log, stats):
+    """Continue generation numbering across a checkpoint resume (see #299).
+
+    Without this, every resumed run restarts its local ``gen`` counter at 0,
+    so the logbook/history end up with duplicate generation indices (e.g.
+    ``0..N`` from the first run followed by another ``0..M`` after resume)
+    instead of a single, monotonically increasing sequence.
+    """
+    if resume_log is not None and len(resume_log) > 0:
+        logbook = resume_log
+        gen_offset = max(logbook.select("gen")) + 1
+    else:
+        logbook = tools.Logbook()
+        gen_offset = 0
+    logbook.header = ["gen", "nevals"] + (stats.fields if stats else []) + TELEMETRY_FIELDS
+    return logbook, gen_offset
+
+
 def _new_telemetry_state():
     return {
         "best_fitness": None,
@@ -361,6 +379,7 @@ def eaSimple(
     callbacks=None,
     verbose=True,
     estimator=None,
+    resume_log=None,
     **kwargs,
 ):
     """
@@ -423,8 +442,7 @@ def eaSimple(
     eval_callbacks(**callbacks_start_args)
 
     telemetry_state = _new_telemetry_state()
-    logbook = tools.Logbook()
-    logbook.header = ["gen", "nevals"] + (stats.fields if stats else []) + TELEMETRY_FIELDS
+    logbook, gen_offset = _seed_logbook(resume_log, stats)
 
     # Evaluate the individuals with an invalid fitness
     invalid_ind = [ind for ind in population if not ind.fitness.valid]
@@ -438,10 +456,10 @@ def eaSimple(
 
     n_gen = gen = 0
     record = _compile_generation_record(stats, population, telemetry_state, gen)
-    logbook.record(gen=n_gen, nevals=len(invalid_ind), **record)
+    logbook.record(gen=n_gen + gen_offset, nevals=len(invalid_ind), **record)
 
     if verbose:
-        _print_verbose_record(n_gen, len(invalid_ind), record)
+        _print_verbose_record(n_gen + gen_offset, len(invalid_ind), record, print_header=True)
 
     # Check if any of the callbacks conditions are True to stop the iteration
 
@@ -465,7 +483,7 @@ def eaSimple(
         # Call ending callback
         eval_callbacks(**callbacks_end_args)
         print("INFO: Stopping the algorithm")
-        return population, logbook, n_gen
+        return population, logbook, n_gen + gen_offset
 
     for gen in range(1, ngen + 1):
         try:
@@ -519,10 +537,10 @@ def eaSimple(
                     sharing_record,
                 ),
             )
-            logbook.record(gen=gen, nevals=len(invalid_ind), **record)
+            logbook.record(gen=gen + gen_offset, nevals=len(invalid_ind), **record)
 
             if verbose:
-                _print_verbose_record(gen, len(invalid_ind), record)
+                _print_verbose_record(gen + gen_offset, len(invalid_ind), record)
 
             callbacks_step_args = {
                 "callbacks": callbacks,
@@ -543,7 +561,7 @@ def eaSimple(
         except (KeyboardInterrupt, SystemExit, StopIteration) as e:
             stored_exception = e
 
-    n_gen = gen + 1
+    n_gen = gen + 1 + gen_offset
     local_refinements = _run_local_refinement(population, toolbox, halloffame, estimator)
     _refresh_last_record_after_local_refinement(
         logbook, stats, population, telemetry_state, local_refinements
@@ -576,6 +594,7 @@ def eaMuPlusLambda(
     callbacks=None,
     verbose=True,
     estimator=None,
+    resume_log=None,
     **kwargs,
 ):
     r"""
@@ -642,8 +661,7 @@ def eaMuPlusLambda(
     eval_callbacks(**callbacks_start_args)
 
     telemetry_state = _new_telemetry_state()
-    logbook = tools.Logbook()
-    logbook.header = ["gen", "nevals"] + (stats.fields if stats else []) + TELEMETRY_FIELDS
+    logbook, gen_offset = _seed_logbook(resume_log, stats)
 
     # Evaluate the individuals with an invalid fitness
     invalid_ind = [ind for ind in population if not ind.fitness.valid]
@@ -656,10 +674,10 @@ def eaMuPlusLambda(
 
     n_gen = gen = 0
     record = _compile_generation_record(stats, population, telemetry_state, gen)
-    logbook.record(gen=n_gen, nevals=len(invalid_ind), **record)
+    logbook.record(gen=n_gen + gen_offset, nevals=len(invalid_ind), **record)
 
     if verbose:
-        _print_verbose_record(n_gen, len(invalid_ind), record)
+        _print_verbose_record(n_gen + gen_offset, len(invalid_ind), record, print_header=True)
 
     # Check if any of the callbacks conditions are True to stop the iteration
     callbacks_step_args = {
@@ -682,7 +700,7 @@ def eaMuPlusLambda(
 
         eval_callbacks(**callbacks_end_args)
         print("INFO: Stopping the algorithm")
-        return population, logbook, n_gen
+        return population, logbook, n_gen + gen_offset
 
     for gen in range(1, ngen + 1):
         try:
@@ -732,10 +750,10 @@ def eaMuPlusLambda(
                     sharing_record,
                 ),
             )
-            logbook.record(gen=gen, nevals=len(invalid_ind), **record)
+            logbook.record(gen=gen + gen_offset, nevals=len(invalid_ind), **record)
 
             if verbose:
-                _print_verbose_record(gen, len(invalid_ind), record)
+                _print_verbose_record(gen + gen_offset, len(invalid_ind), record)
 
             callbacks_step_args = {
                 "callbacks": callbacks,
@@ -756,7 +774,7 @@ def eaMuPlusLambda(
         except (KeyboardInterrupt, SystemExit, StopIteration) as e:
             stored_exception = e
 
-    n_gen = gen + 1
+    n_gen = gen + 1 + gen_offset
     local_refinements = _run_local_refinement(population, toolbox, halloffame, estimator)
     _refresh_last_record_after_local_refinement(
         logbook, stats, population, telemetry_state, local_refinements
@@ -788,6 +806,7 @@ def eaMuCommaLambda(
     callbacks=None,
     verbose=True,
     estimator=None,
+    resume_log=None,
     **kwargs,
 ):
     r"""
@@ -867,15 +886,14 @@ def eaMuCommaLambda(
         halloffame.update(population)
 
     telemetry_state = _new_telemetry_state()
-    logbook = tools.Logbook()
-    logbook.header = ["gen", "nevals"] + (stats.fields if stats else []) + TELEMETRY_FIELDS
+    logbook, gen_offset = _seed_logbook(resume_log, stats)
 
     n_gen = gen = 0
     record = _compile_generation_record(stats, population, telemetry_state, gen)
-    logbook.record(gen=n_gen, nevals=len(invalid_ind), **record)
+    logbook.record(gen=n_gen + gen_offset, nevals=len(invalid_ind), **record)
 
     if verbose:
-        _print_verbose_record(n_gen, len(invalid_ind), record)
+        _print_verbose_record(n_gen + gen_offset, len(invalid_ind), record, print_header=True)
 
     callbacks_step_args = {
         "callbacks": callbacks,
@@ -897,7 +915,7 @@ def eaMuCommaLambda(
 
         eval_callbacks(**callbacks_end_args)
         print("INFO: Stopping the algorithm")
-        return population, logbook, n_gen
+        return population, logbook, n_gen + gen_offset
 
     for gen in range(1, ngen + 1):
         try:
@@ -946,10 +964,10 @@ def eaMuCommaLambda(
                     sharing_record,
                 ),
             )
-            logbook.record(gen=gen, nevals=len(invalid_ind), **record)
+            logbook.record(gen=gen + gen_offset, nevals=len(invalid_ind), **record)
 
             if verbose:
-                _print_verbose_record(gen, len(invalid_ind), record)
+                _print_verbose_record(gen + gen_offset, len(invalid_ind), record)
 
             callbacks_step_args = {
                 "callbacks": callbacks,
@@ -971,7 +989,7 @@ def eaMuCommaLambda(
         except (KeyboardInterrupt, SystemExit, StopIteration) as e:
             stored_exception = e
 
-    n_gen = gen + 1
+    n_gen = gen + 1 + gen_offset
     local_refinements = _run_local_refinement(population, toolbox, halloffame, estimator)
     _refresh_last_record_after_local_refinement(
         logbook, stats, population, telemetry_state, local_refinements

--- a/sklearn_genetic/genetic_search.py
+++ b/sklearn_genetic/genetic_search.py
@@ -1066,6 +1066,7 @@ class GASearchCV(GeneticEstimatorMixin, BaseSearchCV):
         checkpoint_loaded = False
         restored_logbook = None
         restored_fit_stats = None
+        restored_generation_log = None
 
         # Load state if a checkpoint exists
         for callback in self.callbacks:
@@ -1092,6 +1093,11 @@ class GASearchCV(GeneticEstimatorMixin, BaseSearchCV):
                         # it back afterwards (see comment near the
                         # ``_register()`` call).
                         restored_logbook = runtime_state.get("candidate_logbook")
+                        # The per-generation summary log saved under the
+                        # legacy ``"logbook"`` key is exactly what generation
+                        # numbering needs to continue from -- see
+                        # ``_seed_logbook`` in ``algorithms.py``.
+                        restored_generation_log = checkpoint_data.get("logbook")
                         checkpoint_loaded = True
                     break
 
@@ -1103,6 +1109,7 @@ class GASearchCV(GeneticEstimatorMixin, BaseSearchCV):
         self.fit_stats_ = (
             restored_fit_stats if restored_fit_stats is not None else _create_fit_stats()
         )
+        self._resume_generation_log = restored_generation_log
 
         if callable(self.scoring):
             self.scorer_ = self.scoring
@@ -1998,6 +2005,7 @@ class GAFeatureSelectionCV(GeneticEstimatorMixin, MetaEstimatorMixin, SelectorMi
         checkpoint_loaded = False
         restored_logbook = None
         restored_fit_stats = None
+        restored_generation_log = None
 
         # Load state if a checkpoint exists
         for callback in self.callbacks:
@@ -2024,6 +2032,11 @@ class GAFeatureSelectionCV(GeneticEstimatorMixin, MetaEstimatorMixin, SelectorMi
                         # it back afterwards (see comment near the
                         # ``_register()`` call).
                         restored_logbook = runtime_state.get("candidate_logbook")
+                        # The per-generation summary log saved under the
+                        # legacy ``"logbook"`` key is exactly what generation
+                        # numbering needs to continue from -- see
+                        # ``_seed_logbook`` in ``algorithms.py``.
+                        restored_generation_log = checkpoint_data.get("logbook")
                         checkpoint_loaded = True
                     break
 
@@ -2035,6 +2048,7 @@ class GAFeatureSelectionCV(GeneticEstimatorMixin, MetaEstimatorMixin, SelectorMi
         self.fit_stats_ = (
             restored_fit_stats if restored_fit_stats is not None else _create_fit_stats()
         )
+        self._resume_generation_log = restored_generation_log
 
         if callable(self.scoring):
             self.scorer_ = self.scoring

--- a/sklearn_genetic/tests/test_persistence_and_helpers.py
+++ b/sklearn_genetic/tests/test_persistence_and_helpers.py
@@ -374,3 +374,41 @@ def test_checkpoint_resume_preserves_logbook_and_fit_stats(tmp_path):
     assert len(resumed.logbook.chapters["parameters"]) > first_logbook_len
     # fit_stats_ counters must accumulate across the resume, not reset to 0.
     assert resumed.fit_stats_["evaluated_candidates"] > first_evaluated
+
+
+def test_checkpoint_resume_continues_generation_numbering(tmp_path):
+    """#299: resumed generations must continue, not restart, the gen count.
+
+    Every algorithm variant (``eaSimple``, ``eaMuPlusLambda``,
+    ``eaMuCommaLambda``) restarted its local ``gen`` counter at 0 on every
+    ``fit`` call, so a resumed run's ``history``/``logbook`` used to show
+    duplicate generation indices (e.g. ``0, 1`` from the first run followed by
+    another ``0, 1`` after resume) instead of one increasing sequence.
+    """
+    X, y = load_iris(return_X_y=True)
+    checkpoint_path = str(tmp_path / "resume_gen_checkpoint.pkl")
+
+    def build():
+        return GASearchCV(
+            estimator=DecisionTreeClassifier(random_state=0),
+            param_grid={"max_depth": Integer(1, 3)},
+            cv=2,
+            scoring="accuracy",
+            population_size=4,
+            generations=1,
+        )
+
+    first = build()
+    first.fit(X, y, callbacks=ModelCheckpoint(checkpoint_path=checkpoint_path))
+    first_gens = list(first.history["gen"])
+
+    resumed = build()
+    resumed.fit(X, y, callbacks=ModelCheckpoint(checkpoint_path=checkpoint_path))
+    resumed_gens = list(resumed.history["gen"])
+
+    # First run's generation indices are preserved verbatim at the front...
+    assert resumed_gens[: len(first_gens)] == first_gens
+    # ...the new generations continue strictly upward from there...
+    assert resumed_gens[len(first_gens) :] == [g + max(first_gens) + 1 for g in first_gens]
+    # ...so no generation index repeats.
+    assert len(resumed_gens) == len(set(resumed_gens))


### PR DESCRIPTION
## Summary

Every algorithm variant (`eaSimple`, `eaMuPlusLambda`, `eaMuCommaLambda`)
restarted its local `gen` counter at 0 on every `fit()` call, so a resumed
run's `logbook`/`history` showed duplicate generation indices (e.g. `0, 1`
from the first run followed by another `0, 1` after resume) instead of one
continuous, increasing sequence. Adds `_seed_logbook()`, which reuses the
checkpointed per-generation log and offsets new generation numbers past its
last recorded value, threaded through `GASearchCV`/`GAFeatureSelectionCV.fit`
via a new `resume_log` parameter on each algorithm function.

## Related Issue

Part of #299 (follow-up to the logbook/fit_stats_ fix in #330)

Population/hall-of-fame continuation across resume and RNG-stream
continuation are still not addressed, population/hof restart fresh each
resume (only the fitness cache and logbook carry over), and the RNG reseeds
from `random_state` rather than continuing the stream. Those need the design
discussion the issue calls for; #299 should stay open for that remaining
scope.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] Other (describe):

## Checklist

- [x] I checked the linked issue is open and not already covered by another PR
- [x] Tests pass locally (`pytest sklearn_genetic/`) — 286 passed
- [x] Code is formatted with Black (`black sklearn_genetic/`)
- [x] New functionality is covered by tests
- [x] Documentation updated if needed