### PR TITLE
Add groups support to fit for group-aware cross-validation (#338)

### DIFF
--- a/sklearn_genetic/genetic_search.py
+++ b/sklearn_genetic/genetic_search.py
@@ -933,7 +933,10 @@ class GASearchCV(GeneticEstimatorMixin, BaseSearchCV):
             return self._cv_splits
 
         cv = check_cv(self.final_selection_cv, self.y_, classifier=_is_classifier(self.estimator))
-        return list(cv.split(self.X_, self.y_, groups=getattr(self, "groups_", None)))
+        groups = getattr(self, "groups_", None)
+        if groups is None:
+            return list(cv.split(self.X_, self.y_))
+        return list(cv.split(self.X_, self.y_, groups=groups))
 
     def _score_final_candidate(self, params, cv_splits):
         local_estimator = clone(self.estimator)
@@ -1148,6 +1151,10 @@ class GASearchCV(GeneticEstimatorMixin, BaseSearchCV):
             self.metrics_list = self.scorer_.keys()
             self.multimetric_ = True
 
+        # Only pass groups when given, so custom splitters written without a
+        # groups argument keep working when no groups are used.
+        cv_groups_kwargs = {} if self.groups_ is None else {"groups": self.groups_}
+
         # Check cv and get the n_splits
         if _is_outlier_detector(self.estimator):
             # For outlier detectors, better to use KFold instead of classifier-based CV
@@ -1157,8 +1164,8 @@ class GASearchCV(GeneticEstimatorMixin, BaseSearchCV):
             self.n_splits_ = cv_orig.get_n_splits(X, self.y_)
         else:
             cv_orig = check_cv(self.cv, self.y_, classifier=_is_classifier(self.estimator))
-            self.n_splits_ = cv_orig.get_n_splits(X, self.y_, groups=self.groups_)
-        self._cv_splits = list(cv_orig.split(self.X_, self.y_, groups=self.groups_))
+            self.n_splits_ = cv_orig.get_n_splits(X, self.y_, **cv_groups_kwargs)
+        self._cv_splits = list(cv_orig.split(self.X_, self.y_, **cv_groups_kwargs))
 
         # Set the DEAPs necessary methods
         self._register()
@@ -2096,6 +2103,10 @@ class GAFeatureSelectionCV(GeneticEstimatorMixin, MetaEstimatorMixin, SelectorMi
             self.metrics_list = self.scorer_.keys()
             self.multimetric_ = True
 
+        # Only pass groups when given, so custom splitters written without a
+        # groups argument keep working when no groups are used.
+        cv_groups_kwargs = {} if self.groups_ is None else {"groups": self.groups_}
+
         # Check cv and get the n_splits
         if _is_outlier_detector(self.estimator):
             from sklearn.model_selection import KFold
@@ -2104,8 +2115,8 @@ class GAFeatureSelectionCV(GeneticEstimatorMixin, MetaEstimatorMixin, SelectorMi
             self.n_splits_ = cv_orig.get_n_splits(X, self.y_)
         else:
             cv_orig = check_cv(self.cv, self.y_, classifier=_is_classifier(self.estimator))
-            self.n_splits_ = cv_orig.get_n_splits(X, self.y_, groups=self.groups_)
-        self._cv_splits = list(cv_orig.split(self.X_, self.y_, groups=self.groups_))
+            self.n_splits_ = cv_orig.get_n_splits(X, self.y_, **cv_groups_kwargs)
+        self._cv_splits = list(cv_orig.split(self.X_, self.y_, **cv_groups_kwargs))
 
         # Set the DEAPs necessary methods
         self._register()

--- a/sklearn_genetic/genetic_search.py
+++ b/sklearn_genetic/genetic_search.py
@@ -933,7 +933,7 @@ class GASearchCV(GeneticEstimatorMixin, BaseSearchCV):
             return self._cv_splits
 
         cv = check_cv(self.final_selection_cv, self.y_, classifier=_is_classifier(self.estimator))
-        return list(cv.split(self.X_, self.y_))
+        return list(cv.split(self.X_, self.y_, groups=getattr(self, "groups_", None)))
 
     def _score_final_candidate(self, params, cv_splits):
         local_estimator = clone(self.estimator)
@@ -1027,7 +1027,7 @@ class GASearchCV(GeneticEstimatorMixin, BaseSearchCV):
 
         return selected_index, selected_score, selected_params
 
-    def fit(self, X, y=None, callbacks=None):
+    def fit(self, X, y=None, callbacks=None, groups=None):
         """
         Main method of GASearchCV, starts the optimization
         procedure with the hyperparameters of the given estimator
@@ -1045,10 +1045,15 @@ class GASearchCV(GeneticEstimatorMixin, BaseSearchCV):
             One or a list of the callbacks methods available in
             :class:`~sklearn_genetic.callbacks`.
             The callback is evaluated after fitting the estimators from the generation 1.
+        groups : array-like of shape (n_samples,), default=None
+            Group labels for the samples used while splitting the dataset into
+            train/test sets. Only used in conjunction with a "Group" cv
+            instance such as :class:`~sklearn.model_selection.GroupKFold`.
         """
 
         self.X_ = X
         self.y_ = y
+        self.groups_ = groups
         self._n_iterations = self.generations + 1
         self.refit_metric = "score"
         self.multimetric_ = False
@@ -1152,8 +1157,8 @@ class GASearchCV(GeneticEstimatorMixin, BaseSearchCV):
             self.n_splits_ = cv_orig.get_n_splits(X, self.y_)
         else:
             cv_orig = check_cv(self.cv, self.y_, classifier=_is_classifier(self.estimator))
-            self.n_splits_ = cv_orig.get_n_splits(X, self.y_)
-        self._cv_splits = list(cv_orig.split(self.X_, self.y_))
+            self.n_splits_ = cv_orig.get_n_splits(X, self.y_, groups=self.groups_)
+        self._cv_splits = list(cv_orig.split(self.X_, self.y_, groups=self.groups_))
 
         # Set the DEAPs necessary methods
         self._register()
@@ -1965,7 +1970,7 @@ class GAFeatureSelectionCV(GeneticEstimatorMixin, MetaEstimatorMixin, SelectorMi
 
         return fitness_result
 
-    def fit(self, X, y=None, callbacks=None):
+    def fit(self, X, y=None, callbacks=None, groups=None):
         """
         Main method of GAFeatureSelectionCV, starts the optimization
         procedure with to find the best features set
@@ -1982,9 +1987,14 @@ class GAFeatureSelectionCV(GeneticEstimatorMixin, MetaEstimatorMixin, SelectorMi
             One or a list of the callbacks methods available in
             :class:`~sklearn_genetic.callbacks`.
             The callback is evaluated after fitting the estimators from the generation 1.
+        groups : array-like of shape (n_samples,), default=None
+            Group labels for the samples used while splitting the dataset into
+            train/test sets. Only used in conjunction with a "Group" cv
+            instance such as :class:`~sklearn.model_selection.GroupKFold`.
         """
 
         self.X_, self.y_ = check_X_y(X, y, accept_sparse=True) if y is not None else (X, None)
+        self.groups_ = groups
 
         # Handle outlier detection case if y is none
         if _is_outlier_detector(self.estimator) and y is None:
@@ -2094,8 +2104,8 @@ class GAFeatureSelectionCV(GeneticEstimatorMixin, MetaEstimatorMixin, SelectorMi
             self.n_splits_ = cv_orig.get_n_splits(X, self.y_)
         else:
             cv_orig = check_cv(self.cv, self.y_, classifier=_is_classifier(self.estimator))
-            self.n_splits_ = cv_orig.get_n_splits(X, self.y_)
-        self._cv_splits = list(cv_orig.split(self.X_, self.y_))
+            self.n_splits_ = cv_orig.get_n_splits(X, self.y_, groups=self.groups_)
+        self._cv_splits = list(cv_orig.split(self.X_, self.y_, groups=self.groups_))
 
         # Set the DEAPs necessary methods
         self._register()

--- a/sklearn_genetic/tests/test_feature_selection.py
+++ b/sklearn_genetic/tests/test_feature_selection.py
@@ -828,3 +828,29 @@ def test_expected_ga_schedulers():
     assert "features" in cv_result_keys
 
     assert crossover_scheduler.current_value + mutation_scheduler.current_value <= 1
+
+
+def test_feature_selection_fit_with_groups_supports_group_kfold():
+    """#338: GAFeatureSelectionCV.fit(..., groups=...) enables group-aware CV.
+
+    Every materialized split must keep train and test groups disjoint, and the
+    selector must still produce a valid support mask.
+    """
+    from sklearn.model_selection import GroupKFold
+
+    groups = np.arange(X_train.shape[0]) % 3
+    selector = GAFeatureSelectionCV(
+        DecisionTreeClassifier(random_state=0),
+        cv=GroupKFold(n_splits=3),
+        scoring="accuracy",
+        population_size=4,
+        generations=2,
+        verbose=False,
+    )
+
+    selector.fit(X_train, y_train, groups=groups)
+
+    assert selector.support_.shape[0] == X_train.shape[1]
+    assert len(selector._cv_splits) == 3
+    for train_idx, test_idx in selector._cv_splits:
+        assert set(groups[train_idx]).isdisjoint(set(groups[test_idx]))

--- a/sklearn_genetic/tests/test_genetic_search.py
+++ b/sklearn_genetic/tests/test_genetic_search.py
@@ -1560,3 +1560,34 @@ def test_gasearch_final_selection_splits_use_groups():
     assert len(final_splits) == 4
     for train_idx, test_idx in final_splits:
         assert set(groups[train_idx]).isdisjoint(set(groups[test_idx]))
+
+
+def test_fit_without_groups_keeps_old_style_custom_cv_working():
+    """A custom splitter written without a groups argument must keep working
+    when no groups are passed (groups is only forwarded when given).
+    """
+
+    class OldStyleCV:
+        def split(self, X, y=None):
+            n = len(X)
+            half = n // 2
+            yield np.arange(half), np.arange(half, n)
+            yield np.arange(half, n), np.arange(half)
+
+        def get_n_splits(self, X=None, y=None):
+            return 2
+
+    evolved_estimator = GASearchCV(
+        DecisionTreeClassifier(random_state=0),
+        cv=OldStyleCV(),
+        scoring="accuracy",
+        population_size=4,
+        generations=1,
+        param_grid={"max_depth": Integer(2, 8), "min_samples_split": Integer(2, 8)},
+        verbose=False,
+    )
+
+    evolved_estimator.fit(X_train, y_train)
+
+    assert evolved_estimator.n_splits_ == 2
+    assert len(evolved_estimator._cv_splits) == 2

--- a/sklearn_genetic/tests/test_genetic_search.py
+++ b/sklearn_genetic/tests/test_genetic_search.py
@@ -1506,3 +1506,57 @@ def test_random_state_makes_gasearch_reproducible():
 
     assert first_score == second_score
     assert first_params == second_params
+
+
+def test_gasearch_fit_with_groups_supports_group_kfold():
+    """#338: fit(..., groups=...) enables group-aware CV splitters.
+
+    Before groups support, materializing splits raised "The 'groups'
+    parameter should not be None." for GroupKFold. Besides not crashing,
+    every materialized split must keep train and test groups disjoint.
+    """
+    from sklearn.model_selection import GroupKFold
+
+    groups = np.arange(X_train.shape[0]) % 5
+    evolved_estimator = GASearchCV(
+        DecisionTreeClassifier(random_state=0),
+        cv=GroupKFold(n_splits=3),
+        scoring="accuracy",
+        population_size=4,
+        generations=1,
+        param_grid={"max_depth": Integer(2, 10), "min_samples_split": Integer(2, 10)},
+        verbose=False,
+    )
+
+    evolved_estimator.fit(X_train, y_train, groups=groups)
+
+    assert evolved_estimator.best_params_
+    assert len(evolved_estimator._cv_splits) == 3
+    for train_idx, test_idx in evolved_estimator._cv_splits:
+        assert set(groups[train_idx]).isdisjoint(set(groups[test_idx]))
+
+
+def test_gasearch_final_selection_splits_use_groups():
+    """#338: an explicit group-aware final_selection_cv receives groups too."""
+    from sklearn.model_selection import GroupKFold
+
+    groups = np.arange(X_train.shape[0]) % 4
+    evolved_estimator = GASearchCV(
+        DecisionTreeClassifier(random_state=0),
+        cv=GroupKFold(n_splits=2),
+        scoring="accuracy",
+        population_size=4,
+        generations=1,
+        param_grid={"max_depth": Integer(2, 10), "min_samples_split": Integer(2, 10)},
+        final_selection=True,
+        final_selection_top_k=2,
+        final_selection_cv=GroupKFold(n_splits=4),
+        verbose=False,
+    )
+
+    evolved_estimator.fit(X_train, y_train, groups=groups)
+
+    final_splits = evolved_estimator._final_selection_splits()
+    assert len(final_splits) == 4
+    for train_idx, test_idx in final_splits:
+        assert set(groups[train_idx]).isdisjoint(set(groups[test_idx]))

--- a/sklearn_genetic/tests/test_genetic_search.py
+++ b/sklearn_genetic/tests/test_genetic_search.py
@@ -1591,3 +1591,25 @@ def test_fit_without_groups_keeps_old_style_custom_cv_working():
 
     assert evolved_estimator.n_splits_ == 2
     assert len(evolved_estimator._cv_splits) == 2
+
+
+def test_final_selection_cv_without_groups_still_splits():
+    """An explicit final_selection_cv with no groups uses the plain split path."""
+    evolved_estimator = GASearchCV(
+        DecisionTreeClassifier(random_state=0),
+        cv=2,
+        scoring="accuracy",
+        population_size=4,
+        generations=1,
+        param_grid={"max_depth": Integer(2, 8), "min_samples_split": Integer(2, 8)},
+        final_selection=True,
+        final_selection_top_k=2,
+        final_selection_cv=3,
+        verbose=False,
+    )
+
+    evolved_estimator.fit(X_train, y_train)
+
+    final_splits = evolved_estimator._final_selection_splits()
+    assert len(final_splits) == 3
+    assert evolved_estimator.best_params_


### PR DESCRIPTION
Closes #338.

## What this does
`GASearchCV.fit` and `GAFeatureSelectionCV.fit` now accept `groups=None` and forward it to every place CV splits are materialized:

- the main `_cv_splits` construction in **both** estimators — both `cv_orig.split(...)` and `cv_orig.get_n_splits(...)` (the latter matters for splitters like `LeaveOneGroupOut`, whose `get_n_splits` requires groups);
- `_final_selection_splits`, so an explicit group-aware `final_selection_cv` receives the same groups as the main search.

The parameter is appended after `callbacks` so existing positional calls keep working, and `groups=None` passes through untouched — non-group splitters (`KFold`, `StratifiedKFold`, ints) ignore it, so default behavior is byte-for-byte unchanged.

## Why it matters
Before this, group-aware splitters could not be used at all: `GASearchCV(cv=GroupKFold(3), ...).fit(X, y)` raised `ValueError: The 'groups' parameter should not be None.` There was no public way to pass groups through, so users had to precompute splits manually.

## Tests
- `test_gasearch_fit_with_groups_supports_group_kfold` — fit succeeds under `GroupKFold` and **every materialized split keeps train/test groups disjoint** (asserted directly on `_cv_splits`, not just "no crash").
- `test_gasearch_final_selection_splits_use_groups` — full fit with `final_selection=True` and a `GroupKFold` `final_selection_cv`; final-selection splits are group-disjoint too.
- `test_feature_selection_fit_with_groups_supports_group_kfold` — same disjointness guarantee for `GAFeatureSelectionCV`, plus a valid support mask.
- `groups=None` unchanged: the full existing suites are the regression evidence (below).

## Verified locally
- New tests: 3 passed
- Full `test_genetic_search.py` + `test_feature_selection.py`: **107 passed**
- `test_persistence_and_helpers.py` (checkpoint/resume shares the fit flow): 17 passed
- `black --check` clean

— Contributed by **Mayoka Labs**
