### PR TITLE
fix: remove global RNG seed side effect from Categorical.__init__

### DIFF
--- a/sklearn_genetic/space/space.py
+++ b/sklearn_genetic/space/space.py
@@ -187,7 +187,6 @@ class Categorical(BaseDimension):
         self.choices = choices
         self.distribution = distribution
         self.random_state = random_state
-        random.seed(random_state)
         self.rng = (
             np.random.default_rng(self.random_state) if self.random_state is not None else None
         )


### PR DESCRIPTION
## Problem

Categorical.__init__ called  random.seed(random_state) which unconditionally mutated the global Python random module state. Integer and Continuous do not have this side effect.

## Fix

Removed the  random.seed(random_state)  line. When random_state is provided, `self.rng` (numpy `Generator`) is already used for sampling. When `None`, the global RNG is used as-is.

## Before/After

python
# Before: constructing this mutated global random state
Categorical(["a", "b"], random_state=42)  # calls random.seed(42)

# After: no side effect, sampling still deterministic via self.rng
Categorical(["a", "b"], random_state=42)  # uses np.random.default_rng(42)