### PR TITLE
Fail clearly on unsupported fit metadata (#364)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Full release notes with code examples are in the [documentation](https://sklearn
 
 ## Unreleased
 
+### New Features
+
+- `GASearchCV` and `GAFeatureSelectionCV` now reject unsupported `fit` metadata up front with a clear error naming the parameter and the wrapped estimator, instead of failing deep inside cross-validation. Estimators whose `fit` takes `**kwargs` (e.g. `Pipeline`) are left to validate at fit time, so routed keys like `clf__sample_weight` keep working (#364).
+
 ## 0.13.4
 
 ### New Features

--- a/docs-vitepress/versions/latest/guide/understand-cv.md
+++ b/docs-vitepress/versions/latest/guide/understand-cv.md
@@ -90,6 +90,34 @@ The `plot_fitness_evolution` chart shows:
 
 A healthy search shows the mean and best fitness rising together, then plateauing as the population converges.
 
+## Passing Metadata (groups & sample_weight)
+
+Both `GASearchCV` and `GAFeatureSelectionCV` forward metadata from `fit` through
+cross-validation and the final refit:
+
+```python
+from sklearn.model_selection import GroupKFold
+
+evolved_estimator = GASearchCV(clf, cv=GroupKFold(n_splits=5), param_grid=param_grid)
+
+# groups drives the CV splitter; sample_weight reaches the estimator's fit
+evolved_estimator.fit(X, y, groups=groups, sample_weight=weights)
+```
+
+- `groups` is passed to group-aware splitters (`GroupKFold`, `LeaveOneGroupOut`, ...)
+  when materializing the folds, so groups are never silently dropped.
+- `sample_weight` (and any other `fit` metadata) reaches the wrapped estimator during
+  candidate evaluation, final-selection scoring, and the final refit. Sample-aligned
+  values are sliced per fold by scikit-learn.
+
+**Limitations**
+
+- Metadata the wrapped estimator's `fit` cannot accept fails up front with a clear
+  error naming the parameter and the estimator, rather than being ignored. For a
+  `Pipeline`, route it with the step prefix (e.g. `clf__sample_weight`).
+- Full scikit-learn metadata routing (`sklearn.set_config(enable_metadata_routing=True)`)
+  is not wrapped; pass `groups`/`sample_weight` directly to `fit` with routing disabled.
+
 ## Tips & Gotchas
 
 - Use `StratifiedKFold` for classification tasks to keep class balance across folds.

--- a/sklearn_genetic/genetic_search.py
+++ b/sklearn_genetic/genetic_search.py
@@ -1,3 +1,4 @@
+import inspect
 import random
 import time
 import warnings
@@ -103,6 +104,46 @@ def _resolve_config_value(config, field_name, fallback):
         return fallback
 
     return getattr(config, field_name, fallback)
+
+
+def _check_fit_params_supported(estimator, fit_params):
+    """Fail early and clearly when the wrapped estimator can't take a metadata key.
+
+    ``fit_params`` (e.g. ``sample_weight``) are forwarded to the estimator's
+    ``fit`` during cross-validation and refit. If the estimator doesn't accept a
+    given key it would otherwise blow up mid-search with scikit-learn's generic
+    "unexpected keyword argument" error, so we check up front and name the
+    offending parameter and estimator instead.
+
+    The check is intentionally conservative: if ``fit`` takes ``**kwargs`` (as
+    Pipeline and many meta-estimators do) we can't tell statically which keys are
+    valid, so we skip it and let the estimator decide at fit time. That keeps
+    valid routed usage like ``clf__sample_weight`` working untouched.
+    """
+    if not fit_params:
+        return
+
+    try:
+        parameters = inspect.signature(estimator.fit).parameters.values()
+    except (TypeError, ValueError):
+        # Can't introspect fit (e.g. a C-level callable); leave it to fit time.
+        return
+
+    if any(p.kind == inspect.Parameter.VAR_KEYWORD for p in parameters):
+        return
+
+    accepted = {
+        p.name
+        for p in parameters
+        if p.kind in (inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY)
+    }
+    unsupported = sorted(name for name in fit_params if name not in accepted)
+    if unsupported:
+        raise TypeError(
+            f"{type(estimator).__name__}.fit does not accept the metadata "
+            f"{unsupported}; it was passed to fit() but the wrapped estimator "
+            f"cannot use it. Remove it or use an estimator whose fit accepts it."
+        )
 
 
 class GASearchCV(GeneticEstimatorMixin, BaseSearchCV):
@@ -1069,6 +1110,7 @@ class GASearchCV(GeneticEstimatorMixin, BaseSearchCV):
         self.y_ = y
         self.groups_ = groups
         self._fit_params = fit_params
+        _check_fit_params_supported(self.estimator, fit_params)
         self._n_iterations = self.generations + 1
         self.refit_metric = "score"
         self.multimetric_ = False
@@ -2033,6 +2075,7 @@ class GAFeatureSelectionCV(GeneticEstimatorMixin, MetaEstimatorMixin, SelectorMi
         self.X_, self.y_ = check_X_y(X, y, accept_sparse=True) if y is not None else (X, None)
         self.groups_ = groups
         self._fit_params = fit_params
+        _check_fit_params_supported(self.estimator, fit_params)
 
         # Handle outlier detection case if y is none
         if _is_outlier_detector(self.estimator) and y is None:

--- a/sklearn_genetic/tests/test_feature_selection.py
+++ b/sklearn_genetic/tests/test_feature_selection.py
@@ -890,3 +890,24 @@ def test_feature_selection_forwards_sample_weight_and_slices_only_features():
     # Candidate CV fits get per-fold weight slices; the refit gets all samples.
     assert all(w < n_samples for _, w in recorded[:-1])
     assert recorded[-1][1] == n_samples
+
+
+def test_feature_selection_unsupported_fit_param_raises_clearly():
+    """#364: GAFeatureSelectionCV rejects unsupported metadata up front with a
+    clear message naming the parameter and the wrapped estimator."""
+    selector = GAFeatureSelectionCV(
+        DecisionTreeClassifier(random_state=0),
+        cv=2,
+        scoring="accuracy",
+        population_size=4,
+        generations=1,
+        error_score="raise",
+        verbose=False,
+    )
+
+    with pytest.raises(TypeError) as excinfo:
+        selector.fit(X_train, y_train, not_a_real_fit_param=np.ones(X_train.shape[0]))
+
+    message = str(excinfo.value)
+    assert "not_a_real_fit_param" in message
+    assert "DecisionTreeClassifier" in message

--- a/sklearn_genetic/tests/test_genetic_search.py
+++ b/sklearn_genetic/tests/test_genetic_search.py
@@ -1715,7 +1715,11 @@ def test_gasearch_final_selection_scoring_receives_fit_params():
 
 
 def test_gasearch_unsupported_fit_param_raises_clearly():
-    """#339: an unsupported fit param must fail loudly, not be dropped."""
+    """#364: an unsupported fit param must fail up front with a clear message.
+
+    The message names the offending metadata and the wrapped estimator, and the
+    error is raised before the search runs (not deep inside cross-validation).
+    """
     evolved_estimator = GASearchCV(
         DecisionTreeClassifier(random_state=0),
         cv=2,
@@ -1727,5 +1731,33 @@ def test_gasearch_unsupported_fit_param_raises_clearly():
         verbose=False,
     )
 
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError) as excinfo:
         evolved_estimator.fit(X_train, y_train, not_a_real_fit_param=np.ones(X_train.shape[0]))
+
+    message = str(excinfo.value)
+    assert "not_a_real_fit_param" in message
+    assert "DecisionTreeClassifier" in message
+    # Failed up front, so the search never populated a logbook.
+    assert not hasattr(evolved_estimator, "logbook")
+
+
+def test_gasearch_pipeline_routed_fit_param_is_not_falsely_rejected():
+    """#364: a Pipeline forwards ``step__param``; the up-front check must not
+    reject it, since Pipeline.fit takes ``**params`` and validates at fit time."""
+    from sklearn.pipeline import Pipeline
+    from sklearn.preprocessing import StandardScaler
+
+    pipe = Pipeline([("scaler", StandardScaler()), ("clf", DecisionTreeClassifier(random_state=0))])
+    evolved_estimator = GASearchCV(
+        pipe,
+        cv=2,
+        scoring="accuracy",
+        population_size=4,
+        generations=1,
+        param_grid={"clf__max_depth": Integer(2, 10)},
+        verbose=False,
+    )
+
+    # Should run cleanly: clf__sample_weight is a valid routed metadata key.
+    evolved_estimator.fit(X_train, y_train, clf__sample_weight=np.ones(X_train.shape[0]))
+    assert hasattr(evolved_estimator, "best_estimator_")


### PR DESCRIPTION
Closes #364.

Most of #364 already landed in #340/#341: `groups` reaches group-aware CV splitters, and `sample_weight` (and other fit metadata) reaches candidate evaluation, final-selection scoring, and the final refit. The one acceptance criterion still open was *"unsupported metadata fails with a clear message instead of being ignored"* — before this, passing a bad key failed deep inside `cross_validate` with sklearn's generic error, after the whole search had already started.

## What changed

- Added a small up-front check in both `fit` methods. If the wrapped estimator's `fit` can't accept a metadata key, it raises a clear `TypeError` naming the parameter and the estimator, before the search runs.
- The check is conservative: if `fit` takes `**kwargs` (Pipeline, many meta-estimators) it can't know statically which keys are valid, so it skips and lets fit time decide. Routed keys like `clf__sample_weight` keep working.
- Tests: clear-message assertions for both estimators, plus a Pipeline case proving routed params aren't falsely rejected.
- Docs: a short "Passing Metadata" section in the CV guide covering `groups`/`sample_weight` and the limitations (Pipeline prefixes, and that full `enable_metadata_routing` isn't wrapped).
- CHANGELOG entry.

Full `test_genetic_search.py` + `test_feature_selection.py` pass (116). Backward compatible — valid usage is unchanged.

Note: this is the compatibility/clear-error slice, not full sklearn metadata routing (`enable_metadata_routing=True`), which would be a larger separate change.