### PR TITLE
Check local RST directive target links

### DIFF
--- a/docs-vitepress/scripts/check_links.py
+++ b/docs-vitepress/scripts/check_links.py
@@ -47,6 +47,13 @@ LINK_RE = re.compile(r"!?\[[^\]]*\]\(\s*([^)\s]+)")
 # single-token so normal prose with angle brackets is not treated as a path.
 RST_LINK_RE = re.compile(r"`[^`<\n]+<([^\s>]+)>`_|^\.\.\s+_[^:]+:\s+(\S+)", re.MULTILINE)
 RST_DIRECTIVE_TARGET_RE = re.compile(r"^\.\.\s+(?:image|figure)::\s+(\S+)", re.MULTILINE)
+# Keep option targets scoped to an image/figure block so target-like prose is ignored.
+RST_DIRECTIVE_OPTION_TARGET_RE = re.compile(
+    r"^\.\.\s+(?:image|figure)::[^\n]*"
+    r"(?:\n(?![ \t]+:target:)[ \t]+\S[^\n]*)*"
+    r"\n[ \t]+:target:\s+(\S+)[ \t]*$",
+    re.MULTILINE,
+)
 
 _EXTERNAL_PREFIXES = ("http://", "https://", "mailto:", "//")
 
@@ -92,6 +99,7 @@ def _iter_targets(doc_file: Path) -> list[str]:
         for inline, named in RST_LINK_RE.findall(text):
             targets.append(inline or named)
         targets.extend(RST_DIRECTIVE_TARGET_RE.findall(text))
+        targets.extend(RST_DIRECTIVE_OPTION_TARGET_RE.findall(text))
         return targets
     return LINK_RE.findall(text)
 

--- a/docs-vitepress/scripts/test_check_links.py
+++ b/docs-vitepress/scripts/test_check_links.py
@@ -111,3 +111,58 @@ def test_root_doc_rst_image_directive_broken_same_repo_blob_is_reported(tmp_path
     monkeypatch.setattr(check_links, "VERSION_DIRS", [])
     monkeypatch.setattr(check_links, "ROOT_DOCS", [root_doc])
     assert check_links.check() == [(root_doc, target)]
+
+
+@pytest.mark.parametrize("directive", ["image", "figure"])
+def test_root_doc_rst_directive_valid_local_target_passes(tmp_path, monkeypatch, directive):
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "guide.rst").write_text("x", encoding="utf-8")
+    (tmp_path / "logo.png").write_bytes(b"png")
+    root_doc = tmp_path / "README.rst"
+    root_doc.write_text(
+        f".. {directive}:: logo.png\n" "   :alt: Project logo\n" "   :target: docs/guide.rst\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(check_links, "ROOT", tmp_path)
+    monkeypatch.setattr(check_links, "VERSION_DIRS", [])
+    monkeypatch.setattr(check_links, "ROOT_DOCS", [root_doc])
+    assert check_links.check() == []
+
+
+def test_root_doc_rst_directive_missing_local_target_is_reported(tmp_path, monkeypatch):
+    (tmp_path / "logo.png").write_bytes(b"png")
+    root_doc = tmp_path / "README.rst"
+    root_doc.write_text(
+        ".. image:: logo.png\n   :target: docs/missing.rst\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(check_links, "ROOT", tmp_path)
+    monkeypatch.setattr(check_links, "VERSION_DIRS", [])
+    monkeypatch.setattr(check_links, "ROOT_DOCS", [root_doc])
+    assert check_links.check() == [(root_doc, "docs/missing.rst")]
+
+
+def test_root_doc_rst_directive_external_target_is_skipped(tmp_path, monkeypatch):
+    (tmp_path / "logo.png").write_bytes(b"png")
+    root_doc = tmp_path / "README.rst"
+    root_doc.write_text(
+        ".. figure:: logo.png\n   :target: https://example.com/guide\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(check_links, "ROOT", tmp_path)
+    monkeypatch.setattr(check_links, "VERSION_DIRS", [])
+    monkeypatch.setattr(check_links, "ROOT_DOCS", [root_doc])
+    assert check_links.check() == []
+
+
+def test_root_doc_rst_directive_target_like_prose_is_skipped(tmp_path, monkeypatch):
+    root_doc = tmp_path / "README.rst"
+    root_doc.write_text(
+        "Ordinary prose mentions :target: docs/missing.rst.\n"
+        "   :target: docs/also-missing.rst\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(check_links, "ROOT", tmp_path)
+    monkeypatch.setattr(check_links, "VERSION_DIRS", [])
+    monkeypatch.setattr(check_links, "ROOT_DOCS", [root_doc])
+    assert check_links.check() == []


### PR DESCRIPTION
## Summary

- Parse `:target:` options that belong to root-document RST `image` and `figure`
  directives.
- Reuse the existing root-doc resolver so local targets are validated while
  external URLs and the current path-safety rules keep their existing behavior.
- Add regression coverage for valid local targets, missing targets, external
  targets, and `:target:`-like prose.

The checker previously collected only the directive's primary image path, so a
stale local link in its option block could pass unnoticed.

## Related Issue

Closes #337

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] Other (describe):

## Validation

- `python -m pytest docs-vitepress/scripts/test_check_links.py` — 21 passed
- `python docs-vitepress/scripts/check_links.py` — all internal links resolve
- `python -m pytest sklearn_genetic/` — 384 passed, 4 skipped
- `python -m black --check docs-vitepress/scripts/check_links.py docs-vitepress/scripts/test_check_links.py` — unchanged
- `git diff --check` — passed

## Checklist

- [x] I checked the linked issue is open and not already covered by another PR
- [x] Tests pass locally (`pytest sklearn_genetic/`)
- [x] Code is formatted with Black (`black sklearn_genetic/`)
- [x] New functionality is covered by tests
- [x] Documentation updated if needed (no user-facing documentation change is required)
