### PR TITLE
feat: add feature names output to GAFeatureSelectionCV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Full release notes with code examples are in the [documentation](https://sklearn
 
 ## Unreleased
 
+### New Features
+
+- Added `GAFeatureSelectionCV.get_feature_names_out()` support for DataFrame column names and generated NumPy feature names.
+
 ## 0.13.4
 
 ### New Features

--- a/docs-vitepress/versions/latest/api/gafeatureselectioncv.md
+++ b/docs-vitepress/versions/latest/api/gafeatureselectioncv.md
@@ -67,6 +67,7 @@ GAFeatureSelectionCV(
 | `logbook` | DEAP logbook |
 | `fit_stats_` | Evaluation counters |
 | `n_features_` | Number of selected features |
+| `feature_names_in_` | Feature names seen during `fit` when `X` has string column names |
 
 ## Methods
 
@@ -74,6 +75,7 @@ GAFeatureSelectionCV(
 |--------|-------------|
 | `fit(X, y, callbacks=None)` | Run the genetic feature selection |
 | `transform(X)` | Return `X` with only the selected features |
+| `get_feature_names_out(input_features=None)` | Return the selected feature names |
 | `predict(X)` | Predict using `best_estimator_` on selected features |
 | `predict_proba(X)` | Predict class probabilities |
 | `score(X, y)` | Score using `best_estimator_` on selected features |

--- a/sklearn_genetic/genetic_search.py
+++ b/sklearn_genetic/genetic_search.py
@@ -16,6 +16,14 @@ except ImportError:
         return hasattr(estimator, "fit_predict") and hasattr(estimator, "decision_function")
 
 
+try:
+    from sklearn.utils.validation import _check_feature_names
+except ImportError:
+
+    def _check_feature_names(estimator, X, *, reset):
+        estimator._check_feature_names(X, reset=reset)
+
+
 def _safe_estimator_check(check, estimator):
     try:
         return check(estimator)
@@ -2030,6 +2038,7 @@ class GAFeatureSelectionCV(GeneticEstimatorMixin, MetaEstimatorMixin, SelectorMi
             aligned to samples and are sliced per CV fold by scikit-learn.
         """
 
+        _check_feature_names(self, X, reset=True)
         self.X_, self.y_ = check_X_y(X, y, accept_sparse=True) if y is not None else (X, None)
         self.groups_ = groups
         self._fit_params = fit_params

--- a/sklearn_genetic/tests/test_feature_selection.py
+++ b/sklearn_genetic/tests/test_feature_selection.py
@@ -1,7 +1,9 @@
 import pytest
 from deap import tools
+import pandas as pd
 from sklearn.base import clone
 from sklearn.datasets import load_iris, load_diabetes
+from sklearn.exceptions import NotFittedError
 from sklearn.linear_model import SGDClassifier
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 from sklearn.model_selection import train_test_split
@@ -38,6 +40,62 @@ noise = np.random.uniform(1, 4, size=(X.shape[0], 10))
 X = np.hstack((X, noise))
 
 X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.33, random_state=42)
+
+
+def _fit_feature_name_selector(X, y):
+    selector = GAFeatureSelectionCV(
+        DecisionTreeClassifier(random_state=42),
+        cv=2,
+        scoring="accuracy",
+        population_size=4,
+        generations=1,
+        verbose=False,
+        n_jobs=1,
+        random_state=42,
+    )
+    return selector.fit(X, y)
+
+
+def test_get_feature_names_out_requires_fitted_selector():
+    selector = GAFeatureSelectionCV(DecisionTreeClassifier())
+
+    with pytest.raises(NotFittedError, match="not fitted"):
+        selector.get_feature_names_out()
+
+
+def test_get_feature_names_out_generates_numpy_feature_names():
+    iris = load_iris()
+    selector = _fit_feature_name_selector(iris.data, iris.target)
+    input_features = np.asarray([f"x{index}" for index in range(iris.data.shape[1])])
+
+    assert not hasattr(selector, "feature_names_in_")
+    np.testing.assert_array_equal(
+        selector.get_feature_names_out(),
+        input_features[selector.get_support()],
+    )
+
+    with pytest.raises(ValueError, match="input_features should have length equal"):
+        selector.get_feature_names_out(["first", "second"])
+
+
+def test_get_feature_names_out_preserves_dataframe_feature_names():
+    iris = load_iris()
+    input_features = np.asarray(
+        ["sepal_length", "sepal_width", "petal_length", "petal_width"],
+        dtype=object,
+    )
+    X_frame = pd.DataFrame(iris.data, columns=input_features)
+    selector = _fit_feature_name_selector(X_frame, iris.target)
+    expected = input_features[selector.get_support()]
+
+    np.testing.assert_array_equal(selector.feature_names_in_, input_features)
+    np.testing.assert_array_equal(selector.get_feature_names_out(), expected)
+    np.testing.assert_array_equal(selector.get_feature_names_out(input_features), expected)
+
+    mismatched = input_features.copy()
+    mismatched[0] = "different"
+    with pytest.raises(ValueError, match="input_features is not equal to feature_names_in_"):
+        selector.get_feature_names_out(mismatched)
 
 
 def test_default_n_jobs_is_none():


### PR DESCRIPTION
## Summary

Preserves DataFrame column names in `GAFeatureSelectionCV` so the inherited `get_feature_names_out()` returns the selected names. NumPy inputs continue to use generated `x0`, `x1`, ... names.

## Related Issue

Closes #362

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] Other (describe):

## Checklist

- [x] I checked the linked issue is open and not already covered by another PR
- [x] Tests pass locally (`pytest sklearn_genetic/`)
- [x] Code is formatted with Black (`black sklearn_genetic/`)
- [x] New functionality is covered by tests
- [x] Documentation updated if needed