### PR TITLE
Add ExtraTrees preset search spaces

### DIFF
--- a/sklearn_genetic/__init__.py
+++ b/sklearn_genetic/__init__.py
@@ -1,6 +1,8 @@
 from .genetic_search import GASearchCV, GAFeatureSelectionCV
 from .config import EvolutionConfig, OptimizationConfig, PopulationConfig, RuntimeConfig
 from .presets import (
+    extra_trees_classifier_space,
+    extra_trees_regressor_space,
     hist_gradient_boosting_classifier_space,
     hist_gradient_boosting_regressor_space,
     logistic_regression_space,
@@ -36,6 +38,8 @@ __all__ = [
     "OptimizationConfig",
     "PopulationConfig",
     "RuntimeConfig",
+    "extra_trees_classifier_space",
+    "extra_trees_regressor_space",
     "hist_gradient_boosting_classifier_space",
     "hist_gradient_boosting_regressor_space",
     "logistic_regression_space",

--- a/sklearn_genetic/presets.py
+++ b/sklearn_genetic/presets.py
@@ -133,6 +133,7 @@ def extra_trees_classifier_space(profile="balanced", prefix=""):
         prefix,
     )
 
+
 def extra_trees_regressor_space(profile="balanced", prefix=""):
     """Return a starter search space for ``ExtraTreesRegressor``."""
     _check_profile(profile)

--- a/sklearn_genetic/presets.py
+++ b/sklearn_genetic/presets.py
@@ -1,6 +1,8 @@
 from .space import Categorical, Continuous, Integer
 
 __all__ = [
+    "extra_trees_classifier_space",
+    "extra_trees_regressor_space",
     "hist_gradient_boosting_classifier_space",
     "hist_gradient_boosting_regressor_space",
     "logistic_regression_space",
@@ -87,6 +89,52 @@ def random_forest_classifier_space(profile="balanced", prefix=""):
 
 def random_forest_regressor_space(profile="balanced", prefix=""):
     """Return a starter search space for ``RandomForestRegressor``."""
+    _check_profile(profile)
+    bounds = {
+        "fast": (50, 180, 2, 16, 1, 6),
+        "balanced": (80, 350, 2, 24, 1, 10),
+        "wide": (100, 700, 2, 40, 1, 20),
+    }[profile]
+    n_low, n_high, depth_low, depth_high, leaf_low, leaf_high = bounds
+
+    return _with_prefix(
+        {
+            "n_estimators": Integer(n_low, n_high),
+            "max_depth": Integer(depth_low, depth_high),
+            "min_samples_split": Integer(2, max(8, leaf_high * 2)),
+            "min_samples_leaf": Integer(leaf_low, leaf_high),
+            "max_features": Categorical(["sqrt", "log2", None]),
+            "criterion": Categorical(["squared_error", "absolute_error", "friedman_mse"]),
+        },
+        prefix,
+    )
+
+
+def extra_trees_classifier_space(profile="balanced", prefix=""):
+    """Return a starter search space for ``ExtraTreesClassifier``."""
+    _check_profile(profile)
+    bounds = {
+        "fast": (50, 180, 2, 16, 1, 6),
+        "balanced": (80, 350, 2, 24, 1, 10),
+        "wide": (100, 700, 2, 40, 1, 20),
+    }[profile]
+    n_low, n_high, depth_low, depth_high, leaf_low, leaf_high = bounds
+
+    return _with_prefix(
+        {
+            "n_estimators": Integer(n_low, n_high),
+            "max_depth": Integer(depth_low, depth_high),
+            "min_samples_split": Integer(2, max(8, leaf_high * 2)),
+            "min_samples_leaf": Integer(leaf_low, leaf_high),
+            "max_features": Categorical(["sqrt", "log2", None]),
+            "criterion": Categorical(["gini", "entropy"]),
+            "class_weight": Categorical([None, "balanced", "balanced_subsample"]),
+        },
+        prefix,
+    )
+
+def extra_trees_regressor_space(profile="balanced", prefix=""):
+    """Return a starter search space for ``ExtraTreesRegressor``."""
     _check_profile(profile)
     bounds = {
         "fast": (50, 180, 2, 16, 1, 6),

--- a/sklearn_genetic/tests/test_presets.py
+++ b/sklearn_genetic/tests/test_presets.py
@@ -45,6 +45,7 @@ def test_random_forest_regressor_preset_uses_regression_criteria():
     assert space["criterion"].choices == ["squared_error", "absolute_error", "friedman_mse"]
     assert "class_weight" not in space
 
+
 def test_extra_trees_classifier_preset_returns_native_space_dimensions():
     space = extra_trees_classifier_space(profile="fast")
     

--- a/sklearn_genetic/tests/test_presets.py
+++ b/sklearn_genetic/tests/test_presets.py
@@ -1,6 +1,8 @@
 import pytest
 
 from sklearn_genetic import (
+    extra_trees_classifier_space,
+    extra_trees_regressor_space,
     hist_gradient_boosting_classifier_space,
     hist_gradient_boosting_regressor_space,
     logistic_regression_space,
@@ -16,6 +18,8 @@ from sklearn_genetic.space.base import BaseDimension
 PRESET_FUNCTIONS = [
     random_forest_classifier_space,
     random_forest_regressor_space,
+    extra_trees_classifier_space,
+    extra_trees_regressor_space,
     hist_gradient_boosting_classifier_space,
     hist_gradient_boosting_regressor_space,
     logistic_regression_space,
@@ -37,6 +41,22 @@ def test_random_forest_classifier_preset_returns_native_space_dimensions():
 
 def test_random_forest_regressor_preset_uses_regression_criteria():
     space = random_forest_regressor_space()
+
+    assert space["criterion"].choices == ["squared_error", "absolute_error", "friedman_mse"]
+    assert "class_weight" not in space
+
+def test_extra_trees_classifier_preset_returns_native_space_dimensions():
+    space = extra_trees_classifier_space(profile="fast")
+    
+    assert isinstance(space["n_estimators"], Integer)
+    assert space["n_estimators"].lower == 50
+    assert space["n_estimators"].upper == 180
+    assert isinstance(space["max_features"], Categorical)
+    assert space["class_weight"].choices == [None, "balanced", "balanced_subsample"]
+
+
+def test_extra_trees_regressor_preset_uses_regression_criteria():
+    space = extra_trees_regressor_space()
 
     assert space["criterion"].choices == ["squared_error", "absolute_error", "friedman_mse"]
     assert "class_weight" not in space


### PR DESCRIPTION
Adds extra_trees_classifier_space and extra_trees_regressor_space preset search spaces for ExtraTreesClassifier and ExtraTreesRegressor, mirroring the existing random_forest_*_space presets (same parameter ranges and profile shape). Both are exported from the package and added to PRESET_FUNCTIONS, so they automatically pick up all the existing parametrized preset tests. Two dedicated tests also check the classifier's class_weight choices and the regressor's criterion choices.

Closes #361