### PR TITLE
fix: add __getstate__/__setstate__ for proper pickling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Full release notes with code examples are in the [documentation](https://sklearn
 
 ## Unreleased
 
+### Bug Fixes
+
+- Fixed pickling of fitted `GASearchCV` and `GAFeatureSelectionCV` instances. `pickle.dumps`/`pickle.loads` and `joblib.dump`/`joblib.load` previously failed on the DEAP toolbox captured in `__dict__` (`Can't pickle <function ...>`) and now exclude the unpicklable DEAP internals (`toolbox`, `_stats`, `_pop`, `_hof`) via `__getstate__`/`__setstate__`. `save()`/`load()` use the same protocol, and `load()` also accepts files written directly with `pickle.dump(self, f)` (#358).
 ## 0.13.4
 
 ### New Features

--- a/sklearn_genetic/_base.py
+++ b/sklearn_genetic/_base.py
@@ -17,7 +17,7 @@ def history_record(history, index):
 
 
 class GeneticEstimatorMixin:
-    _volatile_pickle_attrs = {"toolbox", "_stats", "_pop", "_hof", "hof"}
+    _volatile_pickle_attrs = {"toolbox", "_stats", "_pop", "_hof"}
 
     # Contract for the two serialization paths (see #297):
     #
@@ -58,12 +58,21 @@ class GeneticEstimatorMixin:
         "sharing_alpha": 1.0,
     }
 
-    def _serializable_state(self):
+    def __getstate__(self):
+        """Exclude unpicklable DEAP internals from the serialized state."""
         return {
             key: value
             for key, value in self.__dict__.items()
             if key not in self._volatile_pickle_attrs
         }
+
+    def __setstate__(self, state):
+        """Restore instance state, leaving DEAP attrs unset (rebuilt on fit)."""
+        self.__dict__.update(state)
+
+    def _serializable_state(self):
+        """Backward-compatible accessor for save/load internals."""
+        return self.__getstate__()
 
     def _checkpoint_state(self):
         """Constructor-compatible subset of the state used to resume a search.
@@ -80,29 +89,42 @@ class GeneticEstimatorMixin:
         return state
 
     def save(self, filepath):
-        """Save the current state of the estimator instance to a file."""
+        """Save the current state of the estimator instance to a file.
+
+        Uses ``__getstate__`` to exclude unpicklable DEAP internals.
+        The saved file is a pickled ``dict`` with keys ``estimator_state``
+        and ``logbook`` for backward compatibility with ``load()``.
+        """
         class_name = self.__class__.__name__
         try:
-            checkpoint_data = {"estimator_state": self._serializable_state(), "logbook": None}
+            checkpoint_data = {"estimator_state": self.__getstate__(), "logbook": None}
             if hasattr(self, "logbook"):
                 checkpoint_data["logbook"] = self.logbook
 
-            serialized_checkpoint = pickle.dumps(checkpoint_data)
             with open(filepath, "wb") as f:
-                f.write(serialized_checkpoint)
+                pickle.dump(checkpoint_data, f)
             print(f"{class_name} model successfully saved to {filepath}")
         except Exception as e:
             print(f"Error saving {class_name}: {e}")
 
     def load(self, filepath):
-        """Load an estimator instance from a file."""
+        """Load an estimator instance from a file.
+
+        Restores state via ``__setstate__``.  Accepts both the current format
+        (pickled ``dict`` with ``estimator_state`` key) and a raw pickled
+        instance produced by ``pickle.dumps(self)``.
+        """
         class_name = self.__class__.__name__
         try:
             with open(filepath, "rb") as f:
                 checkpoint_data = pickle.load(f)
-                for key, value in checkpoint_data["estimator_state"].items():
-                    setattr(self, key, value)
+
+            if isinstance(checkpoint_data, dict) and "estimator_state" in checkpoint_data:
+                self.__setstate__(checkpoint_data["estimator_state"])
                 self.logbook = checkpoint_data["logbook"]
+            else:
+                self.__setstate__(checkpoint_data)
+
             print(f"{class_name} model successfully loaded from {filepath}")
         except Exception as e:
             print(f"Error loading {class_name}: {e}")

--- a/sklearn_genetic/_base.py
+++ b/sklearn_genetic/_base.py
@@ -123,7 +123,7 @@ class GeneticEstimatorMixin:
                 self.__setstate__(checkpoint_data["estimator_state"])
                 self.logbook = checkpoint_data["logbook"]
             else:
-                self.__setstate__(checkpoint_data)
+                self.__setstate__(checkpoint_data.__dict__)
 
             print(f"{class_name} model successfully loaded from {filepath}")
         except Exception as e:

--- a/sklearn_genetic/tests/test_persistence_and_helpers.py
+++ b/sklearn_genetic/tests/test_persistence_and_helpers.py
@@ -1,5 +1,7 @@
+import pickle
 import shutil
 
+import numpy as np
 import pytest
 from sklearn.datasets import load_iris
 from sklearn.exceptions import NotFittedError
@@ -90,6 +92,59 @@ def test_fitted_ga_search_save_and_load_round_trip(tmp_path):
     assert restored.best_score_ == search.best_score_
     assert restored.best_params_ == search.best_params_
     assert restored.predict(X_test).shape[0] == X_test.shape[0]
+
+
+@pytest.mark.parametrize(
+    "build",
+    [
+        lambda: GASearchCV(
+            estimator=DecisionTreeClassifier(random_state=0),
+            param_grid={
+                "max_depth": Integer(1, 3),
+                "min_samples_split": Integer(2, 5),
+            },
+            cv=2,
+            scoring="accuracy",
+            population_size=4,
+            generations=2,
+        ),
+        lambda: GAFeatureSelectionCV(
+            estimator=DecisionTreeClassifier(random_state=0),
+            cv=2,
+            scoring="accuracy",
+            population_size=4,
+            generations=2,
+        ),
+    ],
+    ids=["GASearchCV", "GAFeatureSelectionCV"],
+)
+def test_load_accepts_raw_pickled_instance(build, tmp_path):
+    X, y = load_iris(return_X_y=True)
+    X_train, X_test, y_train, _ = train_test_split(
+        X,
+        y,
+        test_size=0.25,
+        stratify=y,
+        random_state=0,
+    )
+
+    estimator = build()
+    estimator.fit(X_train, y_train)
+
+    checkpoint_path = tmp_path / "raw_instance.pkl"
+    with open(checkpoint_path, "wb") as f:
+        pickle.dump(estimator, f)
+
+    restored = build()
+    restored.load(checkpoint_path)
+
+    assert restored.predict(X_test).shape[0] == X_test.shape[0]
+    if isinstance(restored, GAFeatureSelectionCV):
+        assert np.array_equal(restored.support_, estimator.support_)
+        assert np.array_equal(restored.best_features_, estimator.best_features_)
+    else:
+        assert restored.best_score_ == estimator.best_score_
+        assert restored.best_params_ == estimator.best_params_
 
 
 def test_ga_search_save_and_load_errors_are_reported(tmp_path, capsys):

--- a/sklearn_genetic/tests/test_serialization.py
+++ b/sklearn_genetic/tests/test_serialization.py
@@ -1,3 +1,5 @@
+import pickle
+
 import pytest
 from sklearn.datasets import load_iris, load_diabetes
 from sklearn.linear_model import SGDClassifier
@@ -9,7 +11,7 @@ from sklearn.metrics import accuracy_score, balanced_accuracy_score
 from sklearn.metrics import make_scorer
 import numpy as np
 
-from .. import GAFeatureSelectionCV, EvolutionConfig, PopulationConfig, RuntimeConfig
+from .. import GASearchCV, GAFeatureSelectionCV, EvolutionConfig, PopulationConfig, RuntimeConfig
 from ..callbacks import (
     ThresholdStopping,
     DeltaThreshold,
@@ -18,6 +20,7 @@ from ..callbacks import (
     ProgressBar,
 )
 from ..schedules import ExponentialAdapter, InverseAdapter
+from ..space import Integer
 from joblib import dump, load
 import os
 
@@ -137,3 +140,78 @@ def test_estimator_serialization_with_config_objects():
     assert bool(dumped_estimator.get_params())
 
     os.remove(dump_file)
+
+
+_PICKLABLE_ESTIMATOR_BUILDERS = [
+    pytest.param(
+        lambda: GASearchCV(
+            estimator=DecisionTreeClassifier(random_state=0),
+            param_grid={
+                "max_depth": Integer(1, 3),
+                "min_samples_split": Integer(2, 5),
+            },
+            cv=2,
+            scoring="accuracy",
+            population_size=4,
+            generations=2,
+            verbose=False,
+        ),
+        id="GASearchCV",
+    ),
+    pytest.param(
+        lambda: GAFeatureSelectionCV(
+            estimator=DecisionTreeClassifier(random_state=0),
+            cv=2,
+            scoring="accuracy",
+            population_size=4,
+            generations=2,
+            verbose=False,
+        ),
+        id="GAFeatureSelectionCV",
+    ),
+]
+
+
+@pytest.mark.parametrize("build", _PICKLABLE_ESTIMATOR_BUILDERS)
+def test_pickle_round_trip_preserves_fitted_state(build):
+    estimator = build()
+    estimator.fit(X_train, y_train)
+    expected_predictions = estimator.predict(X_test)
+
+    restored = pickle.loads(pickle.dumps(estimator))
+
+    assert check_is_fitted(restored) is None
+    assert np.array_equal(restored.predict(X_test), expected_predictions)
+    assert not hasattr(restored, "toolbox")
+    assert not hasattr(restored, "_pop")
+    assert not hasattr(restored, "_stats")
+    assert not hasattr(restored, "_hof")
+    if isinstance(restored, GAFeatureSelectionCV):
+        assert np.array_equal(restored.best_features_, estimator.best_features_)
+        assert np.array_equal(restored.support_, estimator.support_)
+    else:
+        assert restored.best_params_ == estimator.best_params_
+        assert restored.best_score_ == estimator.best_score_
+
+    restored.fit(X_train, y_train)
+    assert hasattr(restored, "toolbox")
+    assert restored.predict(X_test).shape[0] == X_test.shape[0]
+
+
+@pytest.mark.parametrize("build", _PICKLABLE_ESTIMATOR_BUILDERS)
+def test_joblib_round_trip_preserves_fitted_state(build, tmp_path):
+    estimator = build()
+    estimator.fit(X_train, y_train)
+    dump_file = str(tmp_path / "estimator.joblib")
+
+    dump(estimator, dump_file)
+    restored = load(dump_file)
+
+    assert check_is_fitted(restored) is None
+    assert np.array_equal(restored.predict(X_test), estimator.predict(X_test))
+    if isinstance(restored, GAFeatureSelectionCV):
+        assert np.array_equal(restored.best_features_, estimator.best_features_)
+        assert np.array_equal(restored.support_, estimator.support_)
+    else:
+        assert restored.best_params_ == estimator.best_params_
+        assert restored.best_score_ == estimator.best_score_


### PR DESCRIPTION
## Summary

- Add `__getstate__` to `GeneticEstimatorMixin` that excludes unpicklable DEAP internals (`toolbox`, `_stats`, `_pop`, `_hof`) from the serialized state
- Add `__setstate__` to restore instance state cleanly, leaving DEAP attrs unset so they're rebuilt on `fit()`
- Remove `hof` from `_volatile_pickle_attrs` — it's a regular dict that should be serializable
- Update `save()`/`load()` to use `__getstate__`/`__setstate__`
- `load()` handles both the legacy dict format (with `estimator_state` key) and raw pickled instances for backward compatibility

## Why This Change

The old `save()`/`load()` used raw pickle on `__dict__` with manual filtering via `_serializable_state()`. Without proper `__getstate__`/`__setstate__`, `pickle.dumps(self)` and `joblib.dump()` would try to serialize unpicklable DEAP internals (`toolbox`, `_stats`, `_pop`, `_hof`), leading to errors or silent corruption. A proper pickle protocol makes the serialization contract explicit and prevents accidental serialization of DEAP objects.