### PR TITLE
fix: parse :target: option lines in root docs RST directives

### DIFF
--- a/docs-vitepress/scripts/check_links.py
+++ b/docs-vitepress/scripts/check_links.py
@@ -47,7 +47,11 @@ LINK_RE = re.compile(r"!?\[[^\]]*\]\(\s*([^)\s]+)")
 # single-token so normal prose with angle brackets is not treated as a path.
 RST_LINK_RE = re.compile(r"`[^`<\n]+<([^\s>]+)>`_|^\.\.\s+_[^:]+:\s+(\S+)", re.MULTILINE)
 RST_DIRECTIVE_TARGET_RE = re.compile(r"^\.\.\s+(?:image|figure)::\s+(\S+)", re.MULTILINE)
-
+RST_DIRECTIVE_OPTION_BLOCK_RE = re.compile(
+    r"^\.\.\s+(?:image|figure)::[^\n]*\n((?:[ \t]+:\S+:.*\n?)*)",
+    re.MULTILINE,
+)
+RST_TARGET_OPTION_RE = re.compile(r"^[ \t]*:target:\s+(\S+)", re.MULTILINE)
 _EXTERNAL_PREFIXES = ("http://", "https://", "mailto:", "//")
 
 
@@ -92,6 +96,8 @@ def _iter_targets(doc_file: Path) -> list[str]:
         for inline, named in RST_LINK_RE.findall(text):
             targets.append(inline or named)
         targets.extend(RST_DIRECTIVE_TARGET_RE.findall(text))
+        for option_block in RST_DIRECTIVE_OPTION_BLOCK_RE.findall(text):
+            targets.extend(RST_TARGET_OPTION_RE.findall(option_block))
         return targets
     return LINK_RE.findall(text)
 

--- a/docs-vitepress/scripts/test_check_links.py
+++ b/docs-vitepress/scripts/test_check_links.py
@@ -111,3 +111,68 @@ def test_root_doc_rst_image_directive_broken_same_repo_blob_is_reported(tmp_path
     monkeypatch.setattr(check_links, "VERSION_DIRS", [])
     monkeypatch.setattr(check_links, "ROOT_DOCS", [root_doc])
     assert check_links.check() == [(root_doc, target)]
+
+
+def test_root_doc_rst_image_directive_target_option_local_link_passes(tmp_path, monkeypatch):
+    logo = tmp_path / "docs-vitepress" / "public" / "logo.png"
+    logo.parent.mkdir(parents=True)
+    logo.write_text("x", encoding="utf-8")
+    guide_index = tmp_path / "docs-vitepress" / "versions" / "latest" / "guide" / "index.md"
+    guide_index.parent.mkdir(parents=True)
+    guide_index.write_text("x", encoding="utf-8")
+    root_doc = tmp_path / "README.rst"
+    root_doc.write_text(
+        ".. image:: docs-vitepress/public/logo.png\n"
+        "   :target: docs-vitepress/versions/latest/guide/\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(check_links, "ROOT", tmp_path)
+    monkeypatch.setattr(check_links, "VERSION_DIRS", [])
+    monkeypatch.setattr(check_links, "ROOT_DOCS", [root_doc])
+    assert check_links.check() == []
+
+
+def test_root_doc_rst_image_directive_target_option_missing_local_link_is_reported(
+    tmp_path, monkeypatch
+):
+    logo = tmp_path / "docs-vitepress" / "public" / "logo.png"
+    logo.parent.mkdir(parents=True)
+    logo.write_text("x", encoding="utf-8")
+    root_doc = tmp_path / "README.rst"
+    root_doc.write_text(
+        ".. image:: docs-vitepress/public/logo.png\n"
+        "   :target: docs-vitepress/versions/latest/missing/\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(check_links, "ROOT", tmp_path)
+    monkeypatch.setattr(check_links, "VERSION_DIRS", [])
+    monkeypatch.setattr(check_links, "ROOT_DOCS", [root_doc])
+    assert check_links.check() == [(root_doc, "docs-vitepress/versions/latest/missing/")]
+
+
+def test_root_doc_rst_image_directive_target_option_external_url_is_skipped(tmp_path, monkeypatch):
+    logo = tmp_path / "docs-vitepress" / "public" / "logo.png"
+    logo.parent.mkdir(parents=True)
+    logo.write_text("x", encoding="utf-8")
+    root_doc = tmp_path / "README.rst"
+    root_doc.write_text(
+        ".. image:: docs-vitepress/public/logo.png\n" "   :target: https://example.com/missing\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(check_links, "ROOT", tmp_path)
+    monkeypatch.setattr(check_links, "VERSION_DIRS", [])
+    monkeypatch.setattr(check_links, "ROOT_DOCS", [root_doc])
+    assert check_links.check() == []
+
+
+def test_root_doc_rst_target_option_prose_without_directive_is_ignored(tmp_path, monkeypatch):
+    root_doc = tmp_path / "README.rst"
+    root_doc.write_text(
+        "See the config key :target: some/missing/path mentioned in prose here,\n"
+        "not inside an image or figure directive.\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(check_links, "ROOT", tmp_path)
+    monkeypatch.setattr(check_links, "VERSION_DIRS", [])
+    monkeypatch.setattr(check_links, "ROOT_DOCS", [root_doc])
+    assert check_links.check() == []


### PR DESCRIPTION
## Summary

Extends `_iter_targets` in the root-docs link checker to also parse RST
directive option lines (`:target:`) belonging to `image`/`figure`
directives, e.g.:

    .. image:: docs-vitepress/public/logo.png
       :target: docs-vitepress/versions/latest/guide/

Previously only the directive's primary path was checked, so a stale local
`:target:` path could pass unnoticed.

The new `RST_DIRECTIVE_OPTION_BLOCK_RE` regex captures the block of option
lines immediately following an `image`/`figure` directive, and
`RST_TARGET_OPTION_RE` extracts `:target:` values from within that block
only — so `:target:`-like text in ordinary prose (with no directive above
it) is never matched.

## Related Issue

Closes #337

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] Other (describe):

## Validation

- `python -m pytest docs-vitepress/scripts/test_check_links.py` — 20 passed
  (4 new tests: valid local target, missing local target, external target
  skipped, prose without directive ignored)
- `python docs-vitepress/scripts/check_links.py` — all internal links resolve
- `python -m pytest sklearn_genetic/` — 409 passed
- `python -m black --check docs-vitepress/scripts/check_links.py
  docs-vitepress/scripts/test_check_links.py` — unchanged

## Checklist

- [x] I checked the linked issue is open and not already covered by another PR
- [x] Tests pass locally (`pytest sklearn_genetic/`)
- [x] Code is formatted with Black (`black sklearn_genetic/`)
- [x] New functionality is covered by tests
- [x] Documentation updated if needed (no user-facing documentation change
      is required)