### PR TITLE
Validate stopping callback inputs (#359)

### DIFF
--- a/sklearn_genetic/callbacks/early_stoppers.py
+++ b/sklearn_genetic/callbacks/early_stoppers.py
@@ -1,6 +1,11 @@
 from datetime import datetime
 
-from .validations import check_stats
+from .validations import (
+    check_stats,
+    check_number,
+    check_positive_number,
+    check_positive_integer,
+)
 from .base import BaseCallback
 
 
@@ -22,6 +27,7 @@ class ThresholdStopping(BaseCallback):
         """
 
         check_stats(metric)
+        check_number("threshold", threshold)
 
         self.threshold = threshold
         self.metric = metric
@@ -59,6 +65,7 @@ class ConsecutiveStopping(BaseCallback):
         """
 
         check_stats(metric)
+        check_positive_integer("generations", generations)
 
         self.generations = generations
         self.metric = metric
@@ -105,6 +112,8 @@ class DeltaThreshold(BaseCallback):
         """
 
         check_stats(metric)
+        check_number("threshold", threshold)
+        check_positive_integer("generations", generations)
 
         self.threshold = threshold
         self.generations = generations
@@ -141,6 +150,8 @@ class TimerStopping(BaseCallback):
         total_seconds: int
             Total time in seconds that the estimator is allowed to fit
         """
+        check_positive_number("total_seconds", total_seconds)
+
         self.initial_training_time = None
         self.total_seconds = total_seconds
 

--- a/sklearn_genetic/callbacks/tests/test_callbacks.py
+++ b/sklearn_genetic/callbacks/tests/test_callbacks.py
@@ -248,3 +248,53 @@ def test_tensorboard_callback(callback, path):
     assert os.path.exists(path)
 
     shutil.rmtree(path)
+
+
+@pytest.mark.parametrize("threshold", ["a", None, [0.1], True])
+def test_threshold_stopping_rejects_non_numeric_threshold(threshold):
+    with pytest.raises(TypeError, match="threshold must be a number"):
+        ThresholdStopping(threshold=threshold)
+
+
+@pytest.mark.parametrize("threshold", ["a", None, True])
+def test_delta_threshold_rejects_non_numeric_threshold(threshold):
+    with pytest.raises(TypeError, match="threshold must be a number"):
+        DeltaThreshold(threshold=threshold)
+
+
+@pytest.mark.parametrize("generations", ["a", 1.5, None, True])
+def test_consecutive_stopping_rejects_non_integer_generations(generations):
+    with pytest.raises(TypeError, match="generations must be an integer"):
+        ConsecutiveStopping(generations=generations)
+
+
+@pytest.mark.parametrize("generations", [0, -1])
+def test_consecutive_stopping_rejects_non_positive_generations(generations):
+    with pytest.raises(ValueError, match="generations must be a positive integer"):
+        ConsecutiveStopping(generations=generations)
+
+
+@pytest.mark.parametrize("generations", [0, -3])
+def test_delta_threshold_rejects_non_positive_generations(generations):
+    with pytest.raises(ValueError, match="generations must be a positive integer"):
+        DeltaThreshold(threshold=0.01, generations=generations)
+
+
+@pytest.mark.parametrize("total_seconds", ["a", None, True])
+def test_timer_stopping_rejects_non_numeric_total_seconds(total_seconds):
+    with pytest.raises(TypeError, match="total_seconds must be a number"):
+        TimerStopping(total_seconds=total_seconds)
+
+
+@pytest.mark.parametrize("total_seconds", [0, -5])
+def test_timer_stopping_rejects_non_positive_total_seconds(total_seconds):
+    with pytest.raises(ValueError, match="total_seconds must be a positive number"):
+        TimerStopping(total_seconds=total_seconds)
+
+
+def test_stopping_callbacks_accept_valid_inputs():
+    # These should not raise.
+    ThresholdStopping(threshold=-0.5)
+    ConsecutiveStopping(generations=3)
+    DeltaThreshold(threshold=0.001, generations=2)
+    TimerStopping(total_seconds=0.5)

--- a/sklearn_genetic/callbacks/validations.py
+++ b/sklearn_genetic/callbacks/validations.py
@@ -1,3 +1,5 @@
+import numbers
+
 from ..parameters import Metrics, CallbackMethods
 from .base import BaseCallback
 
@@ -5,6 +7,27 @@ from .base import BaseCallback
 def check_stats(metric):
     if metric not in Metrics.list():
         raise ValueError(f"metric must be one of {Metrics.list()}, but got {metric} instead")
+
+
+def check_number(name, value):
+    """Raise a TypeError if value is not a real number (bool is rejected)."""
+    if isinstance(value, bool) or not isinstance(value, numbers.Real):
+        raise TypeError(f"{name} must be a number, but got {type(value).__name__} instead")
+
+
+def check_positive_number(name, value):
+    """Raise if value is not a strictly positive real number."""
+    check_number(name, value)
+    if value <= 0:
+        raise ValueError(f"{name} must be a positive number, but got {value} instead")
+
+
+def check_positive_integer(name, value):
+    """Raise if value is not a strictly positive integer (bool is rejected)."""
+    if isinstance(value, bool) or not isinstance(value, numbers.Integral):
+        raise TypeError(f"{name} must be an integer, but got {type(value).__name__} instead")
+    if value <= 0:
+        raise ValueError(f"{name} must be a positive integer, but got {value} instead")
 
 
 def check_callback(callback):


### PR DESCRIPTION
Closes #359.

Adds validation to the four stopping callback constructors so bad inputs fail early with a clear message instead of breaking later during `fit`:

- `ThresholdStopping` / `DeltaThreshold` — `threshold` must be a number
- `ConsecutiveStopping` / `DeltaThreshold` — `generations` must be a positive integer
- `TimerStopping` — `total_seconds` must be a positive number

Added three small helpers in `validations.py` (`check_number`, `check_positive_number`, `check_positive_integer`) and tests for at least one invalid input per callback. Valid usage is unchanged and existing tests still pass. `bool` is rejected for numeric inputs since `True`/`False` there is almost certainly a mistake.
