### PR TITLE
fix: restore adapter state on checkpoint resume

### DIFF
--- a/sklearn_genetic/callbacks/model_checkpoint.py
+++ b/sklearn_genetic/callbacks/model_checkpoint.py
@@ -38,6 +38,13 @@ class ModelCheckpoint(BaseCallback):
                 "fit_stats_": deepcopy(getattr(estimator, "fit_stats_", None)),
                 "candidate_logbook": deepcopy(getattr(estimator, "logbook", None)),
             }
+            crossover_adapter = getattr(estimator, "crossover_adapter", None)
+            mutation_adapter = getattr(estimator, "mutation_adapter", None)
+            if crossover_adapter is not None and mutation_adapter is not None:
+                runtime_state["adapter_state"] = {
+                    "crossover": crossover_adapter.state_dict(),
+                    "mutation": mutation_adapter.state_dict(),
+                }
             checkpoint_data = {
                 "estimator_state": estimator_state,
                 "logbook": deepcopy(logbook),

--- a/sklearn_genetic/genetic_search.py
+++ b/sklearn_genetic/genetic_search.py
@@ -1085,6 +1085,7 @@ class GASearchCV(GeneticEstimatorMixin, BaseSearchCV):
         restored_logbook = None
         restored_fit_stats = None
         restored_generation_log = None
+        restored_adapter_state = None
 
         # Load state if a checkpoint exists
         for callback in self.callbacks:
@@ -1116,6 +1117,7 @@ class GASearchCV(GeneticEstimatorMixin, BaseSearchCV):
                         # numbering needs to continue from -- see
                         # ``_seed_logbook`` in ``algorithms.py``.
                         restored_generation_log = checkpoint_data.get("logbook")
+                        restored_adapter_state = runtime_state.get("adapter_state")
                         checkpoint_loaded = True
                     break
 
@@ -1125,7 +1127,13 @@ class GASearchCV(GeneticEstimatorMixin, BaseSearchCV):
         # pre-resume value instead (see #299).
         _seed_global_rngs(self.random_state)
 
-        if not checkpoint_loaded:
+        if checkpoint_loaded and restored_adapter_state is not None:
+            # Restore the crossover/mutation adapter step counters so the
+            # schedule continues from where the previous run left off
+            # instead of restarting from step 0 (see adapter checkpoint).
+            self.crossover_adapter.load_state_dict(restored_adapter_state["crossover"])
+            self.mutation_adapter.load_state_dict(restored_adapter_state["mutation"])
+        elif not checkpoint_loaded:
             _reset_adapters(self)
 
         # Preserve cumulative counters across a resume instead of zeroing them,
@@ -2048,6 +2056,7 @@ class GAFeatureSelectionCV(GeneticEstimatorMixin, MetaEstimatorMixin, SelectorMi
         restored_logbook = None
         restored_fit_stats = None
         restored_generation_log = None
+        restored_adapter_state = None
 
         # Load state if a checkpoint exists
         for callback in self.callbacks:
@@ -2079,6 +2088,7 @@ class GAFeatureSelectionCV(GeneticEstimatorMixin, MetaEstimatorMixin, SelectorMi
                         # numbering needs to continue from -- see
                         # ``_seed_logbook`` in ``algorithms.py``.
                         restored_generation_log = checkpoint_data.get("logbook")
+                        restored_adapter_state = runtime_state.get("adapter_state")
                         checkpoint_loaded = True
                     break
 
@@ -2088,7 +2098,13 @@ class GAFeatureSelectionCV(GeneticEstimatorMixin, MetaEstimatorMixin, SelectorMi
         # pre-resume value instead (see #299).
         _seed_global_rngs(self.random_state)
 
-        if not checkpoint_loaded:
+        if checkpoint_loaded and restored_adapter_state is not None:
+            # Restore the crossover/mutation adapter step counters so the
+            # schedule continues from where the previous run left off
+            # instead of restarting from step 0 (see adapter checkpoint).
+            self.crossover_adapter.load_state_dict(restored_adapter_state["crossover"])
+            self.mutation_adapter.load_state_dict(restored_adapter_state["mutation"])
+        elif not checkpoint_loaded:
             _reset_adapters(self)
 
         # Preserve cumulative counters across a resume instead of zeroing them,

--- a/sklearn_genetic/schedules/base.py
+++ b/sklearn_genetic/schedules/base.py
@@ -46,3 +46,15 @@ class BaseAdapter(ABC):
         self.current_value = self.initial_value
         self.current_step = 0
         return self
+
+    def state_dict(self):
+        """Return a serializable snapshot of the adapter's mutable state."""
+        return {
+            "current_step": self.current_step,
+            "current_value": self.current_value,
+        }
+
+    def load_state_dict(self, state):
+        """Restore mutable state from a :meth:`state_dict` snapshot."""
+        self.current_step = state["current_step"]
+        self.current_value = state["current_value"]

--- a/sklearn_genetic/tests/test_persistence_and_helpers.py
+++ b/sklearn_genetic/tests/test_persistence_and_helpers.py
@@ -469,3 +469,100 @@ def test_checkpoint_resume_preserves_random_state(tmp_path):
     assert resumed_a.best_params_ == resumed_b.best_params_
     assert resumed_a.best_score_ == resumed_b.best_score_
     assert list(resumed_a.history["fitness"]) == list(resumed_b.history["fitness"])
+
+
+def test_checkpoint_resume_restores_adapter_state(tmp_path):
+    """Adapter step counters must survive checkpoint resume.
+
+    The crossover/mutation adapters are stateful: they track ``current_step``
+    and ``current_value`` which control the probability schedule across
+    generations. Before this fix the adapters were not included in the
+    checkpoint's ``runtime_state``, so a resumed run restarted from step 0
+    instead of continuing from where the previous run left off.
+    """
+    from ..schedules.schedulers import ExponentialAdapter
+
+    X, y = load_iris(return_X_y=True)
+    checkpoint_path = str(tmp_path / "adapter_checkpoint.pkl")
+
+    def build():
+        return GASearchCV(
+            estimator=DecisionTreeClassifier(random_state=0),
+            param_grid={"max_depth": Integer(1, 3)},
+            cv=2,
+            scoring="accuracy",
+            population_size=4,
+            generations=3,
+            crossover_probability=ExponentialAdapter(0.8, 0.2, 0.1),
+            mutation_probability=ExponentialAdapter(0.6, 0.1, 0.1),
+        )
+
+    first = build()
+    first.fit(X, y, callbacks=ModelCheckpoint(checkpoint_path=checkpoint_path))
+
+    cx_step_after_first = first.crossover_adapter.current_step
+    mut_step_after_first = first.mutation_adapter.current_step
+    cx_value_after_first = first.crossover_adapter.current_value
+    mut_value_after_first = first.mutation_adapter.current_value
+    assert cx_step_after_first > 0
+    assert mut_step_after_first > 0
+
+    resumed = build()
+    resumed.fit(X, y, callbacks=ModelCheckpoint(checkpoint_path=checkpoint_path))
+
+    # After resume, the adapter must continue from the first run's final
+    # state, not restart from step 0. With 3 more generations the final
+    # step count should be first_run_steps + 3.
+    assert resumed.crossover_adapter.current_step == cx_step_after_first + 3
+    assert resumed.mutation_adapter.current_step == mut_step_after_first + 3
+    # Values must continue decaying, not restart from initial values.
+    assert resumed.crossover_adapter.current_value < cx_value_after_first
+    assert resumed.mutation_adapter.current_value < mut_value_after_first
+
+
+def test_checkpoint_resume_restores_adapter_state_feature_selection(tmp_path):
+    """GAFeatureSelectionCV must also restore adapter state on resume."""
+    from ..schedules.schedulers import InverseAdapter
+
+    X, y = load_iris(return_X_y=True)
+    checkpoint_path = str(tmp_path / "fs_adapter_checkpoint.pkl")
+
+    def build():
+        return GAFeatureSelectionCV(
+            estimator=DecisionTreeClassifier(random_state=0),
+            cv=2,
+            scoring="accuracy",
+            population_size=4,
+            generations=3,
+            crossover_probability=InverseAdapter(0.8, 0.2, 0.1),
+            mutation_probability=InverseAdapter(0.6, 0.1, 0.1),
+        )
+
+    first = build()
+    first.fit(X, y, callbacks=ModelCheckpoint(checkpoint_path=checkpoint_path))
+
+    cx_step_after_first = first.crossover_adapter.current_step
+    mut_step_after_first = first.mutation_adapter.current_step
+
+    resumed = build()
+    resumed.fit(X, y, callbacks=ModelCheckpoint(checkpoint_path=checkpoint_path))
+
+    assert resumed.crossover_adapter.current_step == cx_step_after_first + 3
+    assert resumed.mutation_adapter.current_step == mut_step_after_first + 3
+
+
+def test_adapter_state_dict_round_trip():
+    """BaseAdapter.state_dict/load_state_dict preserve mutable state."""
+    from ..schedules.schedulers import ExponentialAdapter, InverseAdapter, PotentialAdapter
+
+    for cls in (ExponentialAdapter, InverseAdapter, PotentialAdapter):
+        adapter = cls(initial_value=0.8, end_value=0.2, adaptive_rate=0.1)
+        for _ in range(5):
+            adapter.step()
+        state = adapter.state_dict()
+
+        fresh = cls(initial_value=0.8, end_value=0.2, adaptive_rate=0.1)
+        assert fresh.current_step == 0
+        fresh.load_state_dict(state)
+        assert fresh.current_step == adapter.current_step
+        assert fresh.current_value == pytest.approx(adapter.current_value)


### PR DESCRIPTION
## Problem

When using `ModelCheckpoint` to resume a search, the crossover/mutation adapter step counters (`current_step`, `current_value`) were not saved or restored. This caused adaptive probability schedules (`ExponentialAdapter`, `InverseAdapter`, `PotentialAdapter`) to restart from step 0 instead of continuing from where the previous run left off.

## Reproducible Example


from sklearn.datasets import load_iris
from sklearn.tree import DecisionTreeClassifier
from sklearn_genetic import GASearchCV
from sklearn_genetic.space import Integer
from sklearn_genetic.callbacks.model_checkpoint import ModelCheckpoint
from sklearn_genetic.schedules.schedulers import ExponentialAdapter

X, y = load_iris(return_X_y=True)

def build():
    return GASearchCV(
        estimator=DecisionTreeClassifier(random_state=0),
        param_grid={"max_depth": Integer(1, 3)},
        cv=2, scoring="accuracy", population_size=4, generations=3,
        crossover_probability=ExponentialAdapter(0.8, 0.2, 0.1),
        mutation_probability=ExponentialAdapter(0.6, 0.1, 0.1),
    )

first = build()
first.fit(X, y, callbacks=ModelCheckpoint(checkpoint_path="cp.pkl"))
print(first.crossover_adapter.current_step)  # 3

resumed = build()
resumed.fit(X, y, callbacks=ModelCheckpoint(checkpoint_path="cp.pkl"))
print(resumed.crossover_adapter.current_step)
# Expected: 6  (3 + 3 more generations)
# Before fix: 3  (restarted from 0)
## Root Cause
ModelCheckpoint.on_step() saves _checkpoint_state() (constructor params) and runtime_state (fitness cache, logbook, fit stats) — but not the adapter objects. On resume, __dict__.update() restores constructor params while _reset_adapters() is skipped (checkpoint_loaded=True), leaving adapters stuck at current_step=0.
Fix
- schedules/base.py — Add state_dict() / load_state_dict() to BaseAdapter for serializing mutable state.
- callbacks/model_checkpoint.py — Save adapter state into runtime_state["adapter_state"].
- genetic_search.py — Restore adapter state on resume in both GASearchCV.fit() and GAFeatureSelectionCV.fit().
- Tests — 3 new tests covering adapter checkpoint resume for both estimators and state_dict round-trip.
Backward Compatibility
Old checkpoints without adapter_state in runtime_state still work — adapters default to step 0 (same behavior as before this fix).
<img width="1920" height="1080" alt="Screenshot (400)" src="https://github.com/user-attachments/assets/d71eeadd-21b0-428c-8d0d-0f896d36bc95" />
