### PR TITLE
fix: replace broad exception swallowing with specific exceptions and logging

### DIFF
--- a/sklearn_genetic/_base.py
+++ b/sklearn_genetic/_base.py
@@ -1,3 +1,4 @@
+import logging
 import pickle
 
 from sklearn.exceptions import NotFittedError
@@ -5,6 +6,8 @@ from sklearn.utils.validation import check_is_fitted
 
 from .algorithms import algorithms_factory
 from .parameters import Algorithms
+
+logger = logging.getLogger(__name__)
 
 
 def reset_adapters(estimator):
@@ -82,17 +85,24 @@ class GeneticEstimatorMixin:
     def save(self, filepath):
         """Save the current state of the estimator instance to a file."""
         class_name = self.__class__.__name__
-        try:
-            checkpoint_data = {"estimator_state": self._serializable_state(), "logbook": None}
-            if hasattr(self, "logbook"):
-                checkpoint_data["logbook"] = self.logbook
+        checkpoint_data = {"estimator_state": self._serializable_state(), "logbook": None}
+        if hasattr(self, "logbook"):
+            checkpoint_data["logbook"] = self.logbook
 
+        try:
             serialized_checkpoint = pickle.dumps(checkpoint_data)
+        except (pickle.PicklingError, TypeError, AttributeError) as e:
+            logger.error("Error serializing %s: %s", class_name, e)
+            raise
+
+        try:
             with open(filepath, "wb") as f:
                 f.write(serialized_checkpoint)
-            print(f"{class_name} model successfully saved to {filepath}")
-        except Exception as e:
-            print(f"Error saving {class_name}: {e}")
+        except OSError as e:
+            logger.error("Error saving %s to %s: %s", class_name, filepath, e)
+            raise
+
+        logger.info("%s model successfully saved to %s", class_name, filepath)
 
     def load(self, filepath):
         """Load an estimator instance from a file."""
@@ -100,12 +110,25 @@ class GeneticEstimatorMixin:
         try:
             with open(filepath, "rb") as f:
                 checkpoint_data = pickle.load(f)
-                for key, value in checkpoint_data["estimator_state"].items():
-                    setattr(self, key, value)
-                self.logbook = checkpoint_data["logbook"]
-            print(f"{class_name} model successfully loaded from {filepath}")
-        except Exception as e:
-            print(f"Error loading {class_name}: {e}")
+        except FileNotFoundError:
+            logger.error("Error loading %s: file not found: %s", class_name, filepath)
+            raise
+        except (pickle.UnpicklingError, EOFError, ValueError) as e:
+            logger.error("Error loading %s: corrupted checkpoint: %s", class_name, e)
+            raise
+        except OSError as e:
+            logger.error("Error loading %s from %s: %s", class_name, filepath, e)
+            raise
+
+        try:
+            for key, value in checkpoint_data["estimator_state"].items():
+                setattr(self, key, value)
+            self.logbook = checkpoint_data["logbook"]
+        except KeyError as e:
+            logger.error("Error loading %s: missing key in checkpoint: %s", class_name, e)
+            raise
+
+        logger.info("%s model successfully loaded from %s", class_name, filepath)
 
     def _select_algorithm(self, pop, stats, hof):
         selected_algorithm = algorithms_factory.get(self.algorithm, None)

--- a/sklearn_genetic/callbacks/model_checkpoint.py
+++ b/sklearn_genetic/callbacks/model_checkpoint.py
@@ -49,7 +49,7 @@ class ModelCheckpoint(BaseCallback):
         try:
             with open(self.checkpoint_path, "wb") as f:
                 pickle.dump(checkpoint_data, f)
-        except (OSError, pickle.PicklingError) as e:
+        except (OSError, pickle.PicklingError, AttributeError, TypeError) as e:
             logger.warning("Error saving checkpoint to %s: %s", self.checkpoint_path, e)
             return
 

--- a/sklearn_genetic/callbacks/model_checkpoint.py
+++ b/sklearn_genetic/callbacks/model_checkpoint.py
@@ -1,7 +1,11 @@
+import logging
 import pickle
+
 from .base import BaseCallback
 from .loggers import LogbookSaver
 from copy import deepcopy
+
+logger = logging.getLogger(__name__)
 
 
 class ModelCheckpoint(BaseCallback):
@@ -10,52 +14,60 @@ class ModelCheckpoint(BaseCallback):
         self.dump_options = dump_options
 
     def on_step(self, record=None, logbook=None, estimator=None):
-        try:
-            if logbook is not None and len(logbook) > 0:
-                logbook_saver = LogbookSaver(self.checkpoint_path, **self.dump_options)  # noqa
-                logbook_saver.on_step(record, logbook, estimator)
+        if logbook is not None and len(logbook) > 0:
+            logbook_saver = LogbookSaver(self.checkpoint_path, **self.dump_options)  # noqa
+            logbook_saver.on_step(record, logbook, estimator)
 
-            estimator_state = estimator._checkpoint_state()
-            # Runtime state is kept separate from ``estimator_state`` so the
-            # latter stays constructor-compatible (it is consumed as
-            # ``GASearchCV(**estimator_state)``). Restoring the fitness cache on
-            # resume lets already-evaluated candidates be reused (see fit()).
-            # ``fit_stats_`` is restored too so counters (cache hits, evaluated
-            # candidates, ...) accumulate across a resume instead of resetting.
-            #
-            # ``candidate_logbook`` is ``estimator.logbook`` itself -- the
-            # per-candidate log ("Contains the logs of every set of
-            # hyperparameters fitted with its average scoring metric", see the
-            # class docstring) that backs ``cv_results_``/``history``. It is
-            # NOT the same object as the ``logbook`` argument this method
-            # receives, which is the per-*generation* summary log the
-            # algorithms module builds for its own bookkeeping and callbacks;
-            # saving only that one under the legacy ``"logbook"`` key (kept
-            # below for backward compatibility) silently dropped every
-            # already-evaluated candidate on resume.
-            runtime_state = {
-                "fitness_cache": getattr(estimator, "fitness_cache", {}),
-                "fit_stats_": deepcopy(getattr(estimator, "fit_stats_", None)),
-                "candidate_logbook": deepcopy(getattr(estimator, "logbook", None)),
-            }
-            checkpoint_data = {
-                "estimator_state": estimator_state,
-                "logbook": deepcopy(logbook),
-                "runtime_state": runtime_state,
-            }
+        estimator_state = estimator._checkpoint_state()
+        # Runtime state is kept separate from ``estimator_state`` so the
+        # latter stays constructor-compatible (it is consumed as
+        # ``GASearchCV(**estimator_state)``). Restoring the fitness cache on
+        # resume lets already-evaluated candidates be reused (see fit()).
+        # ``fit_stats_`` is restored too so counters (cache hits, evaluated
+        # candidates, ...) accumulate across a resume instead of resetting.
+        #
+        # ``candidate_logbook`` is ``estimator.logbook`` itself -- the
+        # per-candidate log ("Contains the logs of every set of
+        # hyperparameters fitted with its average scoring metric", see the
+        # class docstring) that backs ``cv_results_``/``history``. It is
+        # NOT the same object as the ``logbook`` argument this method
+        # receives, which is the per-*generation* summary log the
+        # algorithms module builds for its own bookkeeping and callbacks;
+        # saving only that one under the legacy ``"logbook"`` key (kept
+        # below for backward compatibility) silently dropped every
+        # already-evaluated candidate on resume.
+        runtime_state = {
+            "fitness_cache": getattr(estimator, "fitness_cache", {}),
+            "fit_stats_": deepcopy(getattr(estimator, "fit_stats_", None)),
+            "candidate_logbook": deepcopy(getattr(estimator, "logbook", None)),
+        }
+        checkpoint_data = {
+            "estimator_state": estimator_state,
+            "logbook": deepcopy(logbook),
+            "runtime_state": runtime_state,
+        }
+        try:
             with open(self.checkpoint_path, "wb") as f:
                 pickle.dump(checkpoint_data, f)
-                print(f"Checkpoint saved to {self.checkpoint_path}")
+        except (OSError, pickle.PicklingError) as e:
+            logger.warning("Error saving checkpoint to %s: %s", self.checkpoint_path, e)
+            return
 
-        except Exception as e:
-            print(f"Error saving checkpoint: {e}")
+        logger.info("Checkpoint saved to %s", self.checkpoint_path)
 
     def load(self):
         """Load the model state from the checkpoint file."""
         try:
             with open(self.checkpoint_path, "rb") as f:
                 checkpoint_data = pickle.load(f)
-                return checkpoint_data
-        except Exception as e:
-            print(f"Error loading checkpoint: {e}")
-            return None
+        except FileNotFoundError:
+            logger.error("Error loading checkpoint: file not found: %s", self.checkpoint_path)
+            raise
+        except (pickle.UnpicklingError, EOFError, ValueError) as e:
+            logger.error("Error loading checkpoint: corrupted file: %s", e)
+            raise
+        except OSError as e:
+            logger.error("Error loading checkpoint from %s: %s", self.checkpoint_path, e)
+            raise
+
+        return checkpoint_data

--- a/sklearn_genetic/callbacks/model_checkpoint.py
+++ b/sklearn_genetic/callbacks/model_checkpoint.py
@@ -18,39 +18,7 @@ class ModelCheckpoint(BaseCallback):
             logbook_saver = LogbookSaver(self.checkpoint_path, **self.dump_options)  # noqa
             logbook_saver.on_step(record, logbook, estimator)
 
-        estimator_state = estimator._checkpoint_state()
-        # Runtime state is kept separate from ``estimator_state`` so the
-        # latter stays constructor-compatible (it is consumed as
-        # ``GASearchCV(**estimator_state)``). Restoring the fitness cache on
-        # resume lets already-evaluated candidates be reused (see fit()).
-        # ``fit_stats_`` is restored too so counters (cache hits, evaluated
-        # candidates, ...) accumulate across a resume instead of resetting.
-        #
-        # ``candidate_logbook`` is ``estimator.logbook`` itself -- the
-        # per-candidate log ("Contains the logs of every set of
-        # hyperparameters fitted with its average scoring metric", see the
-        # class docstring) that backs ``cv_results_``/``history``. It is
-        # NOT the same object as the ``logbook`` argument this method
-        # receives, which is the per-*generation* summary log the
-        # algorithms module builds for its own bookkeeping and callbacks;
-        # saving only that one under the legacy ``"logbook"`` key (kept
-        # below for backward compatibility) silently dropped every
-        # already-evaluated candidate on resume.
-        runtime_state = {
-            "fitness_cache": getattr(estimator, "fitness_cache", {}),
-            "fit_stats_": deepcopy(getattr(estimator, "fit_stats_", None)),
-            "candidate_logbook": deepcopy(getattr(estimator, "logbook", None)),
-        }
-        checkpoint_data = {
-            "estimator_state": estimator_state,
-            "logbook": deepcopy(logbook),
-            "runtime_state": runtime_state,
-        }
         try:
-            if logbook is not None and len(logbook) > 0:
-                logbook_saver = LogbookSaver(self.checkpoint_path, **self.dump_options)  # noqa
-                logbook_saver.on_step(record, logbook, estimator)
-
             estimator_state = estimator._checkpoint_state()
             # Runtime state is kept separate from ``estimator_state`` so the
             # latter stays constructor-compatible (it is consumed as

--- a/sklearn_genetic/tests/test_persistence_and_helpers.py
+++ b/sklearn_genetic/tests/test_persistence_and_helpers.py
@@ -27,7 +27,10 @@ def test_space_sample_warm_start_fills_missing_parameters():
     assert sampled_params == {"provided": 1, "sampled": 2}
 
 
-def test_ga_search_save_and_load_round_trip(tmp_path, capsys):
+def test_ga_search_save_and_load_round_trip(tmp_path, caplog):
+    import logging
+
+    caplog.set_level(logging.INFO)
     search = GASearchCV(
         estimator=DecisionTreeClassifier(),
         param_grid={"max_depth": Integer(1, 2)},
@@ -47,10 +50,9 @@ def test_ga_search_save_and_load_round_trip(tmp_path, capsys):
         scoring="accuracy",
     )
     restored.load(checkpoint_path)
-    output = capsys.readouterr().out
 
-    assert "GASearchCV model successfully saved" in output
-    assert "GASearchCV model successfully loaded" in output
+    assert "GASearchCV model successfully saved" in caplog.text
+    assert "GASearchCV model successfully loaded" in caplog.text
     assert restored.extra_state == "persisted"
     assert restored.logbook == [{"generation": 0}]
 
@@ -92,7 +94,7 @@ def test_fitted_ga_search_save_and_load_round_trip(tmp_path):
     assert restored.predict(X_test).shape[0] == X_test.shape[0]
 
 
-def test_ga_search_save_and_load_errors_are_reported(tmp_path, capsys):
+def test_ga_search_save_and_load_errors_are_reported(tmp_path, caplog):
     search = GASearchCV(
         estimator=DecisionTreeClassifier(),
         param_grid={"max_depth": Integer(1, 2)},
@@ -100,15 +102,19 @@ def test_ga_search_save_and_load_errors_are_reported(tmp_path, capsys):
         scoring="accuracy",
     )
 
-    search.save(tmp_path / "missing" / "ga_search.pkl")
-    search.load(tmp_path / "missing.pkl")
-    output = capsys.readouterr().out
+    with pytest.raises(OSError):
+        search.save(tmp_path / "missing" / "ga_search.pkl")
+    with pytest.raises(FileNotFoundError):
+        search.load(tmp_path / "missing.pkl")
 
-    assert "Error saving GASearchCV" in output
-    assert "Error loading GASearchCV" in output
+    assert "Error saving GASearchCV" in caplog.text
+    assert "Error loading GASearchCV" in caplog.text
 
 
-def test_ga_feature_selection_save_and_load_round_trip(tmp_path, capsys):
+def test_ga_feature_selection_save_and_load_round_trip(tmp_path, caplog):
+    import logging
+
+    caplog.set_level(logging.INFO)
     selector = GAFeatureSelectionCV(
         estimator=DecisionTreeClassifier(),
         cv=2,
@@ -130,15 +136,14 @@ def test_ga_feature_selection_save_and_load_round_trip(tmp_path, capsys):
         generations=2,
     )
     restored.load(checkpoint_path)
-    output = capsys.readouterr().out
 
-    assert "GAFeatureSelectionCV model successfully saved" in output
-    assert "GAFeatureSelectionCV model successfully loaded" in output
+    assert "GAFeatureSelectionCV model successfully saved" in caplog.text
+    assert "GAFeatureSelectionCV model successfully loaded" in caplog.text
     assert restored.extra_state == "persisted"
     assert restored.logbook == [{"generation": 0}]
 
 
-def test_ga_feature_selection_save_and_load_errors_are_reported(tmp_path, capsys):
+def test_ga_feature_selection_save_and_load_errors_are_reported(tmp_path, caplog):
     selector = GAFeatureSelectionCV(
         estimator=DecisionTreeClassifier(),
         cv=2,
@@ -147,12 +152,13 @@ def test_ga_feature_selection_save_and_load_errors_are_reported(tmp_path, capsys
         generations=2,
     )
 
-    selector.save(tmp_path / "missing" / "ga_feature_selection.pkl")
-    selector.load(tmp_path / "missing.pkl")
-    output = capsys.readouterr().out
+    with pytest.raises(OSError):
+        selector.save(tmp_path / "missing" / "ga_feature_selection.pkl")
+    with pytest.raises(FileNotFoundError):
+        selector.load(tmp_path / "missing.pkl")
 
-    assert "Error saving GAFeatureSelectionCV" in output
-    assert "Error loading GAFeatureSelectionCV" in output
+    assert "Error saving GAFeatureSelectionCV" in caplog.text
+    assert "Error loading GAFeatureSelectionCV" in caplog.text
 
 
 def test_ga_feature_selection_support_mask_requires_fit():
@@ -179,7 +185,10 @@ def _checkpoint_estimator():
     )
 
 
-def test_model_checkpoint_save_load_and_error_paths(tmp_path, capsys):
+def test_model_checkpoint_save_load_and_error_paths(tmp_path, caplog):
+    import logging
+
+    caplog.set_level(logging.INFO)
     estimator = _checkpoint_estimator()
     checkpoint_path = tmp_path / "checkpoint.pkl"
     checkpoint = ModelCheckpoint(checkpoint_path)
@@ -189,15 +198,15 @@ def test_model_checkpoint_save_load_and_error_paths(tmp_path, capsys):
 
     failing_checkpoint = ModelCheckpoint(tmp_path / "missing" / "checkpoint.pkl")
     failing_checkpoint.on_step(logbook=None, estimator=estimator)
-    missing_checkpoint = ModelCheckpoint(tmp_path / "missing.pkl").load()
-    output = capsys.readouterr().out
 
-    assert "Checkpoint saved to" in output
-    assert "Error saving checkpoint" in output
-    assert "Error loading checkpoint" in output
+    with pytest.raises(FileNotFoundError):
+        ModelCheckpoint(tmp_path / "missing.pkl").load()
+
+    assert "Checkpoint saved to" in caplog.text
+    assert "Error saving checkpoint" in caplog.text
+    assert "Error loading checkpoint" in caplog.text
     assert loaded_checkpoint["estimator_state"]["scoring"] == "accuracy"
     assert loaded_checkpoint["logbook"] is None
-    assert missing_checkpoint is None
 
 
 def test_model_checkpoint_estimator_state_keys(tmp_path):
@@ -263,7 +272,7 @@ def test_checkpoint_state_honors_serialization_contract(estimator):
     assert set(checkpoint).issubset(full), set(checkpoint) - set(full)
 
 
-def test_model_checkpoint_supports_feature_selection_estimator(tmp_path, capsys):
+def test_model_checkpoint_supports_feature_selection_estimator(tmp_path, caplog):
     """Checkpointing and resuming a GAFeatureSelectionCV must work (#297).
 
     GAFeatureSelectionCV has no ``param_grid`` attribute; the checkpoint state
@@ -285,8 +294,7 @@ def test_model_checkpoint_supports_feature_selection_estimator(tmp_path, capsys)
         )
 
     build().fit(X, y, callbacks=ModelCheckpoint(checkpoint_path=checkpoint_path))
-    output = capsys.readouterr().out
-    assert "Error saving checkpoint" not in output
+    assert "Error saving checkpoint" not in caplog.text
 
     loaded = ModelCheckpoint(checkpoint_path=checkpoint_path).load()
     assert "estimator_state" in loaded

--- a/sklearn_genetic/tests/test_persistence_and_helpers.py
+++ b/sklearn_genetic/tests/test_persistence_and_helpers.py
@@ -477,3 +477,100 @@ def test_checkpoint_resume_preserves_random_state(tmp_path):
     assert resumed_a.best_params_ == resumed_b.best_params_
     assert resumed_a.best_score_ == resumed_b.best_score_
     assert list(resumed_a.history["fitness"]) == list(resumed_b.history["fitness"])
+
+
+import pickle
+from unittest.mock import patch
+
+
+def test_save_raises_on_serialization_error(tmp_path, caplog):
+    import logging
+
+    caplog.set_level(logging.ERROR)
+    search = GASearchCV(
+        estimator=DecisionTreeClassifier(),
+        param_grid={"max_depth": Integer(1, 2)},
+        cv=2,
+        scoring="accuracy",
+    )
+    with patch("sklearn_genetic._base.pickle.dumps", side_effect=pickle.PicklingError("boom")):
+        with pytest.raises(pickle.PicklingError, match="boom"):
+            search.save(tmp_path / "test.pkl")
+    assert "Error serializing GASearchCV" in caplog.text
+
+
+def test_load_raises_on_corrupted_file(tmp_path, caplog):
+    import logging
+
+    caplog.set_level(logging.ERROR)
+    corrupted = tmp_path / "corrupted.pkl"
+    corrupted.write_bytes(b"not a valid pickle")
+    search = GASearchCV(
+        estimator=DecisionTreeClassifier(),
+        param_grid={"max_depth": Integer(1, 2)},
+        cv=2,
+        scoring="accuracy",
+    )
+    with pytest.raises(pickle.UnpicklingError):
+        search.load(corrupted)
+    assert "corrupted checkpoint" in caplog.text
+
+
+def test_load_raises_on_missing_key(tmp_path, caplog):
+    import logging
+
+    caplog.set_level(logging.ERROR)
+    incomplete = tmp_path / "incomplete.pkl"
+    incomplete_data = {"estimator_state": {"some_key": "val"}}
+    with open(incomplete, "wb") as f:
+        pickle.dump(incomplete_data, f)
+    search = GASearchCV(
+        estimator=DecisionTreeClassifier(),
+        param_grid={"max_depth": Integer(1, 2)},
+        cv=2,
+        scoring="accuracy",
+    )
+    with pytest.raises(KeyError):
+        search.load(incomplete)
+    assert "missing key in checkpoint" in caplog.text
+
+
+def test_checkpoint_load_raises_on_corrupted_file(tmp_path, caplog):
+    import logging
+
+    caplog.set_level(logging.ERROR)
+    corrupted = tmp_path / "corrupted_checkpoint.pkl"
+    corrupted.write_bytes(b"not a valid pickle")
+    checkpoint = ModelCheckpoint(corrupted)
+    with pytest.raises(pickle.UnpicklingError):
+        checkpoint.load()
+    assert "corrupted file" in caplog.text
+
+
+def test_checkpoint_load_raises_on_oserror(tmp_path, caplog):
+    import logging
+
+    caplog.set_level(logging.ERROR)
+    inaccessible = tmp_path / "no_such_dir" / "checkpoint.pkl"
+    checkpoint = ModelCheckpoint(inaccessible)
+    with pytest.raises(FileNotFoundError):
+        checkpoint.load()
+    assert "file not found" in caplog.text
+
+
+def test_checkpoint_on_step_warns_on_oserror(tmp_path, caplog):
+    import logging
+
+    caplog.set_level(logging.WARNING)
+    estimator = GASearchCV(
+        estimator=DecisionTreeClassifier(),
+        param_grid={"max_depth": Integer(1, 2), "min_samples_split": Integer(2, 5)},
+        cv=2,
+        scoring="accuracy",
+        population_size=4,
+        generations=2,
+    )
+    bad_path = tmp_path / "missing_dir" / "checkpoint.pkl"
+    checkpoint = ModelCheckpoint(bad_path)
+    checkpoint.on_step(logbook=None, estimator=estimator)
+    assert "Error saving checkpoint" in caplog.text

--- a/sklearn_genetic/tests/test_persistence_and_helpers.py
+++ b/sklearn_genetic/tests/test_persistence_and_helpers.py
@@ -574,3 +574,36 @@ def test_checkpoint_on_step_warns_on_oserror(tmp_path, caplog):
     checkpoint = ModelCheckpoint(bad_path)
     checkpoint.on_step(logbook=None, estimator=estimator)
     assert "Error saving checkpoint" in caplog.text
+
+
+def test_load_raises_on_oserror(tmp_path, caplog):
+    import logging
+    from unittest.mock import mock_open, patch
+
+    caplog.set_level(logging.ERROR)
+    search = GASearchCV(
+        estimator=DecisionTreeClassifier(),
+        param_grid={"max_depth": Integer(1, 2)},
+        cv=2,
+        scoring="accuracy",
+    )
+    good_file = tmp_path / "good.pkl"
+    search.save(good_file)
+    with patch("builtins.open", side_effect=PermissionError("denied")):
+        with pytest.raises(PermissionError, match="denied"):
+            search.load(good_file)
+    assert "Error loading GASearchCV" in caplog.text
+
+
+def test_checkpoint_load_raises_on_oserror(tmp_path, caplog):
+    import logging
+    from unittest.mock import patch
+
+    caplog.set_level(logging.ERROR)
+    good_file = tmp_path / "checkpoint.pkl"
+    good_file.write_bytes(b"\x80\x04\x95\x05\x00\x00\x00\x00\x00\x00\x00N.")
+    checkpoint = ModelCheckpoint(good_file)
+    with patch("builtins.open", side_effect=PermissionError("denied")):
+        with pytest.raises(PermissionError, match="denied"):
+            checkpoint.load()
+    assert "Error loading checkpoint from" in caplog.text

--- a/sklearn_genetic/tests/test_persistence_and_helpers.py
+++ b/sklearn_genetic/tests/test_persistence_and_helpers.py
@@ -547,7 +547,7 @@ def test_checkpoint_load_raises_on_corrupted_file(tmp_path, caplog):
     assert "corrupted file" in caplog.text
 
 
-def test_checkpoint_load_raises_on_oserror(tmp_path, caplog):
+def test_checkpoint_load_raises_on_file_not_found(tmp_path, caplog):
     import logging
 
     caplog.set_level(logging.ERROR)
@@ -573,6 +573,29 @@ def test_checkpoint_on_step_warns_on_oserror(tmp_path, caplog):
     bad_path = tmp_path / "missing_dir" / "checkpoint.pkl"
     checkpoint = ModelCheckpoint(bad_path)
     checkpoint.on_step(logbook=None, estimator=estimator)
+    assert "Error saving checkpoint" in caplog.text
+
+
+def test_checkpoint_on_step_warns_on_non_serializable_state(tmp_path, caplog):
+    import logging
+    import pickle
+    from unittest.mock import patch
+
+    caplog.set_level(logging.WARNING)
+    estimator = GASearchCV(
+        estimator=DecisionTreeClassifier(),
+        param_grid={"max_depth": Integer(1, 2), "min_samples_split": Integer(2, 5)},
+        cv=2,
+        scoring="accuracy",
+        population_size=4,
+        generations=2,
+    )
+    good_path = tmp_path / "checkpoint.pkl"
+    checkpoint = ModelCheckpoint(good_path)
+    with patch.object(
+        pickle, "dump", side_effect=AttributeError("cannot pickle lambda")
+    ):
+        checkpoint.on_step(logbook=None, estimator=estimator)
     assert "Error saving checkpoint" in caplog.text
 
 

--- a/sklearn_genetic/tests/test_persistence_and_helpers.py
+++ b/sklearn_genetic/tests/test_persistence_and_helpers.py
@@ -592,9 +592,7 @@ def test_checkpoint_on_step_warns_on_non_serializable_state(tmp_path, caplog):
     )
     good_path = tmp_path / "checkpoint.pkl"
     checkpoint = ModelCheckpoint(good_path)
-    with patch.object(
-        pickle, "dump", side_effect=AttributeError("cannot pickle lambda")
-    ):
+    with patch.object(pickle, "dump", side_effect=AttributeError("cannot pickle lambda")):
         checkpoint.on_step(logbook=None, estimator=estimator)
     assert "Error saving checkpoint" in caplog.text
 

--- a/sklearn_genetic/tests/test_persistence_and_helpers.py
+++ b/sklearn_genetic/tests/test_persistence_and_helpers.py
@@ -628,6 +628,8 @@ def test_checkpoint_load_raises_on_oserror(tmp_path, caplog):
         with pytest.raises(PermissionError, match="denied"):
             checkpoint.load()
     assert "Error loading checkpoint from" in caplog.text
+
+
 def test_checkpoint_resume_restores_adapter_state(tmp_path):
     """Adapter step counters must survive checkpoint resume.
 


### PR DESCRIPTION

## Problem

`save()`, `load()`, and `ModelCheckpoint` used bare `except Exception` with `print()`, silently swallowing all errors (including `PermissionError`, `MemoryError`, `OSError`). Users had no way to know if save/load failed.

## Changes

- **`_base.py`**: `save()`/`load()` now catch specific exceptions (`OSError`, `pickle.PicklingError`, `FileNotFoundError`, `KeyError`) and re-raise after logging
- **`model_checkpoint.py`**: `on_step()` catches only `OSError`/`pickle.PicklingError` (checkpoint failure shouldn't crash optimization); `load()` re-raises after logging
- All `print()` calls replaced with Python `logging` module (`logger.info`/`error`/`warning`)
- Tests updated to use `caplog` instead of `capsys` for log assertions
<img width="1360" height="421" alt="Screenshot 2026-07-17 153220" src="https://github.com/user-attachments/assets/df0c558e-337d-4fd1-b256-33cdcc2867ac" />
