### PR TITLE
Fix Categorical.sample() returning numpy scalar types when seeded

### DIFF
--- a/sklearn_genetic/space/space.py
+++ b/sklearn_genetic/space/space.py
@@ -192,9 +192,6 @@ class Categorical(BaseDimension):
             np.random.default_rng(self.random_state) if self.random_state is not None else None
         )
 
-        if self.distribution == CategoricalDistributions.choice.value:
-            self.rvs = self.rng.choice if self.rng else random.choice
-
     def __repr__(self) -> str:
         if self.priors is None:
             return f"{self.__class__.__name__}(choices={self.choices!r})"
@@ -204,11 +201,17 @@ class Categorical(BaseDimension):
     def sample(self) -> Any:
         """Sample a random value from the assigned distribution"""
 
-        if self.priors is None:
-            return self.rvs(self.choices)
+        n_choices = len(self.choices)
         if self.rng is not None:
-            return self.rvs(self.choices, p=self.priors)
-        return random.choices(self.choices, weights=self.priors, k=1)[0]
+            index = self.rng.choice(n_choices, p=self.priors)
+        elif self.priors is None:
+            index = random.randrange(n_choices)
+        else:
+            index = random.choices(range(n_choices), weights=self.priors, k=1)[0]
+        # Index into the original list so the exact Python object (and its
+        # type) is returned, instead of a value numpy has coerced to one of
+        # its own scalar types (e.g. np.True_, np.int64) -- see #324.
+        return self.choices[int(index)]
 
 
 def check_space(param_grid: dict = None):

--- a/sklearn_genetic/space/tests/test_space.py
+++ b/sklearn_genetic/space/tests/test_space.py
@@ -180,6 +180,35 @@ def test_categorical_random_state_zero_uses_numpy_generator():
 
 
 @pytest.mark.parametrize(
+    "choices, priors, random_state",
+    [
+        ([True, False], None, None),
+        ([True, False], None, 1),
+        ([1, 2, 3], None, None),
+        ([1, 2, 3], None, 1),
+        (["a", "b", "c"], [0.5, 0.3, 0.2], None),
+        (["a", "b", "c"], [0.5, 0.3, 0.2], 1),
+    ],
+)
+def test_categorical_sample_returns_native_python_types(choices, priors, random_state):
+    """sample() must return the exact stored object, not a numpy scalar (#324).
+
+    A seeded Categorical previously sampled via ``self.rng.choice(self.choices, ...)``,
+    which numpy coerces to one of its own scalar types (e.g. ``np.True_``,
+    ``np.int64``) -- unlike the unseeded ``random``-module path, which returns the
+    original Python object untouched. The return type should not depend on
+    whether a seed was given.
+    """
+    dimension = Categorical(choices, priors=priors, random_state=random_state)
+    expected_type = type(choices[0])
+
+    for _ in range(20):
+        value = dimension.sample()
+        assert value in choices
+        assert type(value) is expected_type, f"expected {expected_type}, got {type(value)}"
+
+
+@pytest.mark.parametrize(
     "data_object, parameters",
     [
         (Integer, {"lower": 1, "upper": 1000}),


### PR DESCRIPTION
Fixes #324

A seeded Categorical sampled via self.rng.choice(self.choices, ...),
which numpy coerces to one of its own scalar types (np.True_, np.int64,
np.str_) instead of returning the original Python object -- unlike the
unseeded random-module path, which passed values through untouched. The
sampled value's type silently depended on whether random_state was set,
which is surprising for values that flow into best_params_ and get
passed to the estimator (e.g. 'x is True' checks).

sample() now always samples an index and looks it up in the original
choices list, so the exact stored Python object is returned regardless
of which RNG backend is used. This also let self.rvs be dropped, since
it's no longer needed by either backend.

Verified the new test fails on the previous implementation for every
seeded case (bool/int/str) and passes with the fix.

Ran black --check and the full suite locally: 379 passed, 4 skipped.