### PR TITLE
Forward sample_weight and fit params through candidate CV and refit (#339)

### DIFF
--- a/sklearn_genetic/genetic_search.py
+++ b/sklearn_genetic/genetic_search.py
@@ -833,6 +833,7 @@ class GASearchCV(GeneticEstimatorMixin, BaseSearchCV):
             pre_dispatch=self.pre_dispatch,
             error_score=self.error_score,
             return_train_score=self.return_train_score,
+            params=getattr(self, "_fit_params", None) or None,
         )
 
         cv_scores = cv_results[f"test_{self.refit_metric}"]
@@ -952,6 +953,7 @@ class GASearchCV(GeneticEstimatorMixin, BaseSearchCV):
             pre_dispatch=self.pre_dispatch,
             error_score=self.error_score,
             return_train_score=False,
+            params=getattr(self, "_fit_params", None) or None,
         )
         cv_scores = cv_results[f"test_{self.refit_metric}"]
         return float(np.mean(cv_scores)), cv_scores
@@ -1030,7 +1032,7 @@ class GASearchCV(GeneticEstimatorMixin, BaseSearchCV):
 
         return selected_index, selected_score, selected_params
 
-    def fit(self, X, y=None, callbacks=None, groups=None):
+    def fit(self, X, y=None, callbacks=None, groups=None, **fit_params):
         """
         Main method of GASearchCV, starts the optimization
         procedure with the hyperparameters of the given estimator
@@ -1052,11 +1054,18 @@ class GASearchCV(GeneticEstimatorMixin, BaseSearchCV):
             Group labels for the samples used while splitting the dataset into
             train/test sets. Only used in conjunction with a "Group" cv
             instance such as :class:`~sklearn.model_selection.GroupKFold`.
+        **fit_params : dict of str -> object
+            Parameters passed to the ``fit`` method of the underlying
+            estimator (e.g. ``sample_weight``). They are forwarded to every
+            candidate cross-validation, to final-selection scoring, and to
+            the final refit. Sample-aligned parameters are sliced per CV
+            fold by scikit-learn.
         """
 
         self.X_ = X
         self.y_ = y
         self.groups_ = groups
+        self._fit_params = fit_params
         self._n_iterations = self.generations + 1
         self.refit_metric = "score"
         self.multimetric_ = False
@@ -1226,6 +1235,7 @@ class GASearchCV(GeneticEstimatorMixin, BaseSearchCV):
             self.estimator.fit(
                 self.X_,
                 self.y_,
+                **getattr(self, "_fit_params", {}),
             )
             refit_end_time = time.time()
             self.refit_time_ = refit_end_time - refit_start_time
@@ -1886,7 +1896,9 @@ class GAFeatureSelectionCV(GeneticEstimatorMixin, MetaEstimatorMixin, SelectorMi
 
         local_estimator = clone(self.estimator)
 
-        # Use standard cross_validate for all estimator types
+        # Use standard cross_validate for all estimator types. Only X is
+        # feature-sliced; fit params such as sample_weight stay aligned to
+        # samples and are sliced per CV fold by scikit-learn.
         cv_results = cross_validate(
             local_estimator,
             self.X_[:, bool_individual],
@@ -1897,6 +1909,7 @@ class GAFeatureSelectionCV(GeneticEstimatorMixin, MetaEstimatorMixin, SelectorMi
             pre_dispatch=self.pre_dispatch,
             error_score=self.error_score,
             return_train_score=self.return_train_score,
+            params=getattr(self, "_fit_params", None) or None,
         )
 
         score, current_generation_params = self._build_feature_evaluation_record(
@@ -1977,7 +1990,7 @@ class GAFeatureSelectionCV(GeneticEstimatorMixin, MetaEstimatorMixin, SelectorMi
 
         return fitness_result
 
-    def fit(self, X, y=None, callbacks=None, groups=None):
+    def fit(self, X, y=None, callbacks=None, groups=None, **fit_params):
         """
         Main method of GAFeatureSelectionCV, starts the optimization
         procedure with to find the best features set
@@ -1998,10 +2011,17 @@ class GAFeatureSelectionCV(GeneticEstimatorMixin, MetaEstimatorMixin, SelectorMi
             Group labels for the samples used while splitting the dataset into
             train/test sets. Only used in conjunction with a "Group" cv
             instance such as :class:`~sklearn.model_selection.GroupKFold`.
+        **fit_params : dict of str -> object
+            Parameters passed to the ``fit`` method of the underlying
+            estimator (e.g. ``sample_weight``). They are forwarded to every
+            candidate cross-validation and to the final refit. Only ``X`` is
+            feature-sliced during the search; sample-aligned parameters stay
+            aligned to samples and are sliced per CV fold by scikit-learn.
         """
 
         self.X_, self.y_ = check_X_y(X, y, accept_sparse=True) if y is not None else (X, None)
         self.groups_ = groups
+        self._fit_params = fit_params
 
         # Handle outlier detection case if y is none
         if _is_outlier_detector(self.estimator) and y is None:
@@ -2173,7 +2193,11 @@ class GAFeatureSelectionCV(GeneticEstimatorMixin, MetaEstimatorMixin, SelectorMi
             bool_individual = np.array(self.best_features_, dtype=bool)
 
             refit_start_time = time.time()
-            self.estimator.fit(self.X_[:, bool_individual], self.y_)
+            self.estimator.fit(
+                self.X_[:, bool_individual],
+                self.y_,
+                **getattr(self, "_fit_params", {}),
+            )
             refit_end_time = time.time()
             self.refit_time_ = refit_end_time - refit_start_time
 

--- a/sklearn_genetic/tests/test_feature_selection.py
+++ b/sklearn_genetic/tests/test_feature_selection.py
@@ -854,3 +854,39 @@ def test_feature_selection_fit_with_groups_supports_group_kfold():
     assert len(selector._cv_splits) == 3
     for train_idx, test_idx in selector._cv_splits:
         assert set(groups[train_idx]).isdisjoint(set(groups[test_idx]))
+
+
+def test_feature_selection_forwards_sample_weight_and_slices_only_features():
+    """#339: GAFeatureSelectionCV forwards sample_weight while only X is
+    feature-sliced.
+
+    Candidate fits see a feature-sliced X but per-fold sample_weight slices;
+    the final refit sees the full weight vector.
+    """
+    recorded = []
+
+    class WeightRecordingTree(DecisionTreeClassifier):
+        def fit(self, X, y, sample_weight=None):
+            recorded.append((X.shape[1], None if sample_weight is None else len(sample_weight)))
+            return super().fit(X, y, sample_weight=sample_weight)
+
+    n_samples, n_features_total = X_train.shape
+    weights = np.linspace(0.5, 1.5, n_samples)
+    selector = GAFeatureSelectionCV(
+        WeightRecordingTree(random_state=0),
+        cv=2,
+        scoring="accuracy",
+        population_size=4,
+        generations=2,
+        verbose=False,
+    )
+
+    selector.fit(X_train, y_train, sample_weight=weights)
+
+    assert recorded, "no fit calls were recorded"
+    # Every fit received weights, and X never grew beyond the original features.
+    assert all(w is not None for _, w in recorded)
+    assert all(f <= n_features_total for f, _ in recorded)
+    # Candidate CV fits get per-fold weight slices; the refit gets all samples.
+    assert all(w < n_samples for _, w in recorded[:-1])
+    assert recorded[-1][1] == n_samples

--- a/sklearn_genetic/tests/test_genetic_search.py
+++ b/sklearn_genetic/tests/test_genetic_search.py
@@ -1613,3 +1613,86 @@ def test_final_selection_cv_without_groups_still_splits():
     final_splits = evolved_estimator._final_selection_splits()
     assert len(final_splits) == 3
     assert evolved_estimator.best_params_
+
+
+def test_gasearch_forwards_sample_weight_to_candidate_cv_and_refit():
+    """#339: fit(..., sample_weight=...) reaches candidate CV fits and the refit.
+
+    A recording estimator captures the sample_weight length of every fit call:
+    candidate CV fits must receive per-fold slices (smaller than n_samples),
+    and the final refit must receive the full weight vector.
+    """
+    recorded = []
+
+    class WeightRecordingTree(DecisionTreeClassifier):
+        def fit(self, X, y, sample_weight=None):
+            recorded.append(None if sample_weight is None else len(sample_weight))
+            return super().fit(X, y, sample_weight=sample_weight)
+
+    n_samples = X_train.shape[0]
+    weights = np.linspace(0.5, 1.5, n_samples)
+    evolved_estimator = GASearchCV(
+        WeightRecordingTree(random_state=0),
+        cv=2,
+        scoring="accuracy",
+        population_size=4,
+        generations=1,
+        param_grid={"max_depth": Integer(2, 10), "min_samples_split": Integer(2, 10)},
+        verbose=False,
+    )
+
+    evolved_estimator.fit(X_train, y_train, sample_weight=weights)
+
+    assert recorded, "no fit calls were recorded"
+    # Every single fit (candidate folds and refit) received weights.
+    assert all(length is not None for length in recorded)
+    # Candidate CV fits get per-fold slices, strictly smaller than n_samples.
+    assert all(length < n_samples for length in recorded[:-1])
+    # The final refit gets the full, unsliced weight vector.
+    assert recorded[-1] == n_samples
+
+
+def test_gasearch_final_selection_scoring_receives_fit_params():
+    """#339: final-selection candidate re-scoring forwards fit params too."""
+    recorded = []
+
+    class WeightRecordingTree(DecisionTreeClassifier):
+        def fit(self, X, y, sample_weight=None):
+            recorded.append(sample_weight is not None)
+            return super().fit(X, y, sample_weight=sample_weight)
+
+    weights = np.ones(X_train.shape[0])
+    evolved_estimator = GASearchCV(
+        WeightRecordingTree(random_state=0),
+        cv=2,
+        scoring="accuracy",
+        population_size=4,
+        generations=1,
+        param_grid={"max_depth": Integer(2, 10), "min_samples_split": Integer(2, 10)},
+        final_selection=True,
+        final_selection_top_k=2,
+        final_selection_cv=3,
+        verbose=False,
+    )
+
+    evolved_estimator.fit(X_train, y_train, sample_weight=weights)
+
+    # Search CV fits + final-selection re-scoring fits + refit: all weighted.
+    assert recorded and all(recorded)
+
+
+def test_gasearch_unsupported_fit_param_raises_clearly():
+    """#339: an unsupported fit param must fail loudly, not be dropped."""
+    evolved_estimator = GASearchCV(
+        DecisionTreeClassifier(random_state=0),
+        cv=2,
+        scoring="accuracy",
+        population_size=4,
+        generations=1,
+        param_grid={"max_depth": Integer(2, 10), "min_samples_split": Integer(2, 10)},
+        error_score="raise",
+        verbose=False,
+    )
+
+    with pytest.raises(TypeError):
+        evolved_estimator.fit(X_train, y_train, not_a_real_fit_param=np.ones(X_train.shape[0]))


### PR DESCRIPTION
Closes #339. **Builds on #340** (both extend the same `fit()` signatures — this branch includes that commit so the two don't conflict; merging #340 first will leave only this PR's own commit here).

## What this does
`GASearchCV.fit` and `GAFeatureSelectionCV.fit` now accept `**fit_params` (e.g. `sample_weight`) and forward them to **every** place the estimator is fitted:

1. **Candidate evaluation** — `cross_validate(..., params=self._fit_params)` in both `_evaluate_individual` implementations. scikit-learn slices sample-aligned params per CV fold (verified against sklearn 1.9; the `params=` kwarg exists throughout the supported `scikit-learn>=1.5` range).
2. **Final-selection re-scoring** — `_score_final_candidate` passes the same params, so a weighted search ranks its top-k candidates under the same weighting it searched with.
3. **Final refit** — both refit blocks pass `**fit_params` to `estimator.fit`.

For `GAFeatureSelectionCV`, only `X` is feature-sliced during the search; `sample_weight` stays aligned to samples and is row-sliced per fold by sklearn (tested explicitly).

**Parallel path:** params live on `self._fit_params`, and the population-parallel path in `evaluation.py` invokes `estimator._evaluate_individual` through joblib — the estimator (and its params) is what gets shipped to workers, so no separate threading was needed there.

## Behavior guarantees
- No fit params → `params=None` → byte-for-byte identical behavior (full suites pass).
- Unsupported params are **not** silently dropped: they surface as the estimator's own `TypeError` (tested with `error_score="raise"`).

## Tests
- `test_gasearch_forwards_sample_weight_to_candidate_cv_and_refit` — a recording estimator asserts every candidate fold fit got a **per-fold slice** (`< n_samples`) and the refit got the **full** vector (`== n_samples`).
- `test_gasearch_final_selection_scoring_receives_fit_params` — full run with `final_selection=True`; every fit in the pipeline was weighted.
- `test_feature_selection_forwards_sample_weight_and_slices_only_features` — same guarantees for `GAFeatureSelectionCV`, plus `X.shape[1]` never exceeds the original feature count.
- `test_gasearch_unsupported_fit_param_raises_clearly` — bogus param → `TypeError`.

## Verified locally
- New tests: 4 passed (plus the 3 groups tests from #340: 7 total)
- Full `test_genetic_search.py` + `test_feature_selection.py` + `test_persistence_and_helpers.py`: **128 passed**
- `black --check` clean

— Contributed by **Mayoka Labs**
