### PR TITLE
fix: validate early stopping callback inputs

### DIFF
--- a/sklearn_genetic/callbacks/early_stoppers.py
+++ b/sklearn_genetic/callbacks/early_stoppers.py
@@ -1,7 +1,28 @@
 from datetime import datetime
+from numbers import Integral, Real
 
 from .validations import check_stats
 from .base import BaseCallback
+
+
+def _validate_numeric(value, parameter_name):
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise TypeError(f"{parameter_name} must be a numeric value")
+
+
+def _validate_positive_integer(value, parameter_name):
+    if isinstance(value, bool) or not isinstance(value, Integral):
+        raise TypeError(f"{parameter_name} must be a positive integer")
+
+    if value <= 0:
+        raise ValueError(f"{parameter_name} must be greater than 0")
+
+
+def _validate_positive_numeric(value, parameter_name):
+    _validate_numeric(value, parameter_name)
+
+    if value <= 0:
+        raise ValueError(f"{parameter_name} must be greater than 0")
 
 
 class ThresholdStopping(BaseCallback):
@@ -22,6 +43,7 @@ class ThresholdStopping(BaseCallback):
         """
 
         check_stats(metric)
+        _validate_numeric(threshold, "threshold")
 
         self.threshold = threshold
         self.metric = metric
@@ -59,6 +81,7 @@ class ConsecutiveStopping(BaseCallback):
         """
 
         check_stats(metric)
+        _validate_positive_integer(generations, "generations")
 
         self.generations = generations
         self.metric = metric
@@ -105,6 +128,8 @@ class DeltaThreshold(BaseCallback):
         """
 
         check_stats(metric)
+        _validate_numeric(threshold, "threshold")
+        _validate_positive_integer(generations, "generations")
 
         self.threshold = threshold
         self.generations = generations
@@ -141,6 +166,8 @@ class TimerStopping(BaseCallback):
         total_seconds: int
             Total time in seconds that the estimator is allowed to fit
         """
+        _validate_positive_numeric(total_seconds, "total_seconds")
+
         self.initial_training_time = None
         self.total_seconds = total_seconds
 

--- a/sklearn_genetic/callbacks/tests/test_callbacks.py
+++ b/sklearn_genetic/callbacks/tests/test_callbacks.py
@@ -122,6 +122,12 @@ def test_threshold_callback():
     assert str(excinfo.value) == "At least one of record or logbook parameters must be provided"
 
 
+@pytest.mark.parametrize("threshold", ["0.8", None, object()])
+def test_threshold_callback_rejects_non_numeric_threshold(threshold):
+    with pytest.raises((TypeError, ValueError), match="threshold"):
+        ThresholdStopping(threshold=threshold)
+
+
 def test_consecutive_callback():
     callback = ConsecutiveStopping(generations=3)
     assert check_callback(callback) == [callback]
@@ -150,6 +156,18 @@ def test_consecutive_callback():
     with pytest.raises(Exception) as excinfo:
         callback()
     assert str(excinfo.value) == "logbook parameter must be provided"
+
+
+@pytest.mark.parametrize("generations", ["3", None, object()])
+def test_consecutive_callback_rejects_non_numeric_generations(generations):
+    with pytest.raises((TypeError, ValueError), match="generations"):
+        ConsecutiveStopping(generations=generations)
+
+
+@pytest.mark.parametrize("generations", [0, -1])
+def test_consecutive_callback_rejects_non_positive_generations(generations):
+    with pytest.raises((TypeError, ValueError), match="generations"):
+        ConsecutiveStopping(generations=generations)
 
 
 def test_delta_callback():
@@ -181,6 +199,42 @@ def test_delta_callback():
     with pytest.raises(Exception) as excinfo:
         callback()
     assert str(excinfo.value) == "logbook parameter must be provided"
+
+
+@pytest.mark.parametrize("threshold", ["0.001", None, object()])
+def test_delta_callback_rejects_non_numeric_threshold(threshold):
+    with pytest.raises((TypeError, ValueError), match="threshold"):
+        DeltaThreshold(threshold=threshold)
+
+
+@pytest.mark.parametrize("generations", ["2", None, object()])
+def test_delta_callback_rejects_non_numeric_generations(generations):
+    with pytest.raises((TypeError, ValueError), match="generations"):
+        DeltaThreshold(threshold=0.001, generations=generations)
+
+
+@pytest.mark.parametrize("generations", [0, -1])
+def test_delta_callback_rejects_non_positive_generations(generations):
+    with pytest.raises((TypeError, ValueError), match="generations"):
+        DeltaThreshold(threshold=0.001, generations=generations)
+
+
+def test_timer_callback_accepts_numeric_total_seconds():
+    callback = TimerStopping(total_seconds=0.1)
+
+    assert callback.total_seconds == 0.1
+
+
+@pytest.mark.parametrize("total_seconds", ["10", None, object()])
+def test_timer_callback_rejects_non_numeric_total_seconds(total_seconds):
+    with pytest.raises((TypeError, ValueError), match="total_seconds"):
+        TimerStopping(total_seconds=total_seconds)
+
+
+@pytest.mark.parametrize("total_seconds", [0, -1])
+def test_timer_callback_rejects_non_positive_total_seconds(total_seconds):
+    with pytest.raises((TypeError, ValueError), match="total_seconds"):
+        TimerStopping(total_seconds=total_seconds)
 
 
 def test_logbook_saver_callback(caplog):


### PR DESCRIPTION
## Summary
- validate numeric thresholds and time limits at callback construction
- require positive integer generations and positive timer durations
- add focused regression tests for invalid callback inputs

Closes #359

## Verification
- `pytest sklearn_genetic/callbacks/tests/test_callbacks.py -q`
- `pytest sklearn_genetic/`
- `pytest sklearn_genetic/ --cov-fail-under=95 --cov=./ --cov-report=term-missing:skip-covered`
- `black --check .`
- `python -m build && twine check dist/*`
- `git diff --check`