### PR TITLE
fix(benchmark): make fit benchmark comparisons cache-mode aware

### DIFF
--- a/benchmarks/benchmark_fit.py
+++ b/benchmarks/benchmark_fit.py
@@ -744,36 +744,46 @@ def print_summary_table(summaries: list[dict[str, Any]]) -> None:
         print("\t".join(row))
 
 
-def comparison_key(summary: dict[str, Any]) -> tuple[str, str, str, str, str]:
+def comparison_key(summary: dict[str, Any]) -> tuple[str, str, str, str, str, bool | None]:
     return (
         summary["scenario"],
         summary["estimator"],
         str(summary["n_jobs"]),
         summary["parallel_backend"],
         summary["population_initializer"],
+        summary.get("use_cache"),
     )
 
 
-def cache_aware_comparison_key(
-    summary: dict[str, Any],
-) -> tuple[tuple[str, str, str, str, str], bool]:
-    return comparison_key(summary), summary["use_cache"]
-
-
 def print_comparison_table(current: list[dict[str, Any]], baseline: list[dict[str, Any]]) -> None:
-    baseline_by_cache_key = {
-        cache_aware_comparison_key(summary): summary
-        for summary in baseline
-        if "use_cache" in summary
-    }
-    legacy_baseline_by_key = {
-        comparison_key(summary): summary for summary in baseline if "use_cache" not in summary
-    }
+    baseline_by_key: dict[tuple, dict[str, Any]] = {}
+    for summary in baseline:
+        baseline_by_key[comparison_key(summary)] = summary
+
+    legacy_baseline_by_key: dict[tuple, dict[str, Any]] = {}
+    for summary in baseline:
+        if "use_cache" not in summary:
+            legacy_comparison = (
+                summary["scenario"],
+                summary["estimator"],
+                str(summary["n_jobs"]),
+                summary["parallel_backend"],
+                summary["population_initializer"],
+            )
+            legacy_baseline_by_key[legacy_comparison] = summary
+
     comparable = []
     for summary in current:
-        base = baseline_by_cache_key.get(cache_aware_comparison_key(summary))
-        if base is None and summary["use_cache"]:
-            base = legacy_baseline_by_key.get(comparison_key(summary))
+        base = baseline_by_key.get(comparison_key(summary))
+        if base is None:
+            legacy_comparison = (
+                summary["scenario"],
+                summary["estimator"],
+                str(summary["n_jobs"]),
+                summary["parallel_backend"],
+                summary["population_initializer"],
+            )
+            base = legacy_baseline_by_key.get(legacy_comparison)
         if base is not None:
             comparable.append((summary, base))
 

--- a/benchmarks/benchmark_fit.py
+++ b/benchmarks/benchmark_fit.py
@@ -775,7 +775,7 @@ def print_comparison_table(current: list[dict[str, Any]], baseline: list[dict[st
     comparable = []
     for summary in current:
         base = baseline_by_key.get(comparison_key(summary))
-        if base is None:
+        if base is None and summary.get("use_cache", True):
             legacy_comparison = (
                 summary["scenario"],
                 summary["estimator"],

--- a/sklearn_genetic/tests/test_benchmark_fit.py
+++ b/sklearn_genetic/tests/test_benchmark_fit.py
@@ -80,24 +80,60 @@ def test_comparison_matches_same_cache_mode_when_baseline_contains_both(capsys):
     assert rows[-1].split("\t")[5:9] == ["False", "False", "5.0000", "2.0000"]
 
 
-def test_comparison_supports_old_summaries_without_cache_mode(capsys):
+def test_comparison_key_includes_use_cache():
     cache_on = aggregate_results(
         [_benchmark_result(use_cache=True, cache_hits=3, duplicate_candidates=1, cv_calls=4)]
     )[0]
     cache_off = aggregate_results(
         [_benchmark_result(use_cache=False, cache_hits=0, duplicate_candidates=4, cv_calls=7)]
     )[0]
-    old_baseline = dict(cache_off)
+
+    assert comparison_key(cache_on) != comparison_key(cache_off)
+    assert comparison_key(cache_on)[-1] is True
+    assert comparison_key(cache_off)[-1] is False
+
+
+def test_comparison_supports_old_summaries_without_cache_mode(capsys):
+    cache_on = aggregate_results(
+        [_benchmark_result(use_cache=True, cache_hits=3, duplicate_candidates=1, cv_calls=4)]
+    )[0]
+    old_baseline = dict(cache_on)
     old_baseline.pop("use_cache")
 
-    assert comparison_key(cache_on) == comparison_key(cache_off)
-    assert comparison_key(cache_on) == comparison_key(old_baseline)
+    assert comparison_key(old_baseline)[-1] is None
 
-    print_comparison_table([cache_on, cache_off], [old_baseline])
+    print_comparison_table([cache_on], [old_baseline])
 
     output = capsys.readouterr().out
     assert "current_use_cache" in output
     assert "baseline_use_cache" in output
     rows = output.splitlines()
-    assert rows[-1].split("\t")[5:7] == ["True", "True"]
-    assert len(rows) == 5
+    data_rows = [r for r in rows if r.startswith("classification_lr_collisions")]
+    assert len(data_rows) == 1
+    assert data_rows[0].split("\t")[5:7] == ["True", "True"]
+
+
+def test_duplicate_cache_mode_keys_do_not_silently_overwrite(capsys):
+    cache_on = aggregate_results(
+        [_benchmark_result(use_cache=True, cache_hits=3, duplicate_candidates=1, cv_calls=4)]
+    )[0]
+    cache_off = aggregate_results(
+        [_benchmark_result(use_cache=False, cache_hits=0, duplicate_candidates=4, cv_calls=7)]
+    )[0]
+
+    current_on = dict(cache_on, fit_seconds_mean=10.0)
+    current_off = dict(cache_off, fit_seconds_mean=10.0)
+    baseline_on = dict(cache_on, fit_seconds_mean=2.0)
+    baseline_off = dict(cache_off, fit_seconds_mean=5.0)
+
+    print_comparison_table([current_on, current_off], [baseline_on, baseline_off])
+
+    rows = capsys.readouterr().out.splitlines()
+    data_rows = [r for r in rows if r.startswith("classification_lr_collisions")]
+    assert len(data_rows) == 2
+
+    on_row = [r for r in data_rows if "\tTrue\tTrue\t" in r][0]
+    off_row = [r for r in data_rows if "\tFalse\tFalse\t" in r][0]
+
+    assert on_row.split("\t")[7] == "8.0000"
+    assert off_row.split("\t")[7] == "5.0000"

--- a/sklearn_genetic/tests/test_benchmark_fit.py
+++ b/sklearn_genetic/tests/test_benchmark_fit.py
@@ -137,3 +137,26 @@ def test_duplicate_cache_mode_keys_do_not_silently_overwrite(capsys):
 
     assert on_row.split("\t")[7] == "8.0000"
     assert off_row.split("\t")[7] == "5.0000"
+
+
+def test_legacy_baseline_only_matches_cache_on_current(capsys):
+    cache_on = aggregate_results(
+        [_benchmark_result(use_cache=True, cache_hits=3, duplicate_candidates=1, cv_calls=4)]
+    )[0]
+    cache_off = aggregate_results(
+        [_benchmark_result(use_cache=False, cache_hits=0, duplicate_candidates=4, cv_calls=7)]
+    )[0]
+
+    current_on = dict(cache_on, fit_seconds_mean=10.0)
+    current_off = dict(cache_off, fit_seconds_mean=10.0)
+
+    old_baseline = dict(cache_on)
+    old_baseline.pop("use_cache")
+    old_baseline["fit_seconds_mean"] = 2.0
+
+    print_comparison_table([current_on, current_off], [old_baseline])
+
+    rows = capsys.readouterr().out.splitlines()
+    data_rows = [r for r in rows if r.startswith("classification_lr_collisions")]
+    assert len(data_rows) == 1
+    assert data_rows[0].split("\t")[5:7] == ["True", "True"]


### PR DESCRIPTION
Problem

comparison_key in benchmarks/benchmark_fit.py did not include use_cache. When a baseline JSON contained both cache-on and cache-off rows for the same scenario/estimator/n_jobs/backend/initializer, one row silently overwrote the other in the lookup dict causing deltas to compare cache-on against cache-off.

Fix

- comparison_key now returns a 6-tuple including summary.get("use_cache")
- Removed redundant cache_aware_comparison_key (absorbed into comparison_key)
- print_comparison_table uses the new key for primary lookup, with a legacy 5-tuple fallback for old JSON files without use_cache


 All tests pass:
<img width="1920" height="1080" alt="Screenshot (392)" src="https://github.com/user-attachments/assets/818486a4-2495-4fa8-bde2-005c68546127" />

Cache-on vs cache-off produces different comparison keys:
<img width="1841" height="420" alt="Screenshot 2026-07-14 012422" src="https://github.com/user-attachments/assets/d27c6882-72ec-4b09-8465-68da139a519b" />


Comparison matches same cache mode (no cross-matching):
<img width="1857" height="252" alt="Screenshot 2026-07-14 012632" src="https://github.com/user-attachments/assets/d2aa2a59-4ff4-4bdf-93c0-1344bb19fb85" />
