### PR TITLE
fix: _select_final_candidate ignores criteria="min" -selects worst candidate for minimization

### DIFF
--- a/sklearn_genetic/genetic_search.py
+++ b/sklearn_genetic/genetic_search.py
@@ -1007,7 +1007,10 @@ class GASearchCV(GeneticEstimatorMixin, BaseSearchCV):
             )
 
         if candidate_results:
-            selected = max(candidate_results, key=lambda item: item["score"])
+            if self.criteria == "min":
+                selected = min(candidate_results, key=lambda item: item["score"])
+            else:
+                selected = max(candidate_results, key=lambda item: item["score"])
             selected_index = selected["index"]
             selected_score = selected["score"]
             selected_params = selected["params"]

--- a/sklearn_genetic/tests/test_genetic_search.py
+++ b/sklearn_genetic/tests/test_genetic_search.py
@@ -237,6 +237,39 @@ def test_final_selection_can_replace_original_best_candidate(monkeypatch):
     assert len(estimator.final_selection_results_["candidates"]) == 2
 
 
+def test_final_selection_respects_criteria_min(monkeypatch):
+    estimator = GASearchCV(
+        DecisionTreeClassifier(random_state=42),
+        param_grid={"max_depth": Integer(1, 3)},
+        final_selection=True,
+        final_selection_top_k=3,
+        criteria="min",
+        verbose=False,
+    )
+    estimator.refit_metric = "score"
+    estimator.cv_results_ = {
+        "rank_test_score": np.array([2, 3, 1]),
+        "mean_test_score": np.array([0.85, 0.70, 0.90]),
+        "params": [{"max_depth": 1}, {"max_depth": 2}, {"max_depth": 3}],
+    }
+
+    monkeypatch.setattr(estimator, "_final_selection_splits", lambda: ["split"])
+
+    def score_candidate(params, cv_splits):
+        if params["max_depth"] == 2:
+            return 0.65, np.array([0.64, 0.66])
+        return 0.95, np.array([0.94, 0.96])
+
+    monkeypatch.setattr(estimator, "_score_final_candidate", score_candidate)
+
+    best_index, best_score, best_params = estimator._select_final_candidate()
+
+    assert best_index == 1
+    assert best_score == pytest.approx(0.65)
+    assert best_params == {"max_depth": 2}
+    assert estimator.final_selection_results_["changed"] is True
+
+
 def test_wrong_optimizer_control_parameters():
     with pytest.raises(ValueError, match="diversity_threshold must be in the interval"):
         GASearchCV(


### PR DESCRIPTION
Summary

_select_final_candidate in GASearchCV always uses max() to pick the best re-evaluated candidate, even when criteria="min". For minimization problems (e.g., tuning toward RMSE or MAE), this silently selects the worst candidate.

Reproduction

from sklearn.tree import DecisionTreeClassifier
from sklearn_genetic import GASearchCV
from sklearn_genetic.space import Integer

estimator = GASearchCV(
    DecisionTreeClassifier(),
    param_grid={"max_depth": Integer(1, 5)},
    final_selection=True,
    criteria="min",
)
# After fit(), the final candidate is the one with the HIGHEST score
# instead of the lowest — opposite of what criteria="min" means.

Root cause

genetic_search.py:1010:
selected = max(candidate_results, key=lambda item: item["score"])

Should be conditional on self.criteria.

Fix
if self.criteria == "min":
    selected = min(candidate_results, key=lambda item: item["score"])
else:
    selected = max(candidate_results, key=lambda item: item["score"])

TEST CASE 
<img width="1890" height="245" alt="Screenshot 2026-07-14 022630" src="https://github.com/user-attachments/assets/9cd85795-feeb-41c2-b879-27bf94be3ed2" />