### PR TITLE
Detect duplicate benchmark comparison keys instead of silently overwriting

### DIFF
--- a/benchmarks/benchmark_fit.py
+++ b/benchmarks/benchmark_fit.py
@@ -755,35 +755,50 @@ def comparison_key(summary: dict[str, Any]) -> tuple[str, str, str, str, str, bo
     )
 
 
-def print_comparison_table(current: list[dict[str, Any]], baseline: list[dict[str, Any]]) -> None:
-    baseline_by_key: dict[tuple, dict[str, Any]] = {}
-    for summary in baseline:
-        baseline_by_key[comparison_key(summary)] = summary
+def _legacy_comparison_key(summary: dict[str, Any]) -> tuple[str, str, str, str, str]:
+    return (
+        summary["scenario"],
+        summary["estimator"],
+        str(summary["n_jobs"]),
+        summary["parallel_backend"],
+        summary["population_initializer"],
+    )
 
-    legacy_baseline_by_key: dict[tuple, dict[str, Any]] = {}
+
+def build_baseline_lookup(
+    baseline: list[dict[str, Any]], *, key_func: Callable[[dict[str, Any]], tuple]
+) -> dict[tuple, dict[str, Any]]:
+    """Build a ``{key_func(summary): summary}`` lookup.
+
+    Raises rather than silently letting a later row overwrite an earlier one
+    with the same key -- a silent overwrite would compare against the wrong
+    baseline row with no indication in the printed table (#336).
+    """
+    lookup: dict[tuple, dict[str, Any]] = {}
     for summary in baseline:
-        if "use_cache" not in summary:
-            legacy_comparison = (
-                summary["scenario"],
-                summary["estimator"],
-                str(summary["n_jobs"]),
-                summary["parallel_backend"],
-                summary["population_initializer"],
+        key = key_func(summary)
+        if key in lookup:
+            raise ValueError(
+                f"Duplicate baseline comparison key {key!r}: more than one "
+                f"baseline row maps to it. Baseline summaries must be unique "
+                f"per comparison key."
             )
-            legacy_baseline_by_key[legacy_comparison] = summary
+        lookup[key] = summary
+    return lookup
+
+
+def print_comparison_table(current: list[dict[str, Any]], baseline: list[dict[str, Any]]) -> None:
+    baseline_by_key = build_baseline_lookup(baseline, key_func=comparison_key)
+    legacy_baseline_by_key = build_baseline_lookup(
+        [summary for summary in baseline if "use_cache" not in summary],
+        key_func=_legacy_comparison_key,
+    )
 
     comparable = []
     for summary in current:
         base = baseline_by_key.get(comparison_key(summary))
         if base is None and summary.get("use_cache", True):
-            legacy_comparison = (
-                summary["scenario"],
-                summary["estimator"],
-                str(summary["n_jobs"]),
-                summary["parallel_backend"],
-                summary["population_initializer"],
-            )
-            base = legacy_baseline_by_key.get(legacy_comparison)
+            base = legacy_baseline_by_key.get(_legacy_comparison_key(summary))
         if base is not None:
             comparable.append((summary, base))
 

--- a/benchmarks/benchmark_search_methods.py
+++ b/benchmarks/benchmark_search_methods.py
@@ -36,6 +36,7 @@ from sklearn.model_selection import (
 from benchmark_fit import (
     SCENARIOS,
     Scenario,
+    build_baseline_lookup,
     build_gasearch,
     holdout_metrics,
     make_cv,
@@ -467,7 +468,7 @@ def comparison_key(summary: dict[str, Any]) -> tuple[str, str, str]:
 
 
 def print_comparison_table(current: list[dict[str, Any]], baseline: list[dict[str, Any]]) -> None:
-    baseline_by_key = {comparison_key(summary): summary for summary in baseline}
+    baseline_by_key = build_baseline_lookup(baseline, key_func=comparison_key)
     comparable = [
         (summary, baseline_by_key[comparison_key(summary)])
         for summary in current

--- a/sklearn_genetic/tests/test_benchmark_fit.py
+++ b/sklearn_genetic/tests/test_benchmark_fit.py
@@ -1,6 +1,9 @@
+import pytest
+
 from benchmarks.benchmark_fit import (
     SCENARIOS,
     aggregate_results,
+    build_baseline_lookup,
     comparison_key,
     print_comparison_table,
 )
@@ -160,3 +163,47 @@ def test_legacy_baseline_only_matches_cache_on_current(capsys):
     data_rows = [r for r in rows if r.startswith("classification_lr_collisions")]
     assert len(data_rows) == 1
     assert data_rows[0].split("\t")[5:7] == ["True", "True"]
+
+
+def test_build_baseline_lookup_raises_on_duplicate_key():
+    with pytest.raises(ValueError, match="Duplicate baseline comparison key"):
+        build_baseline_lookup(
+            [{"scenario": "a", "n": 1}, {"scenario": "a", "n": 2}],
+            key_func=lambda summary: (summary["scenario"],),
+        )
+
+
+def test_build_baseline_lookup_allows_distinct_keys():
+    lookup = build_baseline_lookup(
+        [{"scenario": "a"}, {"scenario": "b"}],
+        key_func=lambda summary: (summary["scenario"],),
+    )
+
+    assert set(lookup) == {("a",), ("b",)}
+
+
+def test_duplicate_true_comparison_keys_raise():
+    """Two genuinely identical comparison keys (#336) must not silently pick
+    whichever baseline row happens to be built last."""
+    cache_on = aggregate_results(
+        [_benchmark_result(use_cache=True, cache_hits=3, duplicate_candidates=1, cv_calls=4)]
+    )[0]
+    baseline_a = dict(cache_on, fit_seconds_mean=2.0)
+    baseline_b = dict(cache_on, fit_seconds_mean=9.0)
+
+    with pytest.raises(ValueError, match="Duplicate baseline comparison key"):
+        print_comparison_table([cache_on], [baseline_a, baseline_b])
+
+
+def test_duplicate_legacy_comparison_keys_raise():
+    """Same as above, for the legacy (no use_cache) baseline lookup (#336)."""
+    cache_on = aggregate_results(
+        [_benchmark_result(use_cache=True, cache_hits=3, duplicate_candidates=1, cv_calls=4)]
+    )[0]
+    old_baseline_a = dict(cache_on)
+    old_baseline_a.pop("use_cache")
+    old_baseline_a["fit_seconds_mean"] = 2.0
+    old_baseline_b = dict(old_baseline_a, fit_seconds_mean=9.0)
+
+    with pytest.raises(ValueError, match="Duplicate baseline comparison key"):
+        print_comparison_table([cache_on], [old_baseline_a, old_baseline_b])

--- a/sklearn_genetic/tests/test_benchmark_search_methods.py
+++ b/sklearn_genetic/tests/test_benchmark_search_methods.py
@@ -1,0 +1,59 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+# benchmark_search_methods.py does `from benchmark_fit import ...` (a bare,
+# sibling-relative import meant for running the script directly, where Python
+# puts its own directory on sys.path). Importing it as benchmarks.* for
+# testing does not add benchmarks/ itself to sys.path, so that import would
+# otherwise fail with ModuleNotFoundError.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "benchmarks"))
+
+from benchmarks.benchmark_search_methods import comparison_key, print_comparison_table  # noqa: E402
+
+
+def _summary(*, scenario="scenario_a", method="ga", n_jobs=1, fit_seconds_mean=1.0):
+    return {
+        "scenario": scenario,
+        "method": method,
+        "n_jobs": n_jobs,
+        "fit_seconds_mean": fit_seconds_mean,
+    }
+
+
+def test_comparison_key_uses_scenario_method_n_jobs():
+    summary = _summary(scenario="s", method="m", n_jobs=2)
+
+    assert comparison_key(summary) == ("s", "m", "2")
+
+
+def test_comparison_table_matches_same_key(capsys):
+    current = _summary(fit_seconds_mean=10.0)
+    baseline = _summary(fit_seconds_mean=2.0)
+
+    print_comparison_table([current], [baseline])
+
+    rows = capsys.readouterr().out.splitlines()
+    data_rows = [r for r in rows if r.startswith("scenario_a")]
+    assert len(data_rows) == 1
+    assert data_rows[0].split("\t")[3] == "8.0000"
+
+
+def test_comparison_table_reports_no_comparable_rows(capsys):
+    current = _summary(scenario="s1")
+    baseline = _summary(scenario="s2")
+
+    print_comparison_table([current], [baseline])
+
+    assert "No comparable baseline rows found." in capsys.readouterr().out
+
+
+def test_duplicate_comparison_keys_raise():
+    """Two baseline rows with the same (scenario, method, n_jobs) must not
+    silently let one win over the other (#336)."""
+    baseline_a = _summary(fit_seconds_mean=2.0)
+    baseline_b = _summary(fit_seconds_mean=9.0)
+
+    with pytest.raises(ValueError, match="Duplicate baseline comparison key"):
+        print_comparison_table([_summary()], [baseline_a, baseline_b])


### PR DESCRIPTION
Closes #336

Both benchmark_fit.py::print_comparison_table and
benchmark_search_methods.py::print_comparison_table built their baseline
lookup as {comparison_key(summary): summary for summary in baseline}, so
two baseline rows sharing a comparison key silently picked whichever was
built last -- comparing the current run against the wrong baseline row
with no indication in the printed table.

Added a shared build_baseline_lookup() helper in benchmark_fit.py
(benchmark_search_methods.py already imports shared code from there) that
raises a clear ValueError on a duplicate key. Both scripts'
print_comparison_table now use it, including the legacy (no use_cache)
baseline lookup in benchmark_fit.py.

Added sklearn_genetic/tests/test_benchmark_search_methods.py, which did
not exist before -- it needs a small sys.path shim since
benchmark_search_methods.py's own sibling-relative 'from benchmark_fit
import ...' only resolves when benchmarks/ itself is on sys.path (true
when run directly, not when imported as benchmarks.* for testing).

Verified all four new duplicate-key tests fail against the previous
silent-overwrite implementation and pass with the fix. Ran black --check,
the full suite (405 passed, 4 skipped), and a real
benchmark_search_methods.py --quick run to confirm the script still works.