### PR TITLE
Preserve and correctly apply random_state across checkpoint resume

### DIFF
--- a/sklearn_genetic/_base.py
+++ b/sklearn_genetic/_base.py
@@ -41,6 +41,7 @@ class GeneticEstimatorMixin:
         "crossover_probability",
         "mutation_probability",
         "algorithm",
+        "random_state",
     )
     _checkpoint_optional_defaults = {
         "local_search": False,

--- a/sklearn_genetic/genetic_search.py
+++ b/sklearn_genetic/genetic_search.py
@@ -1047,8 +1047,6 @@ class GASearchCV(GeneticEstimatorMixin, BaseSearchCV):
             The callback is evaluated after fitting the estimators from the generation 1.
         """
 
-        _seed_global_rngs(self.random_state)
-
         self.X_ = X
         self.y_ = y
         self._n_iterations = self.generations + 1
@@ -1100,6 +1098,12 @@ class GASearchCV(GeneticEstimatorMixin, BaseSearchCV):
                         restored_generation_log = checkpoint_data.get("logbook")
                         checkpoint_loaded = True
                     break
+
+        # Seed after the checkpoint (if any) is loaded: ``self.__dict__.update()``
+        # above may have just replaced ``self.random_state`` with the value from
+        # a resumed run's checkpoint, and seeding before that point would use the
+        # pre-resume value instead (see #299).
+        _seed_global_rngs(self.random_state)
 
         if not checkpoint_loaded:
             _reset_adapters(self)
@@ -1980,8 +1984,6 @@ class GAFeatureSelectionCV(GeneticEstimatorMixin, MetaEstimatorMixin, SelectorMi
             The callback is evaluated after fitting the estimators from the generation 1.
         """
 
-        _seed_global_rngs(self.random_state)
-
         self.X_, self.y_ = check_X_y(X, y, accept_sparse=True) if y is not None else (X, None)
 
         # Handle outlier detection case if y is none
@@ -2039,6 +2041,12 @@ class GAFeatureSelectionCV(GeneticEstimatorMixin, MetaEstimatorMixin, SelectorMi
                         restored_generation_log = checkpoint_data.get("logbook")
                         checkpoint_loaded = True
                     break
+
+        # Seed after the checkpoint (if any) is loaded: ``self.__dict__.update()``
+        # above may have just replaced ``self.random_state`` with the value from
+        # a resumed run's checkpoint, and seeding before that point would use the
+        # pre-resume value instead (see #299).
+        _seed_global_rngs(self.random_state)
 
         if not checkpoint_loaded:
             _reset_adapters(self)

--- a/sklearn_genetic/tests/test_persistence_and_helpers.py
+++ b/sklearn_genetic/tests/test_persistence_and_helpers.py
@@ -1,3 +1,5 @@
+import shutil
+
 import pytest
 from sklearn.datasets import load_iris
 from sklearn.exceptions import NotFittedError
@@ -412,3 +414,58 @@ def test_checkpoint_resume_continues_generation_numbering(tmp_path):
     assert resumed_gens[len(first_gens) :] == [g + max(first_gens) + 1 for g in first_gens]
     # ...so no generation index repeats.
     assert len(resumed_gens) == len(set(resumed_gens))
+
+
+def test_checkpoint_resume_preserves_random_state(tmp_path):
+    """#299: random_state must survive checkpoint resume and actually seed it.
+
+    ``_checkpoint_core_keys`` did not include ``random_state``, so a resumed
+    estimator silently fell back to whatever its own constructor set (often
+    None) instead of the value the checkpointed run was built with. Restoring
+    the key alone is not enough either: seeding happened *before* the
+    checkpoint's ``estimator_state`` was applied to ``self``, so it used the
+    pre-resume value regardless. Both are exercised here: the restored
+    attribute, and that two independent resumes from the same checkpoint (each
+    built without a random_state of their own) produce identical results --
+    the only source of determinism available to them is the seed restored
+    from the checkpoint.
+    """
+    X, y = load_iris(return_X_y=True)
+    base_checkpoint = tmp_path / "base_checkpoint.pkl"
+
+    # A wide, two-parameter grid sampled by a tiny population: different random
+    # trajectories are overwhelmingly likely to evaluate different candidates
+    # and land on different fitness values, so this is sensitive to exactly the
+    # kind of divergence an unseeded (or wrongly-seeded) resume would produce.
+    def build(random_state=None):
+        return GASearchCV(
+            estimator=DecisionTreeClassifier(random_state=0),
+            param_grid={
+                "max_depth": Integer(1, 50),
+                "min_samples_split": Integer(2, 50),
+            },
+            cv=2,
+            scoring="accuracy",
+            population_size=4,
+            generations=1,
+            random_state=random_state,
+        )
+
+    first = build(random_state=42)
+    first.fit(X, y, callbacks=ModelCheckpoint(checkpoint_path=str(base_checkpoint)))
+
+    def resume_from_base(name):
+        checkpoint_path = tmp_path / f"resume_{name}.pkl"
+        shutil.copy(base_checkpoint, checkpoint_path)
+        resumed = build(random_state=None)
+        resumed.fit(X, y, callbacks=ModelCheckpoint(checkpoint_path=str(checkpoint_path)))
+        return resumed
+
+    resumed_a = resume_from_base("a")
+    resumed_b = resume_from_base("b")
+
+    assert resumed_a.random_state == 42
+    assert resumed_b.random_state == 42
+    assert resumed_a.best_params_ == resumed_b.best_params_
+    assert resumed_a.best_score_ == resumed_b.best_score_
+    assert list(resumed_a.history["fitness"]) == list(resumed_b.history["fitness"])


### PR DESCRIPTION
Part of #299

_checkpoint_core_keys did not include random_state, so a resumed
GASearchCV/GAFeatureSelectionCV silently fell back to whatever the
resuming instance's own constructor set (often None) instead of the
value the checkpointed run was built with.

Restoring the key alone was not sufficient either: _seed_global_rngs()
ran before the checkpoint's estimator_state was applied via
self.__dict__.update(), so it always seeded with the pre-resume
random_state regardless. Moved the seed call to after checkpoint
loading in both fit() methods.

Added a regression test that resumes twice from the same checkpoint
(with the resuming instances built without their own random_state) and
verifies identical results -- the only source of determinism available
to them is the seed restored from the checkpoint. Verified the test
fails without either half of the fix, and passes with both.

Ran black --check and the full suite locally: 374 passed, 4 skipped.