### PR TITLE
Add Extra Trees preset search spaces (#361)

### DIFF
--- a/sklearn_genetic/__init__.py
+++ b/sklearn_genetic/__init__.py
@@ -1,6 +1,8 @@
 from .genetic_search import GASearchCV, GAFeatureSelectionCV
 from .config import EvolutionConfig, OptimizationConfig, PopulationConfig, RuntimeConfig
 from .presets import (
+    extra_trees_classifier_space,
+    extra_trees_regressor_space,
     hist_gradient_boosting_classifier_space,
     hist_gradient_boosting_regressor_space,
     logistic_regression_space,
@@ -36,6 +38,8 @@ __all__ = [
     "OptimizationConfig",
     "PopulationConfig",
     "RuntimeConfig",
+    "extra_trees_classifier_space",
+    "extra_trees_regressor_space",
     "hist_gradient_boosting_classifier_space",
     "hist_gradient_boosting_regressor_space",
     "logistic_regression_space",

--- a/sklearn_genetic/presets.py
+++ b/sklearn_genetic/presets.py
@@ -1,6 +1,8 @@
 from .space import Categorical, Continuous, Integer
 
 __all__ = [
+    "extra_trees_classifier_space",
+    "extra_trees_regressor_space",
     "hist_gradient_boosting_classifier_space",
     "hist_gradient_boosting_regressor_space",
     "logistic_regression_space",
@@ -87,6 +89,53 @@ def random_forest_classifier_space(profile="balanced", prefix=""):
 
 def random_forest_regressor_space(profile="balanced", prefix=""):
     """Return a starter search space for ``RandomForestRegressor``."""
+    _check_profile(profile)
+    bounds = {
+        "fast": (50, 180, 2, 16, 1, 6),
+        "balanced": (80, 350, 2, 24, 1, 10),
+        "wide": (100, 700, 2, 40, 1, 20),
+    }[profile]
+    n_low, n_high, depth_low, depth_high, leaf_low, leaf_high = bounds
+
+    return _with_prefix(
+        {
+            "n_estimators": Integer(n_low, n_high),
+            "max_depth": Integer(depth_low, depth_high),
+            "min_samples_split": Integer(2, max(8, leaf_high * 2)),
+            "min_samples_leaf": Integer(leaf_low, leaf_high),
+            "max_features": Categorical(["sqrt", "log2", None]),
+            "criterion": Categorical(["squared_error", "absolute_error", "friedman_mse"]),
+        },
+        prefix,
+    )
+
+
+def extra_trees_classifier_space(profile="balanced", prefix=""):
+    """Return a starter search space for ``ExtraTreesClassifier``."""
+    _check_profile(profile)
+    bounds = {
+        "fast": (50, 180, 2, 16, 1, 6),
+        "balanced": (80, 350, 2, 24, 1, 10),
+        "wide": (100, 700, 2, 40, 1, 20),
+    }[profile]
+    n_low, n_high, depth_low, depth_high, leaf_low, leaf_high = bounds
+
+    return _with_prefix(
+        {
+            "n_estimators": Integer(n_low, n_high),
+            "max_depth": Integer(depth_low, depth_high),
+            "min_samples_split": Integer(2, max(8, leaf_high * 2)),
+            "min_samples_leaf": Integer(leaf_low, leaf_high),
+            "max_features": Categorical(["sqrt", "log2", None]),
+            "criterion": Categorical(["gini", "entropy"]),
+            "class_weight": Categorical([None, "balanced", "balanced_subsample"]),
+        },
+        prefix,
+    )
+
+
+def extra_trees_regressor_space(profile="balanced", prefix=""):
+    """Return a starter search space for ``ExtraTreesRegressor``."""
     _check_profile(profile)
     bounds = {
         "fast": (50, 180, 2, 16, 1, 6),

--- a/sklearn_genetic/tests/test_presets.py
+++ b/sklearn_genetic/tests/test_presets.py
@@ -1,6 +1,8 @@
 import pytest
 
 from sklearn_genetic import (
+    extra_trees_classifier_space,
+    extra_trees_regressor_space,
     hist_gradient_boosting_classifier_space,
     hist_gradient_boosting_regressor_space,
     logistic_regression_space,
@@ -14,6 +16,8 @@ from sklearn_genetic.space import Categorical, Continuous, Integer
 from sklearn_genetic.space.base import BaseDimension
 
 PRESET_FUNCTIONS = [
+    extra_trees_classifier_space,
+    extra_trees_regressor_space,
     random_forest_classifier_space,
     random_forest_regressor_space,
     hist_gradient_boosting_classifier_space,
@@ -176,3 +180,29 @@ def test_discovery_helpers_return_fresh_lists():
         second = helper()
         assert "__mutated__" not in second
         assert second == sorted(second) and len(second) > 0
+
+
+def test_extra_trees_classifier_preset_returns_native_dimensions():
+    space = extra_trees_classifier_space(profile="fast")
+
+    assert isinstance(space["n_estimators"], Integer)
+    assert space["n_estimators"].lower == 50
+    assert space["n_estimators"].upper == 180
+    assert isinstance(space["max_features"], Categorical)
+    assert space["criterion"].choices == ["gini", "entropy"]
+    assert space["class_weight"].choices == [None, "balanced", "balanced_subsample"]
+
+
+def test_extra_trees_regressor_preset_uses_regression_criteria():
+    space = extra_trees_regressor_space()
+
+    assert space["criterion"].choices == ["squared_error", "absolute_error", "friedman_mse"]
+    assert "class_weight" not in space
+
+
+def test_extra_trees_presets_are_discoverable():
+    from sklearn_genetic import list_preset_spaces
+
+    names = list_preset_spaces()
+    assert "extra_trees_classifier_space" in names
+    assert "extra_trees_regressor_space" in names


### PR DESCRIPTION
Closes #361.

Adds `extra_trees_classifier_space` and `extra_trees_regressor_space`, following the existing random forest presets — same `fast`/`balanced`/`wide` profiles and `prefix` support, returning only native `Integer`/`Categorical` dimensions.

- Exported from `sklearn_genetic` and `sklearn_genetic.presets`, so both appear in `list_preset_spaces()`.
- All keys are valid `ExtraTreesClassifier`/`ExtraTreesRegressor` parameters (verified against a real estimator's `get_params`).
- Added focused tests and included both in the shared preset parametrization, so they're covered by the existing all-preset checks too.
