### PR TITLE
fix: add input validation to early stopping callbacks

### DIFF
--- a/sklearn_genetic/callbacks/early_stoppers.py
+++ b/sklearn_genetic/callbacks/early_stoppers.py
@@ -20,8 +20,13 @@ class ThresholdStopping(BaseCallback):
         metric: {'fitness', 'fitness_std', 'fitness_best', 'fitness_max', 'fitness_min'}, default ='fitness'
             Name of the metric inside 'record' logged in each iteration
         """
-
         check_stats(metric)
+
+        if not isinstance(threshold, (int, float)):
+            raise TypeError(
+                f"threshold must be a numeric value (int or float), "
+                f"but got {type(threshold).__name__}"
+            )
 
         self.threshold = threshold
         self.metric = metric
@@ -57,8 +62,17 @@ class ConsecutiveStopping(BaseCallback):
         metric: {'fitness', 'fitness_std', 'fitness_best', 'fitness_max', 'fitness_min'}, default ='fitness'
             Name of the metric inside 'record' logged in each iteration
         """
-
         check_stats(metric)
+
+        if not isinstance(generations, int):
+            raise TypeError(
+                f"generations must be an integer, "
+                f"but got {type(generations).__name__}"
+            )
+        if generations <= 0:
+            raise ValueError(
+                f"generations must be a positive integer, but got {generations}"
+            )
 
         self.generations = generations
         self.metric = metric
@@ -103,8 +117,22 @@ class DeltaThreshold(BaseCallback):
         metric: {'fitness', 'fitness_std', 'fitness_best', 'fitness_max', 'fitness_min'}, default ='fitness'
             Name of the metric inside 'record' logged in each iteration.
         """
-
         check_stats(metric)
+
+        if not isinstance(threshold, (int, float)):
+            raise TypeError(
+                f"threshold must be a numeric value (int or float), "
+                f"but got {type(threshold).__name__}"
+            )
+        if not isinstance(generations, int):
+            raise TypeError(
+                f"generations must be an integer, "
+                f"but got {type(generations).__name__}"
+            )
+        if generations <= 0:
+            raise ValueError(
+                f"generations must be a positive integer, but got {generations}"
+            )
 
         self.threshold = threshold
         self.generations = generations
@@ -141,6 +169,16 @@ class TimerStopping(BaseCallback):
         total_seconds: int
             Total time in seconds that the estimator is allowed to fit
         """
+        if not isinstance(total_seconds, (int, float)):
+            raise TypeError(
+                f"total_seconds must be a numeric value (int or float), "
+                f"but got {type(total_seconds).__name__}"
+            )
+        if total_seconds <= 0:
+            raise ValueError(
+                f"total_seconds must be a positive value, but got {total_seconds}"
+            )
+
         self.initial_training_time = None
         self.total_seconds = total_seconds
 

--- a/sklearn_genetic/callbacks/tests/test_callbacks.py
+++ b/sklearn_genetic/callbacks/tests/test_callbacks.py
@@ -116,7 +116,6 @@ def test_threshold_callback():
     logbook.record(fitness=0.95)
 
     assert callback(logbook=logbook)
-
     with pytest.raises(Exception) as excinfo:
         callback()
     assert str(excinfo.value) == "At least one of record or logbook parameters must be provided"
@@ -125,7 +124,6 @@ def test_threshold_callback():
 def test_consecutive_callback():
     callback = ConsecutiveStopping(generations=3)
     assert check_callback(callback) == [callback]
-
     logbook = Logbook()
 
     logbook.record(fitness=0.9)
@@ -155,7 +153,6 @@ def test_consecutive_callback():
 def test_delta_callback():
     callback = DeltaThreshold(0.001)
     assert check_callback(callback) == [callback]
-
     logbook = Logbook()
 
     logbook.record(fitness=0.9)
@@ -204,9 +201,7 @@ def test_logbook_saver_callback(caplog):
     evolved_estimator.fit(X_train, y_train, callbacks=callback)
 
     assert os.path.exists("./logbook.pkl")
-
     os.remove("./logbook.pkl")
-
     with caplog.at_level(logging.ERROR):
         callback = LogbookSaver(checkpoint_path="./no_folder/logbook.pkl", estimator=4)
         callback()
@@ -244,7 +239,103 @@ def test_tensorboard_callback(callback, path):
     )
 
     evolved_estimator.fit(X_train, y_train, callbacks=callback)
-
     assert os.path.exists(path)
-
     shutil.rmtree(path)
+
+
+# ============================================================
+# Input validation tests (issue #359)
+# ============================================================
+
+
+class TestThresholdStoppingValidation:
+    def test_valid_threshold_int(self):
+        cb = ThresholdStopping(threshold=1)
+        assert cb.threshold == 1
+
+    def test_valid_threshold_float(self):
+        cb = ThresholdStopping(threshold=0.8)
+        assert cb.threshold == 0.8
+
+    def test_invalid_threshold_string(self):
+        with pytest.raises(TypeError, match="threshold must be a numeric value"):
+            ThresholdStopping(threshold="invalid")
+
+    def test_invalid_threshold_none(self):
+        with pytest.raises(TypeError, match="threshold must be a numeric value"):
+            ThresholdStopping(threshold=None)
+
+    def test_invalid_threshold_list(self):
+        with pytest.raises(TypeError, match="threshold must be a numeric value"):
+            ThresholdStopping(threshold=[0.5])
+
+
+class TestConsecutiveStoppingValidation:
+    def test_valid_generations(self):
+        cb = ConsecutiveStopping(generations=3)
+        assert cb.generations == 3
+
+    def test_invalid_generations_string(self):
+        with pytest.raises(TypeError, match="generations must be an integer"):
+            ConsecutiveStopping(generations="3")
+
+    def test_invalid_generations_float(self):
+        with pytest.raises(TypeError, match="generations must be an integer"):
+            ConsecutiveStopping(generations=3.5)
+
+    def test_invalid_generations_zero(self):
+        with pytest.raises(ValueError, match="generations must be a positive integer"):
+            ConsecutiveStopping(generations=0)
+
+    def test_invalid_generations_negative(self):
+        with pytest.raises(ValueError, match="generations must be a positive integer"):
+            ConsecutiveStopping(generations=-1)
+
+
+class TestDeltaThresholdValidation:
+    def test_valid_inputs(self):
+        cb = DeltaThreshold(threshold=0.001, generations=3)
+        assert cb.threshold == 0.001
+        assert cb.generations == 3
+
+    def test_invalid_threshold_string(self):
+        with pytest.raises(TypeError, match="threshold must be a numeric value"):
+            DeltaThreshold(threshold="bad", generations=3)
+
+    def test_invalid_generations_string(self):
+        with pytest.raises(TypeError, match="generations must be an integer"):
+            DeltaThreshold(threshold=0.1, generations="2")
+
+    def test_invalid_generations_zero(self):
+        with pytest.raises(ValueError, match="generations must be a positive integer"):
+            DeltaThreshold(threshold=0.1, generations=0)
+
+    def test_invalid_generations_negative(self):
+        with pytest.raises(ValueError, match="generations must be a positive integer"):
+            DeltaThreshold(threshold=0.1, generations=-5)
+
+
+class TestTimerStoppingValidation:
+    def test_valid_total_seconds(self):
+        cb = TimerStopping(total_seconds=60)
+        assert cb.total_seconds == 60
+
+    def test_valid_total_seconds_float(self):
+        cb = TimerStopping(total_seconds=30.5)
+        assert cb.total_seconds == 30.5
+
+    def test_invalid_total_seconds_string(self):
+        with pytest.raises(TypeError, match="total_seconds must be a numeric value"):
+            TimerStopping(total_seconds="abc")
+
+    def test_invalid_total_seconds_none(self):
+        with pytest.raises(TypeError, match="total_seconds must be a numeric value"):
+            TimerStopping(total_seconds=None)
+
+    def test_invalid_total_seconds_zero(self):
+        with pytest.raises(ValueError, match="total_seconds must be a positive value"):
+            TimerStopping(total_seconds=0)
+
+    def test_invalid_total_seconds_negative(self):
+        with pytest.raises(ValueError, match="total_seconds must be a positive value"):
+            TimerStopping(total_seconds=-5)


### PR DESCRIPTION
## Summary

Adds constructor input validation for ThresholdStopping, ConsecutiveStopping, DeltaThreshold, and TimerStopping callbacks.

Closes #359

## Changes

- ThresholdStopping: Reject non-numeric threshold values (raises TypeError)
- ConsecutiveStopping: Reject non-integer or non-positive generations (raises TypeError/ValueError)
- DeltaThreshold: Reject non-numeric threshold and non-integer/non-positive generations
- TimerStopping: Reject non-numeric or non-positive total_seconds

All invalid inputs now raise clear TypeError (wrong type) or ValueError (wrong value) messages. Existing valid behavior is unchanged.

## Tests

Added 18 new test cases covering:
- Valid inputs (int, float) for each callback
- Invalid types (string, None, list, float for integer params)
- Invalid values (zero, negative for positive-integer params)

Before: ThresholdStopping(threshold="invalid") silently accepted, broke at on_step
After: ThresholdStopping(threshold="invalid") raises TypeError immediately