### PR TITLE
Benchmark cache behavior under candidate collisions

### DIFF
--- a/benchmarks/benchmark_fit.py
+++ b/benchmarks/benchmark_fit.py
@@ -7,6 +7,10 @@ Run from the repository root, for example:
     python benchmarks/benchmark_fit.py --parallel-backends auto cv --runs 3
     python benchmarks/benchmark_fit.py --label current --output-json benchmarks/current.json
     python benchmarks/benchmark_fit.py --compare-json benchmarks/baseline.json
+    python benchmarks/benchmark_fit.py --quick --scenarios classification_lr_collisions \
+        --estimators gasearch --n-jobs 1 --label cache_on --use-cache
+    python benchmarks/benchmark_fit.py --quick --scenarios classification_lr_collisions \
+        --estimators gasearch --n-jobs 1 --label cache_off --no-use-cache
 
 The benchmark intentionally lives outside the test suite. It measures wall time,
 candidate evaluation counters, serial/parallel strategies, and holdout model
@@ -152,6 +156,17 @@ SCENARIOS = {
         estimator_builder=logistic_pipeline,
         param_grid_builder=lambda: {
             "clf__C": Continuous(1e-4, 100.0, distribution="log-uniform"),
+            "clf__class_weight": Categorical([None, "balanced"]),
+        },
+    ),
+    "classification_lr_collisions": Scenario(
+        name="classification_lr_collisions",
+        task="classification",
+        scoring="roc_auc",
+        loader=classification_data,
+        estimator_builder=logistic_pipeline,
+        param_grid_builder=lambda: {
+            "clf__C": Integer(1, 2),
             "clf__class_weight": Categorical([None, "balanced"]),
         },
     ),
@@ -502,6 +517,7 @@ def run_one_benchmark(
     n_jobs: int | None,
     parallel_backend: str,
     population_initializer: str,
+    use_cache: bool,
     run_index: int,
 ) -> dict[str, Any]:
     counters = FitCounters()
@@ -523,6 +539,7 @@ def run_one_benchmark(
         "n_jobs": n_jobs,
         "parallel_backend": parallel_backend,
         "population_initializer": population_initializer,
+        "use_cache": use_cache,
         "fit_seconds": fit_seconds,
         **summarize_fit_mechanics(estimator, counters),
         **summarize_optimizer_telemetry(estimator),
@@ -552,7 +569,7 @@ def run_one_benchmark(
     return result
 
 
-def group_key(result: dict[str, Any]) -> tuple[str, str, str, str, str, str]:
+def group_key(result: dict[str, Any]) -> tuple[str, str, str, str, str, str, bool]:
     return (
         result["label"],
         result["scenario"],
@@ -560,11 +577,12 @@ def group_key(result: dict[str, Any]) -> tuple[str, str, str, str, str, str]:
         str(result["n_jobs"]),
         result["parallel_backend"],
         result["population_initializer"],
+        result["use_cache"],
     )
 
 
 def aggregate_results(results: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    grouped: dict[tuple[str, str, str, str, str, str], list[dict[str, Any]]] = {}
+    grouped: dict[tuple[str, str, str, str, str, str, bool], list[dict[str, Any]]] = {}
     for result in results:
         grouped.setdefault(group_key(result), []).append(result)
 
@@ -580,6 +598,7 @@ def aggregate_results(results: list[dict[str, Any]]) -> list[dict[str, Any]]:
         n_jobs,
         parallel_backend,
         population_initializer,
+        use_cache,
     ), items in grouped.items():
         metric_names = sorted(
             {metric_name for item in items for metric_name in item["holdout_metrics"].keys()}
@@ -597,11 +616,16 @@ def aggregate_results(results: list[dict[str, Any]]) -> list[dict[str, Any]]:
             "n_jobs": n_jobs,
             "parallel_backend": parallel_backend,
             "population_initializer": population_initializer,
+            "use_cache": use_cache,
             "runs": len(items),
             "fit_seconds_mean": float(np.mean([item["fit_seconds"] for item in items])),
             "fit_seconds_std": float(np.std([item["fit_seconds"] for item in items])),
             "actual_cross_validate_calls_mean": float(
                 np.mean([item["actual_cross_validate_calls"] for item in items])
+            ),
+            "cache_hits_mean": float(np.mean([item["cache_hits"] for item in items])),
+            "duplicate_candidates_mean": float(
+                np.mean([item["duplicate_candidates"] for item in items])
             ),
             "duplicate_or_cache_reuses_mean": float(
                 np.mean([item["duplicate_or_cache_reuses"] for item in items])
@@ -679,9 +703,12 @@ def print_summary_table(summaries: list[dict[str, Any]]) -> None:
         "n_jobs",
         "parallel_backend",
         "population_initializer",
+        "use_cache",
         "runs",
         "fit_seconds_mean",
         "actual_cross_validate_calls_mean",
+        "cache_hits_mean",
+        "duplicate_candidates_mean",
         "duplicate_or_cache_reuses_mean",
         "skipped_invalid_candidates_mean",
         "generations_ran_mean",
@@ -745,6 +772,8 @@ def print_comparison_table(current: list[dict[str, Any]], baseline: list[dict[st
         "n_jobs",
         "parallel_backend",
         "population_initializer",
+        "current_use_cache",
+        "baseline_use_cache",
         "fit_seconds_delta",
         "fit_seconds_ratio",
         "accuracy_delta",
@@ -762,6 +791,8 @@ def print_comparison_table(current: list[dict[str, Any]], baseline: list[dict[st
             "n_jobs": summary["n_jobs"],
             "parallel_backend": summary["parallel_backend"],
             "population_initializer": summary["population_initializer"],
+            "current_use_cache": summary.get("use_cache", True),
+            "baseline_use_cache": base.get("use_cache", True),
             "fit_seconds_delta": summary["fit_seconds_mean"] - base["fit_seconds_mean"],
             "fit_seconds_ratio": summary["fit_seconds_mean"] / base["fit_seconds_mean"],
         }
@@ -942,6 +973,7 @@ def main() -> None:
                                     n_jobs=n_jobs,
                                     parallel_backend=parallel_backend,
                                     population_initializer=population_initializer,
+                                    use_cache=args.use_cache,
                                     run_index=run_index,
                                 )
                             )
@@ -971,6 +1003,7 @@ def main() -> None:
                                     n_jobs=n_jobs,
                                     parallel_backend=parallel_backend,
                                     population_initializer=population_initializer,
+                                    use_cache=args.use_cache,
                                     run_index=run_index,
                                 )
                             )

--- a/benchmarks/benchmark_fit.py
+++ b/benchmarks/benchmark_fit.py
@@ -754,13 +754,28 @@ def comparison_key(summary: dict[str, Any]) -> tuple[str, str, str, str, str]:
     )
 
 
+def cache_aware_comparison_key(
+    summary: dict[str, Any],
+) -> tuple[tuple[str, str, str, str, str], bool]:
+    return comparison_key(summary), summary["use_cache"]
+
+
 def print_comparison_table(current: list[dict[str, Any]], baseline: list[dict[str, Any]]) -> None:
-    baseline_by_key = {comparison_key(summary): summary for summary in baseline}
-    comparable = [
-        (summary, baseline_by_key[comparison_key(summary)])
-        for summary in current
-        if comparison_key(summary) in baseline_by_key
-    ]
+    baseline_by_cache_key = {
+        cache_aware_comparison_key(summary): summary
+        for summary in baseline
+        if "use_cache" in summary
+    }
+    legacy_baseline_by_key = {
+        comparison_key(summary): summary for summary in baseline if "use_cache" not in summary
+    }
+    comparable = []
+    for summary in current:
+        base = baseline_by_cache_key.get(cache_aware_comparison_key(summary))
+        if base is None and summary["use_cache"]:
+            base = legacy_baseline_by_key.get(comparison_key(summary))
+        if base is not None:
+            comparable.append((summary, base))
 
     if not comparable:
         print("\nNo comparable baseline rows found.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ testpaths = ["sklearn_genetic"]
 omit = [
     "./tests/*",
     "./venv/*",
+    "./benchmarks/*",
     "./examples/*",
     "./demo/*",
     "*/tests/*",

--- a/sklearn_genetic/tests/test_benchmark_fit.py
+++ b/sklearn_genetic/tests/test_benchmark_fit.py
@@ -60,7 +60,27 @@ def test_aggregate_results_separates_cache_modes_and_reports_cache_counters():
     assert summaries_by_cache[False]["actual_cross_validate_calls_mean"] == 7
 
 
-def test_comparison_matches_across_cache_modes_and_supports_old_summaries(capsys):
+def test_comparison_matches_same_cache_mode_when_baseline_contains_both(capsys):
+    cache_on = aggregate_results(
+        [_benchmark_result(use_cache=True, cache_hits=3, duplicate_candidates=1, cv_calls=4)]
+    )[0]
+    cache_off = aggregate_results(
+        [_benchmark_result(use_cache=False, cache_hits=0, duplicate_candidates=4, cv_calls=7)]
+    )[0]
+
+    current_on = dict(cache_on, fit_seconds_mean=10.0)
+    current_off = dict(cache_off, fit_seconds_mean=10.0)
+    baseline_on = dict(cache_on, fit_seconds_mean=2.0)
+    baseline_off = dict(cache_off, fit_seconds_mean=5.0)
+
+    print_comparison_table([current_on, current_off], [baseline_on, baseline_off])
+
+    rows = capsys.readouterr().out.splitlines()
+    assert rows[-2].split("\t")[5:9] == ["True", "True", "8.0000", "5.0000"]
+    assert rows[-1].split("\t")[5:9] == ["False", "False", "5.0000", "2.0000"]
+
+
+def test_comparison_supports_old_summaries_without_cache_mode(capsys):
     cache_on = aggregate_results(
         [_benchmark_result(use_cache=True, cache_hits=3, duplicate_candidates=1, cv_calls=4)]
     )[0]
@@ -73,9 +93,11 @@ def test_comparison_matches_across_cache_modes_and_supports_old_summaries(capsys
     assert comparison_key(cache_on) == comparison_key(cache_off)
     assert comparison_key(cache_on) == comparison_key(old_baseline)
 
-    print_comparison_table([cache_on], [old_baseline])
+    print_comparison_table([cache_on, cache_off], [old_baseline])
 
     output = capsys.readouterr().out
     assert "current_use_cache" in output
     assert "baseline_use_cache" in output
-    assert "True" in output
+    rows = output.splitlines()
+    assert rows[-1].split("\t")[5:7] == ["True", "True"]
+    assert len(rows) == 5

--- a/sklearn_genetic/tests/test_benchmark_fit.py
+++ b/sklearn_genetic/tests/test_benchmark_fit.py
@@ -1,0 +1,81 @@
+from benchmarks.benchmark_fit import (
+    SCENARIOS,
+    aggregate_results,
+    comparison_key,
+    print_comparison_table,
+)
+from sklearn_genetic.space import Categorical, Integer
+
+
+def _benchmark_result(*, use_cache, cache_hits, duplicate_candidates, cv_calls):
+    return {
+        "label": "cache-comparison",
+        "scenario": "classification_lr_collisions",
+        "estimator": "GASearchCV",
+        "n_jobs": 1,
+        "parallel_backend": "auto",
+        "population_initializer": "smart",
+        "use_cache": use_cache,
+        "fit_seconds": 1.0,
+        "actual_cross_validate_calls": cv_calls,
+        "cache_hits": cache_hits,
+        "duplicate_candidates": duplicate_candidates,
+        "duplicate_or_cache_reuses": cache_hits + duplicate_candidates,
+        "skipped_invalid_candidates": 0,
+        "population_parallel_batches": 0,
+        "holdout_metrics": {"roc_auc": 0.9},
+        "train_metrics": {"roc_auc": 0.9},
+        "generalization_gap": {"roc_auc_gap": 0.0},
+    }
+
+
+def test_collision_scenario_has_four_discrete_candidates():
+    scenario = SCENARIOS["classification_lr_collisions"]
+    param_grid = scenario.param_grid_builder()
+
+    integer = param_grid["clf__C"]
+    categorical = param_grid["clf__class_weight"]
+
+    assert isinstance(integer, Integer)
+    assert integer.upper - integer.lower + 1 == 2
+    assert isinstance(categorical, Categorical)
+    assert len(categorical.choices) == 2
+
+
+def test_aggregate_results_separates_cache_modes_and_reports_cache_counters():
+    results = [
+        _benchmark_result(use_cache=True, cache_hits=3, duplicate_candidates=1, cv_calls=4),
+        _benchmark_result(use_cache=False, cache_hits=0, duplicate_candidates=4, cv_calls=7),
+    ]
+
+    summaries = aggregate_results(results)
+
+    assert len(summaries) == 2
+    summaries_by_cache = {summary["use_cache"]: summary for summary in summaries}
+    assert summaries_by_cache[True]["cache_hits_mean"] == 3
+    assert summaries_by_cache[True]["duplicate_candidates_mean"] == 1
+    assert summaries_by_cache[True]["actual_cross_validate_calls_mean"] == 4
+    assert summaries_by_cache[False]["cache_hits_mean"] == 0
+    assert summaries_by_cache[False]["duplicate_candidates_mean"] == 4
+    assert summaries_by_cache[False]["actual_cross_validate_calls_mean"] == 7
+
+
+def test_comparison_matches_across_cache_modes_and_supports_old_summaries(capsys):
+    cache_on = aggregate_results(
+        [_benchmark_result(use_cache=True, cache_hits=3, duplicate_candidates=1, cv_calls=4)]
+    )[0]
+    cache_off = aggregate_results(
+        [_benchmark_result(use_cache=False, cache_hits=0, duplicate_candidates=4, cv_calls=7)]
+    )[0]
+    old_baseline = dict(cache_off)
+    old_baseline.pop("use_cache")
+
+    assert comparison_key(cache_on) == comparison_key(cache_off)
+    assert comparison_key(cache_on) == comparison_key(old_baseline)
+
+    print_comparison_table([cache_on], [old_baseline])
+
+    output = capsys.readouterr().out
+    assert "current_use_cache" in output
+    assert "baseline_use_cache" in output
+    assert "True" in output


### PR DESCRIPTION
## Summary

- add an opt-in classification scenario with only four discrete candidates to make cache collisions reproducible
- report cache mode, cache hits, duplicate candidates, and actual cross-validation calls separately
- keep cache-on/cache-off comparisons compatible with older benchmark JSON files
- add focused tests for the collision search space and cache comparison reporting

## Verification

- `PYTHONPATH=. python -m pytest -q -o addopts=''`
- `python -m black --check benchmarks/benchmark_fit.py sklearn_genetic/tests/test_benchmark_fit.py`
- quick benchmark with cache enabled: 4 cross-validation calls, 21 cache hits
- quick benchmark with cache disabled: 26 cross-validation calls, 0 cache hits

Closes #300
